### PR TITLE
Replace usages of sudo -i with sudo -s on linux

### DIFF
--- a/localhost.go
+++ b/localhost.go
@@ -121,7 +121,7 @@ func (c *Localhost) command(cmd string) *osexec.Cmd {
 	}
 
 	if c.cansudo && c.user != "" {
-		return osexec.Command("sudo", "-n", "-i", "--", "su", "-l", "-c", cmd, c.user)
+		return osexec.Command("sudo", "-n", "-s", "--", "su", "-l", "-c", cmd, c.user)
 	}
 
 	return osexec.Command("bash", "-c", "--", cmd)

--- a/os/initsystem/systemd.go
+++ b/os/initsystem/systemd.go
@@ -5,40 +5,40 @@ type Systemd struct{}
 
 // StartService starts a a service
 func (i Systemd) StartService(h Host, s string) error {
-	return h.Execf("sudo -i systemctl start %s 2> /dev/null", s)
+	return h.Execf("sudo -s systemctl start %s 2> /dev/null", s)
 }
 
 // EnableService enables a a service
 func (i Systemd) EnableService(h Host, s string) error {
-	return h.Execf("sudo -i systemctl enable %s 2> /dev/null", s)
+	return h.Execf("sudo -s systemctl enable %s 2> /dev/null", s)
 }
 
 // DisableService disables a a service
 func (i Systemd) DisableService(h Host, s string) error {
-	return h.Execf("sudo -i systemctl disable %s 2> /dev/null", s)
+	return h.Execf("sudo -s systemctl disable %s 2> /dev/null", s)
 }
 
 // StopService stops a a service
 func (i Systemd) StopService(h Host, s string) error {
-	return h.Execf("sudo -i systemctl stop %s 2> /dev/null", s)
+	return h.Execf("sudo -s systemctl stop %s 2> /dev/null", s)
 }
 
 // RestartService restarts a a service
 func (i Systemd) RestartService(h Host, s string) error {
-	return h.Execf("sudo -i systemctl restart %s 2> /dev/null", s)
+	return h.Execf("sudo -s systemctl restart %s 2> /dev/null", s)
 }
 
 // DaemonReload reloads init system configuration
 func (i Systemd) DaemonReload(h Host) error {
-	return h.Execf("sudo -i systemctl daemon-reload 2> /dev/null")
+	return h.Execf("sudo -s systemctl daemon-reload 2> /dev/null")
 }
 
 // ServiceIsRunning returns true if a service is running
 func (i Systemd) ServiceIsRunning(h Host, s string) bool {
-	return h.Execf(`sudo -i systemctl status %s 2> /dev/null | grep -q "(running)"`, s) == nil
+	return h.Execf(`sudo -s systemctl status %s 2> /dev/null | grep -q "(running)"`, s) == nil
 }
 
 // ServiceScriptPath returns the path to a service configuration file
 func (i Systemd) ServiceScriptPath(h Host, s string) (string, error) {
-	return h.ExecOutputf(`sudo -i systemctl show -p FragmentPath %s.service 2> /dev/null | cut -d"=" -f2`, s)
+	return h.ExecOutputf(`sudo -s systemctl show -p FragmentPath %s.service 2> /dev/null | cut -d"=" -f2`, s)
 }

--- a/os/linux.go
+++ b/os/linux.go
@@ -34,7 +34,7 @@ func (c Linux) Kind() string {
 // memoizing accessor to the init system (systemd, openrc)
 func (c Linux) is(h Host) initSystem {
 	if c.isys == nil {
-		initctl, err := h.ExecOutput("basename $(sudo -i command -v rc-service systemctl 2>/dev/null) 2>/dev/null")
+		initctl, err := h.ExecOutput("basename $(sudo -s command -v rc-service systemctl 2>/dev/null) 2>/dev/null")
 		if err != nil {
 			return nil
 		}
@@ -219,10 +219,10 @@ func (c Linux) CleanupEnvironment(h Host, env map[string]string) error {
 
 // CommandExist returns true if the command exists
 func (c Linux) CommandExist(h Host, cmd string) bool {
-	return h.Execf(`sudo -i command -v "%s" 2> /dev/null`, cmd) == nil
+	return h.Execf(`sudo -s command -v "%s" 2> /dev/null`, cmd) == nil
 }
 
 // Reboot executes the reboot command
 func (c Linux) Reboot(h Host) error {
-	return h.Exec("sudo -i shutdown --reboot 0 2> /dev/null && exit")
+	return h.Exec("sudo -s shutdown --reboot 0 2> /dev/null && exit")
 }


### PR DESCRIPTION
Apparently `sudo -i` will often add stuff from motd etc to the command stdout.
