### PR TITLE
Fix Windows 2019 detection

### DIFF
--- a/os/windows/windows2019.go
+++ b/os/windows/windows2019.go
@@ -14,7 +14,7 @@ type Windows2019 struct {
 func init() {
 	registry.RegisterOSModule(
 		func(os rig.OSVersion) bool {
-			return os.ID == "windows-10.0.17763"
+			return os.ID == "windows" && os.Version == "10.0.17763"
 		},
 		func() interface{} {
 			return Windows2019{}


### PR DESCRIPTION
It didn't work at all. The os ID is "windows" without the version.
