### PR TITLE
Export OpenRC /etc/conf.d envs

### DIFF
--- a/os/initsystem/openrc.go
+++ b/os/initsystem/openrc.go
@@ -61,7 +61,7 @@ func (i OpenRC) ServiceEnvironmentPath(h Host, s string) (string, error) {
 func (i OpenRC) ServiceEnvironmentContent(env map[string]string) string {
 	var b strings.Builder
 	for k, v := range env {
-		_, _ = fmt.Fprintf(&b, "%s=%s\n", k, strconv.Quote(v))
+		_, _ = fmt.Fprintf(&b, "export %s=%s\n", k, strconv.Quote(v))
 	}
 
 	return b.String()


### PR DESCRIPTION
As stated in https://docs.k0sproject.io/v1.22.1+k0s.0/environment-variables/ and https://github.com/k0sproject/k0sctl/issues/339#issuecomment-1075616791 the /etc/conf.d env variables need to be exported.
