### PR TITLE
Don't try to resolve OS on connect when already configured

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -71,7 +71,7 @@ type Connection struct {
 	SSH       *SSH       `yaml:"ssh,omitempty"`
 	Localhost *Localhost `yaml:"localhost,omitempty"`
 
-	OSVersion OSVersion `yaml:"-"`
+	OSVersion *OSVersion `yaml:"-"`
 
 	client   client `yaml:"-"`
 	sudofunc func(string) string
@@ -185,11 +185,14 @@ func (c *Connection) Connect() error {
 		return err
 	}
 
-	o, err := GetOSVersion(c)
-	if err != nil {
-		return err
+	if c.OSVersion == nil {
+		o, err := GetOSVersion(c)
+		if err != nil {
+			return err
+		}
+		c.OSVersion = &o
 	}
-	c.OSVersion = o
+
 	c.configureSudo()
 
 	return nil

--- a/examples/os/stock/stock.go
+++ b/examples/os/stock/stock.go
@@ -34,7 +34,7 @@ type Host struct {
 // LoadOS is a function that assigns a OS support package to the host and
 // typecasts it to a suitable interface
 func (h *Host) LoadOS() error {
-	bf, err := registry.GetOSModuleBuilder(h.OSVersion)
+	bf, err := registry.GetOSModuleBuilder(*h.OSVersion)
 	if err != nil {
 		return err
 	}

--- a/examples/upload/upload.go
+++ b/examples/upload/upload.go
@@ -30,7 +30,7 @@ type Host struct {
 // LoadOS is a function that assigns a OS support package to the host and
 // typecasts it to a suitable interface
 func (h *Host) LoadOS() error {
-	bf, err := registry.GetOSModuleBuilder(h.OSVersion)
+	bf, err := registry.GetOSModuleBuilder(*h.OSVersion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Avoids running the possibly failing OS detection when the OS has been set already (like in k0sctl's OS detection override).
