### PR TITLE
Add exec.Sudo() exec option

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -25,7 +25,7 @@ func (e *NotConnectedError) Error() string { return e.Connection.String() + ": n
 type client interface {
 	Connect() error
 	Disconnect()
-	Upload(source string) (string, error)
+	Upload(source, destination string, opts ...exec.Option) error
 	IsWindows() bool
 	Exec(string, ...exec.Option) error
 	ExecInteractive(string) error
@@ -261,14 +261,14 @@ func (c *Connection) Disconnect() {
 	c.client = nil
 }
 
-// Upload copies a file from a local path src to the remote host tempfile and returns the path to the new file. For
+// Upload copies a file from a local path src to the remote host path dst. For
 // smaller files you should probably use os.WriteFile
-func (c Connection) Upload(src string) (string, error) {
+func (c Connection) Upload(src, dst string, opts ...exec.Option) error {
 	if !c.IsConnected() {
-		return "", &NotConnectedError{&c}
+		return &NotConnectedError{&c}
 	}
 
-	return c.client.Upload(src)
+	return c.client.Upload(src, dst, opts...)
 }
 
 func (c *Connection) configuredClient() client {

--- a/connection.go
+++ b/connection.go
@@ -205,17 +205,14 @@ func (c *Connection) configureSudo() {
 	default:
 		if c.Exec(`[ "$(id -u)" = 0 ]`) == nil {
 			c.sudofunc = func(cmd string) string {
-				println("id=0")
 				return cmd
 			}
 		} else if c.Exec("sudo -n true") == nil {
 			c.sudofunc = func(cmd string) string {
-				println("sudo -s " + cmd)
 				return "sudo -s " + cmd
 			}
 		} else if c.Exec("doas -n true") == nil {
 			c.sudofunc = func(cmd string) string {
-				println("doas -s " + cmd)
 				return "doas -s " + cmd
 			}
 		}

--- a/examples/os/stock/stock.go
+++ b/examples/os/stock/stock.go
@@ -26,7 +26,7 @@ type configurer interface {
 
 // Host is a host that utilizes rig for connections
 type Host struct {
-	rig.Connection
+	*rig.Connection
 
 	Configurer configurer
 }
@@ -46,7 +46,7 @@ func (h *Host) LoadOS() error {
 
 func main() {
 	h := Host{
-		Connection: rig.Connection{
+		Connection: &rig.Connection{
 			Localhost: &rig.Localhost{
 				Enabled: true,
 			},

--- a/examples/os/stock/stock.go
+++ b/examples/os/stock/stock.go
@@ -26,7 +26,7 @@ type configurer interface {
 
 // Host is a host that utilizes rig for connections
 type Host struct {
-	*rig.Connection
+	rig.Connection
 
 	Configurer configurer
 }
@@ -46,7 +46,7 @@ func (h *Host) LoadOS() error {
 
 func main() {
 	h := Host{
-		Connection: &rig.Connection{
+		Connection: rig.Connection{
 			Localhost: &rig.Localhost{
 				Enabled: true,
 			},

--- a/examples/upload/upload.go
+++ b/examples/upload/upload.go
@@ -1,0 +1,115 @@
+package main
+
+// A simple file uploader for testing
+import (
+	"flag"
+	"fmt"
+	goos "os"
+
+	"github.com/k0sproject/rig"
+	"github.com/k0sproject/rig/os"
+	"github.com/k0sproject/rig/os/registry"
+	_ "github.com/k0sproject/rig/os/support"
+	ps "github.com/k0sproject/rig/powershell"
+)
+
+type configurer interface {
+	Pwd(os.Host) string
+	CheckPrivilege(os.Host) error
+}
+
+// Host is a host that utilizes rig for connections
+type Host struct {
+	rig.Connection
+
+	Configurer configurer
+}
+
+// LoadOS is a function that assigns a OS support package to the host and
+// typecasts it to a suitable interface
+func (h *Host) LoadOS() error {
+	bf, err := registry.GetOSModuleBuilder(h.OSVersion)
+	if err != nil {
+		return err
+	}
+
+	h.Configurer = bf().(configurer)
+
+	return nil
+}
+
+func main() {
+	dh := flag.String("host", "127.0.0.1", "target host")
+	dp := flag.Int("port", 9022, "target host port")
+	df := flag.String("src", "tmpfile", "source file")
+	usr := flag.String("user", "root", "user name")
+	pwd := flag.String("pass", "", "password")
+	proto := flag.String("proto", "ssh", "ssh/winrm")
+
+	flag.Parse()
+
+	if *dh == "" {
+		println("see -help")
+		goos.Exit(1)
+	}
+
+	var h Host
+
+	if *proto == "ssh" {
+		h = Host{
+			Connection: rig.Connection{
+				SSH: &rig.SSH{
+					Address: *dh,
+					Port:    *dp,
+					User:    *usr,
+					KeyPath: "/Users/kimmo/.ssh/id_rsa",
+				},
+			},
+		}
+	} else {
+		h = Host{
+			Connection: rig.Connection{
+				WinRM: &rig.WinRM{
+					Address:  *dh,
+					Port:     *dp,
+					User:     *usr,
+					UseHTTPS: true,
+					Insecure: true,
+					Password: *pwd,
+				},
+			},
+		}
+	}
+
+	if err := h.Connect(); err != nil {
+		fmt.Println(*dh, *dp)
+		panic(err)
+	}
+
+	if err := h.LoadOS(); err != nil {
+		panic(err)
+	}
+
+	path, err := h.Upload(*df)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Done, file now at", path)
+	var md5 string
+	if h.IsWindows() {
+		md5, err = h.ExecOutputf("certutil -hashfile %s MD5", ps.DoubleQuote(path))
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		md5, err = h.ExecOutputf("md5sum %s", path)
+		if err != nil {
+			panic(err)
+		}
+	}
+	fmt.Println("md5sum:", md5)
+	if err := h.Configurer.CheckPrivilege(h); err != nil {
+		panic(err)
+	}
+}

--- a/examples/upload/upload.go
+++ b/examples/upload/upload.go
@@ -66,7 +66,6 @@ func main() {
 					Address: *dh,
 					Port:    *dp,
 					User:    *usr,
-					KeyPath: "/Users/kimmo/.ssh/id_rsa",
 				},
 			},
 		}

--- a/os/host.go
+++ b/os/host.go
@@ -6,7 +6,7 @@ import (
 
 // Host is an interface to a host object that has the functions needed by the various OS support packages
 type Host interface {
-	Upload(source string) (string, error)
+	Upload(source, destination string, opts ...exec.Option) error
 	Exec(string, ...exec.Option) error
 	ExecOutput(string, ...exec.Option) (string, error)
 	Execf(string, ...interface{}) error

--- a/os/host.go
+++ b/os/host.go
@@ -12,4 +12,5 @@ type Host interface {
 	Execf(string, ...interface{}) error
 	ExecOutputf(string, ...interface{}) (string, error)
 	String() string
+	Sudo(string) (string, error)
 }

--- a/os/host.go
+++ b/os/host.go
@@ -6,7 +6,7 @@ import (
 
 // Host is an interface to a host object that has the functions needed by the various OS support packages
 type Host interface {
-	Upload(source string, destination string) error
+	Upload(source string) (string, error)
 	Exec(string, ...exec.Option) error
 	ExecOutput(string, ...exec.Option) (string, error)
 	Execf(string, ...interface{}) error

--- a/os/initsystem/host.go
+++ b/os/initsystem/host.go
@@ -4,4 +4,5 @@ package initsystem
 type Host interface {
 	Execf(string, ...interface{}) error
 	ExecOutputf(string, ...interface{}) (string, error)
+	Sudo(string) (string, error)
 }

--- a/os/initsystem/openrc.go
+++ b/os/initsystem/openrc.go
@@ -1,26 +1,28 @@
 package initsystem
 
+import "github.com/k0sproject/rig/exec"
+
 // OpenRC is found on some linux systems, often installed on Alpine for example.
 type OpenRC struct{}
 
 // StartService starts a a service
 func (i OpenRC) StartService(h Host, s string) error {
-	return h.Execf("sudo rc-service %s start", s)
+	return h.Execf("rc-service %s start", s, exec.Sudo())
 }
 
 // StopService stops a a service
 func (i OpenRC) StopService(h Host, s string) error {
-	return h.Execf("sudo rc-service %s stop", s)
+	return h.Execf("rc-service %s stop", s, exec.Sudo())
 }
 
 // ServiceScriptPath returns the path to a service configuration file
 func (i OpenRC) ServiceScriptPath(h Host, s string) (string, error) {
-	return h.ExecOutputf("sudo rc-service -r %s 2> /dev/null", s)
+	return h.ExecOutputf("rc-service -r %s 2> /dev/null", s, exec.Sudo())
 }
 
 // RestartService restarts a a service
 func (i OpenRC) RestartService(h Host, s string) error {
-	return h.Execf("sudo rc-service %s restart", s)
+	return h.Execf("rc-service %s restart", s, exec.Sudo())
 }
 
 // DaemonReload reloads init system configuration
@@ -30,15 +32,15 @@ func (i OpenRC) DaemonReload(_ Host) error {
 
 // EnableService enables a a service
 func (i OpenRC) EnableService(h Host, s string) error {
-	return h.Execf("sudo rc-update add %s", s)
+	return h.Execf("rc-update add %s", s, exec.Sudo())
 }
 
 // DisableService disables a a service
 func (i OpenRC) DisableService(h Host, s string) error {
-	return h.Execf("sudo rc-update del %s", s)
+	return h.Execf("rc-update del %s", s, exec.Sudo())
 }
 
 // ServiceIsRunning returns true if a service is running
 func (i OpenRC) ServiceIsRunning(h Host, s string) bool {
-	return h.Execf(`sudo rc-service %s status | grep -q "status: started"`, s) == nil
+	return h.Execf(`rc-service %s status | grep -q "status: started"`, s, exec.Sudo()) == nil
 }

--- a/os/initsystem/openrc.go
+++ b/os/initsystem/openrc.go
@@ -7,22 +7,22 @@ type OpenRC struct{}
 
 // StartService starts a a service
 func (i OpenRC) StartService(h Host, s string) error {
-	return h.Execf("rc-service %s start", s, exec.Sudo())
+	return h.Execf("rc-service %s start", s, exec.Sudo(h))
 }
 
 // StopService stops a a service
 func (i OpenRC) StopService(h Host, s string) error {
-	return h.Execf("rc-service %s stop", s, exec.Sudo())
+	return h.Execf("rc-service %s stop", s, exec.Sudo(h))
 }
 
 // ServiceScriptPath returns the path to a service configuration file
 func (i OpenRC) ServiceScriptPath(h Host, s string) (string, error) {
-	return h.ExecOutputf("rc-service -r %s 2> /dev/null", s, exec.Sudo())
+	return h.ExecOutputf("rc-service -r %s 2> /dev/null", s, exec.Sudo(h))
 }
 
 // RestartService restarts a a service
 func (i OpenRC) RestartService(h Host, s string) error {
-	return h.Execf("rc-service %s restart", s, exec.Sudo())
+	return h.Execf("rc-service %s restart", s, exec.Sudo(h))
 }
 
 // DaemonReload reloads init system configuration
@@ -32,15 +32,15 @@ func (i OpenRC) DaemonReload(_ Host) error {
 
 // EnableService enables a a service
 func (i OpenRC) EnableService(h Host, s string) error {
-	return h.Execf("rc-update add %s", s, exec.Sudo())
+	return h.Execf("rc-update add %s", s, exec.Sudo(h))
 }
 
 // DisableService disables a a service
 func (i OpenRC) DisableService(h Host, s string) error {
-	return h.Execf("rc-update del %s", s, exec.Sudo())
+	return h.Execf("rc-update del %s", s, exec.Sudo(h))
 }
 
 // ServiceIsRunning returns true if a service is running
 func (i OpenRC) ServiceIsRunning(h Host, s string) bool {
-	return h.Execf(`rc-service %s status | grep -q "status: started"`, s, exec.Sudo()) == nil
+	return h.Execf(`rc-service %s status | grep -q "status: started"`, s, exec.Sudo(h)) == nil
 }

--- a/os/initsystem/systemd.go
+++ b/os/initsystem/systemd.go
@@ -7,40 +7,40 @@ type Systemd struct{}
 
 // StartService starts a a service
 func (i Systemd) StartService(h Host, s string) error {
-	return h.Execf("systemctl start %s 2> /dev/null", s, exec.Sudo())
+	return h.Execf("systemctl start %s 2> /dev/null", s, exec.Sudo(h))
 }
 
 // EnableService enables a a service
 func (i Systemd) EnableService(h Host, s string) error {
-	return h.Execf("systemctl enable %s 2> /dev/null", s, exec.Sudo())
+	return h.Execf("systemctl enable %s 2> /dev/null", s, exec.Sudo(h))
 }
 
 // DisableService disables a a service
 func (i Systemd) DisableService(h Host, s string) error {
-	return h.Execf("systemctl disable %s 2> /dev/null", s, exec.Sudo())
+	return h.Execf("systemctl disable %s 2> /dev/null", s, exec.Sudo(h))
 }
 
 // StopService stops a a service
 func (i Systemd) StopService(h Host, s string) error {
-	return h.Execf("systemctl stop %s 2> /dev/null", s, exec.Sudo())
+	return h.Execf("systemctl stop %s 2> /dev/null", s, exec.Sudo(h))
 }
 
 // RestartService restarts a a service
 func (i Systemd) RestartService(h Host, s string) error {
-	return h.Execf("systemctl restart %s 2> /dev/null", s, exec.Sudo())
+	return h.Execf("systemctl restart %s 2> /dev/null", s, exec.Sudo(h))
 }
 
 // DaemonReload reloads init system configuration
 func (i Systemd) DaemonReload(h Host) error {
-	return h.Execf("systemctl daemon-reload 2> /dev/null", exec.Sudo())
+	return h.Execf("systemctl daemon-reload 2> /dev/null", exec.Sudo(h))
 }
 
 // ServiceIsRunning returns true if a service is running
 func (i Systemd) ServiceIsRunning(h Host, s string) bool {
-	return h.Execf(`systemctl status %s 2> /dev/null | grep -q "(running)"`, s, exec.Sudo()) == nil
+	return h.Execf(`systemctl status %s 2> /dev/null | grep -q "(running)"`, s, exec.Sudo(h)) == nil
 }
 
 // ServiceScriptPath returns the path to a service configuration file
 func (i Systemd) ServiceScriptPath(h Host, s string) (string, error) {
-	return h.ExecOutputf(`systemctl show -p FragmentPath %s.service 2> /dev/null | cut -d"=" -f2`, s, exec.Sudo())
+	return h.ExecOutputf(`systemctl show -p FragmentPath %s.service 2> /dev/null | cut -d"=" -f2`, s, exec.Sudo(h))
 }

--- a/os/initsystem/systemd.go
+++ b/os/initsystem/systemd.go
@@ -1,44 +1,46 @@
 package initsystem
 
+import "github.com/k0sproject/rig/exec"
+
 // Systemd is found by default on most linux distributions today
 type Systemd struct{}
 
 // StartService starts a a service
 func (i Systemd) StartService(h Host, s string) error {
-	return h.Execf("sudo -s systemctl start %s 2> /dev/null", s)
+	return h.Execf("systemctl start %s 2> /dev/null", s, exec.Sudo())
 }
 
 // EnableService enables a a service
 func (i Systemd) EnableService(h Host, s string) error {
-	return h.Execf("sudo -s systemctl enable %s 2> /dev/null", s)
+	return h.Execf("systemctl enable %s 2> /dev/null", s, exec.Sudo())
 }
 
 // DisableService disables a a service
 func (i Systemd) DisableService(h Host, s string) error {
-	return h.Execf("sudo -s systemctl disable %s 2> /dev/null", s)
+	return h.Execf("systemctl disable %s 2> /dev/null", s, exec.Sudo())
 }
 
 // StopService stops a a service
 func (i Systemd) StopService(h Host, s string) error {
-	return h.Execf("sudo -s systemctl stop %s 2> /dev/null", s)
+	return h.Execf("systemctl stop %s 2> /dev/null", s, exec.Sudo())
 }
 
 // RestartService restarts a a service
 func (i Systemd) RestartService(h Host, s string) error {
-	return h.Execf("sudo -s systemctl restart %s 2> /dev/null", s)
+	return h.Execf("systemctl restart %s 2> /dev/null", s, exec.Sudo())
 }
 
 // DaemonReload reloads init system configuration
 func (i Systemd) DaemonReload(h Host) error {
-	return h.Execf("sudo -s systemctl daemon-reload 2> /dev/null")
+	return h.Execf("systemctl daemon-reload 2> /dev/null", exec.Sudo())
 }
 
 // ServiceIsRunning returns true if a service is running
 func (i Systemd) ServiceIsRunning(h Host, s string) bool {
-	return h.Execf(`sudo -s systemctl status %s 2> /dev/null | grep -q "(running)"`, s) == nil
+	return h.Execf(`systemctl status %s 2> /dev/null | grep -q "(running)"`, s, exec.Sudo()) == nil
 }
 
 // ServiceScriptPath returns the path to a service configuration file
 func (i Systemd) ServiceScriptPath(h Host, s string) (string, error) {
-	return h.ExecOutputf(`sudo -s systemctl show -p FragmentPath %s.service 2> /dev/null | cut -d"=" -f2`, s)
+	return h.ExecOutputf(`systemctl show -p FragmentPath %s.service 2> /dev/null | cut -d"=" -f2`, s, exec.Sudo())
 }

--- a/os/linux/enterpriselinux.go
+++ b/os/linux/enterpriselinux.go
@@ -14,5 +14,5 @@ type EnterpriseLinux struct {
 
 // InstallPackage installs packages via yum
 func (c EnterpriseLinux) InstallPackage(h os.Host, s ...string) error {
-	return h.Execf("yum install -y %s", strings.Join(s, " "), exec.Sudo())
+	return h.Execf("yum install -y %s", strings.Join(s, " "), exec.Sudo(h))
 }

--- a/os/linux/enterpriselinux.go
+++ b/os/linux/enterpriselinux.go
@@ -3,6 +3,7 @@ package linux
 import (
 	"strings"
 
+	"github.com/k0sproject/rig/exec"
 	"github.com/k0sproject/rig/os"
 )
 
@@ -13,5 +14,5 @@ type EnterpriseLinux struct {
 
 // InstallPackage installs packages via yum
 func (c EnterpriseLinux) InstallPackage(h os.Host, s ...string) error {
-	return h.Execf("sudo yum install -y %s", strings.Join(s, " "))
+	return h.Execf("yum install -y %s", strings.Join(s, " "), exec.Sudo())
 }

--- a/os/linux/sles.go
+++ b/os/linux/sles.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/k0sproject/rig"
+	"github.com/k0sproject/rig/exec"
 	"github.com/k0sproject/rig/os"
 	"github.com/k0sproject/rig/os/registry"
 )
@@ -15,7 +16,7 @@ type SLES struct {
 
 // InstallPackage installs packages via zypper
 func (c SLES) InstallPackage(h os.Host, s ...string) error {
-	return h.Execf("sudo zypper refresh && sudo zypper -n install -y %s", strings.Join(s, " "))
+	return h.Execf("zypper refresh && sudo zypper -n install -y %s", strings.Join(s, " "), exec.Sudo())
 }
 
 func init() {

--- a/os/linux/sles.go
+++ b/os/linux/sles.go
@@ -16,7 +16,7 @@ type SLES struct {
 
 // InstallPackage installs packages via zypper
 func (c SLES) InstallPackage(h os.Host, s ...string) error {
-	return h.Execf("zypper refresh && sudo zypper -n install -y %s", strings.Join(s, " "), exec.Sudo())
+	return h.Execf("zypper refresh && sudo zypper -n install -y %s", strings.Join(s, " "), exec.Sudo(h))
 }
 
 func init() {

--- a/os/linux/ubuntu.go
+++ b/os/linux/ubuntu.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/k0sproject/rig"
+	"github.com/k0sproject/rig/exec"
 	"github.com/k0sproject/rig/os"
 	"github.com/k0sproject/rig/os/registry"
 )
@@ -26,5 +27,5 @@ func init() {
 
 // InstallPackage installs packages via apt-get
 func (c Ubuntu) InstallPackage(h os.Host, s ...string) error {
-	return h.Execf("sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q %s", strings.Join(s, " "))
+	return h.Execf("apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q %s", strings.Join(s, " "), exec.Sudo())
 }

--- a/os/linux/ubuntu.go
+++ b/os/linux/ubuntu.go
@@ -27,5 +27,8 @@ func init() {
 
 // InstallPackage installs packages via apt-get
 func (c Ubuntu) InstallPackage(h os.Host, s ...string) error {
-	return h.Execf("apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q %s", strings.Join(s, " "), exec.Sudo())
+	if err := h.Execf("apt-get update", exec.Sudo(h)); err != nil {
+		return err
+	}
+	return h.Execf("DEBIAN_FRONTEND=noninteractive apt-get install -y -q %s", strings.Join(s, " "), exec.Sudo(h))
 }

--- a/os/mac/darwin.go
+++ b/os/mac/darwin.go
@@ -21,12 +21,12 @@ func (c Darwin) Kind() string {
 
 // StartService starts a a service
 func (c Darwin) StartService(h os.Host, s string) error {
-	return h.Execf(`sudo launchctl start %s`, s)
+	return h.Execf(`launchctl start %s`, s)
 }
 
 // StopService stops a a service
 func (c Darwin) StopService(h os.Host, s string) error {
-	return h.Execf(`sudo launchctl stop %s`, s)
+	return h.Execf(`launchctl stop %s`, s)
 }
 
 // ServiceScriptPath returns the path to a service configuration file
@@ -36,7 +36,7 @@ func (c Darwin) ServiceScriptPath(s string) (string, error) {
 
 // RestartService restarts a a service
 func (c Darwin) RestartService(h os.Host, s string) error {
-	return h.Execf(`sudo launchctl kickstart -k %s`, s)
+	return h.Execf(`launchctl kickstart -k %s`, s)
 }
 
 // DaemonReload reloads init system configuration
@@ -46,17 +46,17 @@ func (c Darwin) DaemonReload(_ os.Host) error {
 
 // EnableService enables a a service
 func (c Darwin) EnableService(h os.Host, s string) error {
-	return h.Execf(`sudo launchctl enable %s`, s)
+	return h.Execf(`launchctl enable %s`, s)
 }
 
 // DisableService disables a a service
 func (c Darwin) DisableService(h os.Host, s string) error {
-	return h.Execf(`sudo launchctl disable %s`, s)
+	return h.Execf(`launchctl disable %s`, s)
 }
 
 // ServiceIsRunning returns true if a service is running
 func (c Darwin) ServiceIsRunning(h os.Host, s string) bool {
-	return h.Execf(`sudo launchctl list %s | grep -q '"PID"'`, s) == nil
+	return h.Execf(`launchctl list %s | grep -q '"PID"'`, s) == nil
 }
 
 // InstallPackage installs a package using brew

--- a/os/windows.go
+++ b/os/windows.go
@@ -40,6 +40,10 @@ func (c Windows) InstallPackage(h Host, s ...string) error {
 	return nil
 }
 
+func (c Windows) InstallFile(h Host, src, dst, _ string) error {
+	return h.Execf("move /y %s %s", ps.DoubleQuote(src), ps.DoubleQuote(dst), exec.Sudo(h))
+}
+
 // Pwd returns the current working directory
 func (c Windows) Pwd(h Host) string {
 	if pwd, err := h.ExecOutput("echo %cd%"); err == nil {

--- a/ssh.go
+++ b/ssh.go
@@ -359,7 +359,7 @@ func (c *SSH) uploadLinux(src string) (string, error) {
 	}
 	defer func() {
 		if err != nil {
-			c.Exec(fmt.Sprintf("rm -f %s", shellescape.Quote(tmpFile)))
+			_ = c.Exec(fmt.Sprintf("rm -f %s", shellescape.Quote(tmpFile)))
 		}
 	}()
 	tmpFile = strings.TrimSpace(tmpFile)

--- a/ssh.go
+++ b/ssh.go
@@ -192,6 +192,8 @@ func (c *SSH) Exec(cmd string, opts ...exec.Option) error {
 	}
 	defer session.Close()
 
+	cmd = o.Command(cmd)
+
 	if len(o.Stdin) == 0 && c.knowOs && !c.isWindows {
 		// Only request a PTY when there's no STDIN data, because
 		// then you would need to send a CTRL-D after input to signal
@@ -386,7 +388,7 @@ func (c *SSH) uploadLinux(src, dst string) error {
 		return err
 	}
 
-	return c.Exec(fmt.Sprintf("sudo install -D %s %s", shellescape.Quote(tmpFile), shellescape.Quote(dst)))
+	return c.Exec(fmt.Sprintf("install -D %s %s", shellescape.Quote(tmpFile), shellescape.Quote(dst)), exec.Sudo())
 }
 
 func (c *SSH) uploadWindows(src, dst string) error {

--- a/winrm.go
+++ b/winrm.go
@@ -285,7 +285,7 @@ func (c *WinRM) ExecInteractive(cmd string) error {
 }
 
 // Upload uploads a file from local src path to remote dst path
-func (c *WinRM) Upload(src, dst string) error {
+func (c *WinRM) Upload(_ func(string) string, src, dst string) error {
 	psCmd := ps.UploadCmd(dst)
 	stat, err := os.Stat(src)
 	if err != nil {

--- a/winrm.go
+++ b/winrm.go
@@ -178,7 +178,7 @@ func (c *WinRM) Connect() error {
 	}
 
 	log.Debugf("%s: testing connection", c)
-	_, err = client.Run("echo ok", ioutil.Discard, ioutil.Discard)
+	_, err = client.Run("echo ok", io.Discard, io.Discard)
 	if err != nil {
 		return err
 	}
@@ -288,9 +288,10 @@ func (c *WinRM) ExecInteractive(cmd string) error {
 func (c *WinRM) Upload(src string) (string, error) {
 	var dst string
 	var err error
-	if err := c.Exec(ps.Cmd("(New-TemporaryFile).FullPath"), exec.Output(&dst)); err != nil {
+	if err := c.Exec(ps.Cmd("(New-TemporaryFile).FullName"), exec.Output(&dst)); err != nil {
 		return "", err
 	}
+	dst = strings.TrimSpace(dst)
 	defer func() {
 		if err != nil {
 			_ = c.Exec(fmt.Sprintf(`del "%s"`, dst))
@@ -427,7 +428,7 @@ func (c *WinRM) Upload(src string) (string, error) {
 	wg.Wait()
 
 	if cmd.ExitCode() != 0 {
-		return dst, fmt.Errorf("non-zero exit code")
+		return dst, fmt.Errorf("non-zero exit code: %d during upload", cmd.ExitCode())
 	}
 	if sha256DigestRemote == "" {
 		return dst, fmt.Errorf("copy file command did not output the expected JSON to stdout but exited with code 0")

--- a/winrm.go
+++ b/winrm.go
@@ -283,23 +283,18 @@ func (c *WinRM) ExecInteractive(cmd string) error {
 	return err
 }
 
-// Upload uploads a file from local src path to remote temp file, returning the tempfile path or error
-func (c *WinRM) Upload(src string) (string, error) {
-	var dst string
+// Upload uploads a file from local src path to remote path dst
+func (c *WinRM) Upload(src, dst string, opts ...exec.Option) error {
 	var err error
-	if err := c.Exec(ps.Cmd("(New-TemporaryFile).FullName"), exec.Output(&dst)); err != nil {
-		return "", err
-	}
-	dst = strings.TrimSpace(dst)
 	defer func() {
 		if err != nil {
-			_ = c.Exec(fmt.Sprintf(`del "%s"`, dst))
+			_ = c.Exec(fmt.Sprintf(`del %s`, ps.DoubleQuote(dst)), opts...)
 		}
 	}()
 	psCmd := ps.UploadCmd(dst)
 	stat, err := os.Stat(src)
 	if err != nil {
-		return dst, err
+		return err
 	}
 	sha256DigestLocalObj := sha256.New()
 	sha256DigestLocal := ""
@@ -310,7 +305,7 @@ func (c *WinRM) Upload(src string) (string, error) {
 	var fdClosed bool
 	fd, err := os.Open(src)
 	if err != nil {
-		return dst, err
+		return err
 	}
 	defer func() {
 		if !fdClosed {
@@ -320,12 +315,18 @@ func (c *WinRM) Upload(src string) (string, error) {
 	}()
 	shell, err := c.client.CreateShell()
 	if err != nil {
-		return dst, err
+		return err
 	}
 	defer shell.Close()
-	cmd, err := shell.Execute("powershell -ExecutionPolicy Unrestricted -EncodedCommand " + psCmd)
+	o := exec.Build(opts...)
+	upcmd, err := o.Command("powershell -ExecutionPolicy Unrestricted -EncodedCommand " + psCmd)
 	if err != nil {
-		return dst, err
+		return err
+	}
+
+	cmd, err := shell.Execute(upcmd)
+	if err != nil {
+		return err
 	}
 
 	// Create a dummy request to get its length
@@ -364,7 +365,7 @@ func (c *WinRM) Upload(src string) (string, error) {
 
 			bufferLength = 0
 			if err != nil {
-				return dst, err
+				return err
 			}
 		}
 	}
@@ -375,7 +376,7 @@ func (c *WinRM) Upload(src string) (string, error) {
 	}
 	if err != nil {
 		cmd.Close()
-		return dst, err
+		return err
 	}
 	if !ended {
 		_, _ = sha256DigestLocalObj.Write(buffer[:bufferLength])
@@ -388,7 +389,7 @@ func (c *WinRM) Upload(src string) (string, error) {
 		if err != nil {
 			if !strings.Contains(err.Error(), ps.PipeHasEnded) && !strings.Contains(err.Error(), ps.PipeIsBeingClosed) {
 				cmd.Close()
-				return dst, err
+				return err
 			}
 			// ignore pipe errors that results from passing true to cmd.SendInput
 		}
@@ -427,13 +428,13 @@ func (c *WinRM) Upload(src string) (string, error) {
 	wg.Wait()
 
 	if cmd.ExitCode() != 0 {
-		return dst, fmt.Errorf("non-zero exit code: %d during upload", cmd.ExitCode())
+		return fmt.Errorf("non-zero exit code: %d during upload", cmd.ExitCode())
 	}
 	if sha256DigestRemote == "" {
-		return dst, fmt.Errorf("copy file command did not output the expected JSON to stdout but exited with code 0")
+		return fmt.Errorf("copy file command did not output the expected JSON to stdout but exited with code 0")
 	} else if sha256DigestRemote != sha256DigestLocal {
-		return dst, fmt.Errorf("copy file checksum mismatch (local = %s, remote = %s)", sha256DigestLocal, sha256DigestRemote)
+		return fmt.Errorf("copy file checksum mismatch (local = %s, remote = %s)", sha256DigestLocal, sha256DigestRemote)
 	}
 
-	return dst, nil
+	return nil
 }


### PR DESCRIPTION
Adds an exec option `exec.Sudo(host)` and replaces all `sudo ...` commands with it.

Example:

```go
h.Exec("reboot", exec.Sudo(h))
```

Changes the upload API:  it now takes exec options, pretty much only utilizes `exec.Sudo(h)`. If you want to upload and overwrite a file that usually requires root to write, use `h.Upload(src, dst, exec.Sudo(h))`. I assume this is the only API change, if you use `h.Exec("sudo ..")` it should still work. Upload will still work as previously, but uploads to protected files will fail with some kind of permission error.

Fixes #35 
