### PR TITLE
Test WinRM client after connection

### DIFF
--- a/winrm.go
+++ b/winrm.go
@@ -167,6 +167,11 @@ func (c *WinRM) Connect() error {
 		return err
 	}
 
+	_, err = client.Run("echo ok", ioutil.Discard, ioutil.Discard)
+	if err != nil {
+		return err
+	}
+
 	c.client = client
 
 	return nil

--- a/winrm.go
+++ b/winrm.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/k0sproject/rig/exec"
+	"github.com/k0sproject/rig/log"
 	ps "github.com/k0sproject/rig/powershell"
 	"github.com/mitchellh/go-homedir"
 
@@ -176,10 +177,12 @@ func (c *WinRM) Connect() error {
 		return err
 	}
 
+	log.Debugf("%s: testing connection", c)
 	_, err = client.Run("echo ok", ioutil.Discard, ioutil.Discard)
 	if err != nil {
 		return err
 	}
+	log.Debugf("%s: test passed", c)
 
 	c.client = client
 


### PR DESCRIPTION
Apparently some connection errors only present themselves when the client is used, leading to confusing error messages.

This happens when you connect to a host with a self-signed cert without `insecure: true`:

```
ERRO [winrm] x.x.x.x:5986: attempt 2 of 60.. failed to connect: unable to determine host os
ERRO [winrm] x.x.x.x:5986: attempt 3 of 60.. failed to connect: unable to determine host os
```

With this PR:

```
DEBUG [winrm] ec2-15-188-50-106.eu-west-3.compute.amazonaws.com:5986: testing connection
ERROR unknown error Post "https://ec2-15-188-50-106.eu-west-3.compute.amazonaws.com:5986/wsman": x509: certificate is valid for EC2AMAZ-83xxxx, not ec2-xxxxx.eu-west-3.compute.amazonaws.com
````
