### PR TITLE
added sudo + worked around broken shell variables

### DIFF
--- a/os/linux.go
+++ b/os/linux.go
@@ -235,7 +235,8 @@ func (c Linux) FileExist(h Host, path string) bool {
 // TODO refactor this into go because it's too magical.
 func (c Linux) LineIntoFile(h Host, path, matcher, newLine string) error {
 	if c.FileExist(h, path) {
-		err := h.Exec(fmt.Sprintf(`/bin/bash -c -- 'file=%s; match=%s; line=%s; grep -q "${match}" "$file" && sed -i "/${match}/c ${line}" -- "$file" || (echo "$line" | tee -a -- "$file" > /dev/null)'`, escape.Quote(path), escape.Quote(matcher), escape.Quote(newLine)))
+		err := h.Exec(fmt.Sprintf(`/bin/bash -c -- 'grep -q "%s" "%s" && sed -i "/%s/c %s" -- "%s" || (echo "%s" | tee -a -- "%s" > /dev/null)'`, 
+			escape.Quote(matcher), escape.Quote(path), escape.Quote(matcher), escape.Quote(newLine), escape.Quote(path), escape.Quote(newLine), escape.Quote(path)), exec.Sudo(h))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
see also: https://github.com/k0sproject/rig/issues/55

It took a bit more effort than just adding exec.Sudo(h), because the shell variables file= etc break when running it with sudo -s. 
I'm not a go guy, so the formatting could probably be done smarter, but this works.
