### PR TITLE
Add exec.Writer option for streaming output to an io.Writer

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -1,9 +1,11 @@
 package rig
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/creasty/defaults"
+	"github.com/k0sproject/rig/exec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,4 +41,20 @@ func TestHostFunctions(t *testing.T) {
 	require.NoError(t, defaults.Set(&h))
 	require.Equal(t, "SSH", h.Protocol())
 	require.Equal(t, "10.0.0.1", h.Address())
+}
+
+func TestOutputWriter(t *testing.T) {
+	h := Host{
+		Connection: Connection{
+			Localhost: &Localhost{
+				Enabled: true,
+			},
+		},
+	}
+	defaults.Set(&h)
+	h.Connect()
+	var buf []byte
+	writer := bytes.NewBuffer(buf)
+	require.NoError(t, h.Exec("echo hello world", exec.Writer(writer)))
+	require.Equal(t, "hello world\n", writer.String())
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -51,8 +51,8 @@ func TestOutputWriter(t *testing.T) {
 			},
 		},
 	}
-	defaults.Set(&h)
-	h.Connect()
+	require.NoError(t, defaults.Set(&h))
+	require.NoError(t, h.Connect())
 	var buf []byte
 	writer := bytes.NewBuffer(buf)
 	require.NoError(t, h.Exec("echo hello world", exec.Writer(writer)))

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -60,6 +61,7 @@ type Options struct {
 	StreamOutput   bool
 	RedactFunc     func(string) string
 	Output         *string
+	Writer         io.Writer
 }
 
 // LogCmd is for logging the command to be executed
@@ -229,6 +231,13 @@ func RedactString(s ...string) Option {
 	}
 }
 
+// Writer exec option for sending command stdout to an io.Writer
+func Writer(w io.Writer) Option {
+	return func(o *Options) {
+		o.Writer = w
+	}
+}
+
 // Build returns an instance of Options
 func Build(opts ...Option) *Options {
 	options := &Options{
@@ -240,6 +249,7 @@ func Build(opts ...Option) *Options {
 		LogOutput:    true,
 		StreamOutput: false,
 		Output:       nil,
+		Writer:       nil,
 	}
 
 	for _, o := range opts {


### PR DESCRIPTION
Adds `exec.Writer(io.Writer)` exec option for streaming the output from `h.Exec` to for example a tar / gzip decoder.
