### PR TITLE
Fix SSH login when both keyPath and ssh-agent defined

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -130,20 +130,6 @@ func (c *SSH) Connect() error {
 
 	var pubkeySigners []ssh.Signer
 
-	sshAgentSock := os.Getenv("SSH_AUTH_SOCK")
-
-	if sshAgentSock != "" {
-		sshAgent, err := net.Dial("unix", sshAgentSock)
-		if err != nil {
-			log.Errorf("can't connect to SSH agent auth socket %s: %s", sshAgentSock, err)
-		} else {
-			signers, err := agent.NewClient(sshAgent).Signers()
-			if err == nil {
-				pubkeySigners = append(pubkeySigners, signers...)
-			}
-		}
-	}
-
 	_, err := os.Stat(c.KeyPath)
 	if err != nil && !c.keypathDefault {
 		return err
@@ -159,6 +145,19 @@ func (c *SSH) Connect() error {
 			log.Errorf("can't parse keyfile %s: %s", c.KeyPath, err.Error())
 		} else {
 			pubkeySigners = append(pubkeySigners, signer)
+		}
+	}
+
+	sshAgentSock := os.Getenv("SSH_AUTH_SOCK")
+	if sshAgentSock != "" {
+		sshAgent, err := net.Dial("unix", sshAgentSock)
+		if err != nil {
+			log.Errorf("can't connect to SSH agent auth socket %s: %s", sshAgentSock, err)
+		} else {
+			signers, err := agent.NewClient(sshAgent).Signers()
+			if err == nil {
+				pubkeySigners = append(pubkeySigners, signers...)
+			}
 		}
 	}
 


### PR DESCRIPTION
Go's SSH package marks authentication methods "tried" by using the auth method name.

Both the agent and publickey methods return `publickey` from their `method()`, so if SSH agent was detected, and logging in using it didn't work, the ssh key from `KeyPath` was not being attempted at all.

This PR changes the way public key authentication is set up, both of the above methods now insert their pubkey signers into the `ssh.PublicKeys` auth  method instead of appending a new auth method to `config.Auth`.

