### PR TITLE
Build using go 1.16

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,8 +13,8 @@ jobs:
       uses: actions/setup-go@v2
       if: github.ref != 'refs/heads/main'
       with:
-        go-version: 1.15
-          
+        go-version: 1.16
+
     - name: Go modules cache
       uses: actions/cache@v2
       if: github.ref != 'refs/heads/main'
@@ -23,7 +23,7 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-              
+
     - name: Run golangci-lint
       if: github.ref != 'refs/heads/main'
       uses: golangci/golangci-lint-action@v2.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,15 @@
 module github.com/k0sproject/rig
 
-go 1.15
+go 1.16
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alessio/shellescape v1.4.1
 	github.com/creasty/defaults v1.5.1
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/masterzen/winrm v0.0.0-20201030141608-56ca5c5f2380
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5
-	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20190222235706-ffb98f73852f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/ssh.go
+++ b/ssh.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -144,7 +143,7 @@ func (c *SSH) Connect() error {
 	}
 	if err == nil {
 		var key []byte
-		key, err = ioutil.ReadFile(c.KeyPath)
+		key, err = os.ReadFile(c.KeyPath)
 		if err != nil {
 			return err
 		}

--- a/winrm.go
+++ b/winrm.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -98,7 +97,7 @@ func (c *WinRM) IsWindows() bool {
 func (c *WinRM) loadCertificates() error {
 	c.caCert = nil
 	if c.CACertPath != "" {
-		ca, err := ioutil.ReadFile(c.CACertPath)
+		ca, err := os.ReadFile(c.CACertPath)
 		if err != nil {
 			return err
 		}
@@ -107,7 +106,7 @@ func (c *WinRM) loadCertificates() error {
 
 	c.cert = nil
 	if c.CertPath != "" {
-		cert, err := ioutil.ReadFile(c.CertPath)
+		cert, err := os.ReadFile(c.CertPath)
 		if err != nil {
 			return err
 		}
@@ -116,7 +115,7 @@ func (c *WinRM) loadCertificates() error {
 
 	c.key = nil
 	if c.KeyPath != "" {
-		key, err := ioutil.ReadFile(c.KeyPath)
+		key, err := os.ReadFile(c.KeyPath)
 		if err != nil {
 			return err
 		}
@@ -178,7 +177,7 @@ func (c *WinRM) Connect() error {
 	}
 
 	log.Debugf("%s: testing connection", c)
-	_, err = client.Run("echo ok", ioutil.Discard, ioutil.Discard)
+	_, err = client.Run("echo ok", io.Discard, io.Discard)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Run tests using go 1.16, change the version in go.mod and migrate usages of ioutil.