### PR TITLE
Fix exec.HideOutput

### DIFF
--- a/examples/logging/logging.go
+++ b/examples/logging/logging.go
@@ -15,4 +15,9 @@ func main() {
 
 	c := &rig.Localhost{Enabled: true}
 	c.Exec("echo Hello, world", exec.StreamOutput())
+
+	log.Infof("testing without HideOutput()")
+	c.Exec("ls")
+	log.Infof("testing with HideOutput()")
+	c.Exec("ls", exec.HideOutput())
 }

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -56,6 +56,7 @@ type Options struct {
 	LogDebug       bool
 	LogError       bool
 	LogCommand     bool
+	LogOutput      bool
 	StreamOutput   bool
 	RedactFunc     func(string) string
 	Output         *string
@@ -124,9 +125,9 @@ func (o *Options) AddOutput(prefix, s string) {
 	}
 
 	if o.StreamOutput {
-		InfoFunc("%s: %s", prefix, o.Redact(s))
-	} else {
-		DebugFunc("%s: %s", prefix, o.Redact(s))
+		InfoFunc("%s: %s", prefix, strings.TrimSpace(o.Redact(s)))
+	} else if o.LogOutput {
+		DebugFunc("%s: %s", prefix, strings.TrimSpace(o.Redact(s)))
 	}
 }
 
@@ -176,7 +177,7 @@ func HideCommand() Option {
 // HideOutput exec option for hiding the command output from logs
 func HideOutput() Option {
 	return func(o *Options) {
-		o.LogDebug = false
+		o.LogOutput = false
 	}
 }
 
@@ -228,6 +229,7 @@ func Build(opts ...Option) *Options {
 		LogCommand:   true,
 		LogDebug:     true,
 		LogError:     true,
+		LogOutput:    true,
 		StreamOutput: false,
 		Output:       nil,
 	}


### PR DESCRIPTION
Adds `LogOutput` to exec options, which is used to control if the command output is logged or not.
