### PR TITLE
Fix WinRM stdout being closed twice

### DIFF
--- a/winrm.go
+++ b/winrm.go
@@ -253,7 +253,7 @@ func (c *WinRM) Exec(cmd string, opts ...exec.Option) error {
 			gotErrors = true
 			o.LogErrorf("%s: %s", c, err.Error())
 		}
-		command.Stdout.Close()
+		command.Stderr.Close()
 	}()
 
 	command.Wait()


### PR DESCRIPTION
Causing frequent "close of closed channel" panics.
