### PR TITLE
Support paths and commands starting with hyphens on Linux

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -211,11 +211,11 @@ func (c *Connection) configureSudo() {
 			}
 		} else if c.Exec("sudo -n true") == nil {
 			c.sudofunc = func(cmd string) string {
-				return "sudo -s " + cmd
+				return "sudo -s -- " + cmd
 			}
 		} else if c.Exec("doas -n true") == nil {
 			c.sudofunc = func(cmd string) string {
-				return "doas -s " + cmd
+				return "doas -s -- " + cmd
 			}
 		}
 	}

--- a/localhost.go
+++ b/localhost.go
@@ -138,7 +138,7 @@ func (c *Localhost) Upload(src, dst string, opts ...exec.Option) error {
 			if c.IsWindows() {
 				_ = c.Exec(fmt.Sprintf(`del %s`, ps.DoubleQuote(dst)))
 			} else {
-				_ = c.Exec(fmt.Sprintf(`rm -f %s`, shellescape.Quote(dst)))
+				_ = c.Exec(fmt.Sprintf(`rm -f -- %s`, shellescape.Quote(dst)))
 			}
 		}
 	}()

--- a/os/linux.go
+++ b/os/linux.go
@@ -213,17 +213,17 @@ func (c Linux) WriteFile(h Host, path string, data string, permissions string) e
 }
 
 func (c Linux) InstallFile(h Host, src, dst, permissions string) error {
-	return h.Execf("install -D -m %s %s %s", permissions, src, dst, exec.Sudo(h))
+	return h.Execf("install -D -m %s -- %s %s", permissions, src, dst, exec.Sudo(h))
 }
 
 // ReadFile reads a files contents from the host.
 func (c Linux) ReadFile(h Host, path string) (string, error) {
-	return h.ExecOutputf("cat %s 2> /dev/null", escape.Quote(path), exec.HideOutput(), exec.Sudo(h))
+	return h.ExecOutputf("cat -- %s 2> /dev/null", escape.Quote(path), exec.HideOutput(), exec.Sudo(h))
 }
 
 // DeleteFile deletes a file from the host.
 func (c Linux) DeleteFile(h Host, path string) error {
-	return h.Execf(`rm -f %s 2> /dev/null`, escape.Quote(path), exec.Sudo(h))
+	return h.Execf(`rm -f -- %s 2> /dev/null`, escape.Quote(path), exec.Sudo(h))
 }
 
 // FileExist checks if a file exists on the host
@@ -235,7 +235,7 @@ func (c Linux) FileExist(h Host, path string) bool {
 // TODO refactor this into go because it's too magical.
 func (c Linux) LineIntoFile(h Host, path, matcher, newLine string) error {
 	if c.FileExist(h, path) {
-		err := h.Exec(fmt.Sprintf(`/bin/bash -c -- 'file=%s; match=%s; line=%s; grep -q "${match}" "$file" && sed -i "/${match}/c ${line}" "$file" || (echo "$line" | tee -a "$file" > /dev/null)'`, escape.Quote(path), escape.Quote(matcher), escape.Quote(newLine)))
+		err := h.Exec(fmt.Sprintf(`/bin/bash -c -- 'file=%s; match=%s; line=%s; grep -q "${match}" "$file" && sed -i "/${match}/c ${line}" -- "$file" || (echo "$line" | tee -a -- "$file" > /dev/null)'`, escape.Quote(path), escape.Quote(matcher), escape.Quote(newLine)))
 		if err != nil {
 			return err
 		}
@@ -302,7 +302,7 @@ func (c Linux) CleanupServiceEnvironment(h Host, s string) error {
 
 // CommandExist returns true if the command exists
 func (c Linux) CommandExist(h Host, cmd string) bool {
-	return h.Execf(`command -v "%s" 2> /dev/null`, cmd, exec.Sudo(h)) == nil
+	return h.Execf(`command -v -- "%s" 2> /dev/null`, cmd, exec.Sudo(h)) == nil
 }
 
 // Reboot executes the reboot command
@@ -316,12 +316,12 @@ func (c Linux) Reboot(h Host) error {
 
 // MkDir creates a directory (including intermediate directories)
 func (c Linux) MkDir(h Host, s string, opts ...exec.Option) error {
-	return h.Exec(fmt.Sprintf("mkdir -p %s", escape.Quote(s)), opts...)
+	return h.Exec(fmt.Sprintf("mkdir -p -- %s", escape.Quote(s)), opts...)
 }
 
 // Chmod updates permissions of a path
 func (c Linux) Chmod(h Host, s, perm string, opts ...exec.Option) error {
-	return h.Exec(fmt.Sprintf("chmod %s %s", perm, escape.Quote(s)), opts...)
+	return h.Exec(fmt.Sprintf("chmod %s -- %s", perm, escape.Quote(s)), opts...)
 }
 
 // Stat gets file / directory information
@@ -354,5 +354,5 @@ func (c Linux) Stat(h Host, path string, opts ...exec.Option) (*FileInfo, error)
 
 // Touch updates a file's last modified time or creates a new empty file
 func (c Linux) Touch(h Host, path string, ts time.Time, opts ...exec.Option) error {
-	return h.Exec(fmt.Sprintf("touch -m -t %s %s", ts.Format("200601021504.05"), shellescape.Quote(path)), opts...)
+	return h.Exec(fmt.Sprintf("touch -m -t %s -- %s", ts.Format("200601021504.05"), shellescape.Quote(path)), opts...)
 }

--- a/ssh.go
+++ b/ssh.go
@@ -369,7 +369,7 @@ func (c *SSH) uploadLinux(src, dst string, opts ...exec.Option) error {
 	defer func() {
 		if err != nil {
 			log.Debugf("%s: cleaning up %s", c, dst)
-			_ = c.Exec(fmt.Sprintf("rm -f %s", shellescape.Quote(dst)), opts...)
+			_ = c.Exec(fmt.Sprintf("rm -f -- %s", shellescape.Quote(dst)), opts...)
 		}
 	}()
 
@@ -395,7 +395,7 @@ func (c *SSH) uploadLinux(src, dst string, opts ...exec.Option) error {
 	}
 
 	o := exec.Build(opts...)
-	teeCmd, err := o.Command(fmt.Sprintf("tee %s > /dev/null", shellescape.Quote(dst)))
+	teeCmd, err := o.Command(fmt.Sprintf("tee -- %s > /dev/null", shellescape.Quote(dst)))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Paths or commands that start with a hyphen may be erroneously interpreted as options to prepended commands. Mitigate that by adding a double-hyphen in the right places, which signals "end of options" to most commands.