### PR TITLE
fix service environment

### DIFF
--- a/os/initsystem/openrc.go
+++ b/os/initsystem/openrc.go
@@ -61,7 +61,7 @@ func (i OpenRC) ServiceEnvironmentPath(h Host, s string) (string, error) {
 func (i OpenRC) ServiceEnvironmentContent(env map[string]string) string {
 	var b strings.Builder
 	for k, v := range env {
-		_, _ = fmt.Fprintf(&b, `%s=%s\n`, k, strconv.Quote(v))
+		_, _ = fmt.Fprintf(&b, "%s=%s\n", k, strconv.Quote(v))
 	}
 
 	return b.String()

--- a/os/initsystem/systemd.go
+++ b/os/initsystem/systemd.go
@@ -67,7 +67,7 @@ func (i Systemd) ServiceEnvironmentContent(env map[string]string) string {
 	var b strings.Builder
 	fmt.Fprintln(&b, "[Service]")
 	for k, v := range env {
-		_, _ = fmt.Fprintf(&b, `Environment=%s=%s\n`, k, strconv.Quote(v))
+		_, _ = fmt.Fprintf(&b, "Environment=%s=%s\n", k, strconv.Quote(v))
 	}
 
 	return b.String()

--- a/os/linux.go
+++ b/os/linux.go
@@ -263,7 +263,12 @@ func (c Linux) UpdateServiceEnvironment(h Host, s string, env map[string]string)
 	if err != nil {
 		return err
 	}
-	return c.WriteFile(h, fp, is.ServiceEnvironmentContent(env), "0660")
+	err = c.WriteFile(h, fp, is.ServiceEnvironmentContent(env), "0660")
+	if err != nil {
+		return err
+	}
+
+	return c.DaemonReload(h)
 }
 
 // CleanupEnvironment removes environment variable configuration


### PR DESCRIPTION
- replace backtick quotes with double quotes in `ServiceEnvironmentContent` so the trailing `\n` is translated to a newline
- always call `DaemonReload` after updating the service environment file (this is needed for systemd to pick up changes when it previously already knew about the service)

Signed-off-by: erdii <me@erdii.engineering>