### PR TITLE
Fix ArchLinux detection

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -20,7 +20,7 @@ var Resolvers []resolveFunc
 func GetOSVersion(c *Connection) (OSVersion, error) {
 	for _, r := range Resolvers {
 		if os, err := r(c); err == nil {
-			log.Debugf("%s: detected OS: %s", os)
+			log.Debugf("%s: detected OS: %s", c, os)
 			return os, nil
 		}
 	}

--- a/resolver.go
+++ b/resolver.go
@@ -116,14 +116,16 @@ func parseOSReleaseFile(s string, os *OSVersion) error {
 			os.ID = unquote(fields[1])
 		case "ID_LIKE":
 			os.IDLike = unquote(fields[1])
-			if os.IDLike == "arch" {
-				os.Version = "0.0.0"
-			}
 		case "VERSION_ID":
 			os.Version = unquote(fields[1])
 		case "PRETTY_NAME":
 			os.Name = unquote(fields[1])
 		}
+	}
+
+	// ArchLinux has no versions
+	if os.ID == "arch" || os.IDLike == "arch" {
+		os.Version = "0.0.0"
 	}
 
 	if os.ID == "" || os.Version == "" {

--- a/resolver.go
+++ b/resolver.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/k0sproject/rig/log"
 	ps "github.com/k0sproject/rig/powershell"
 )
 
@@ -19,6 +20,7 @@ var Resolvers []resolveFunc
 func GetOSVersion(c *Connection) (OSVersion, error) {
 	for _, r := range Resolvers {
 		if os, err := r(c); err == nil {
+			log.Debugf("%s: detected OS: %s", os)
 			return os, nil
 		}
 	}

--- a/resolver.go
+++ b/resolver.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/k0sproject/rig/log"
 	ps "github.com/k0sproject/rig/powershell"
 )
 
@@ -20,7 +19,6 @@ var Resolvers []resolveFunc
 func GetOSVersion(c *Connection) (OSVersion, error) {
 	for _, r := range Resolvers {
 		if os, err := r(c); err == nil {
-			log.Debugf("%s: detected OS: %s", c, os)
 			return os, nil
 		}
 	}


### PR DESCRIPTION
ArchLinux detection relied on the `ID_LIKE` field, should have been `ID`. This changes the detection to use either.
