### PR TITLE
Reduce error log level of ParsePrivateKey to Infof

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -145,7 +145,7 @@ func (c *SSH) Connect() error {
 		}
 		signer, err := ssh.ParsePrivateKey(key)
 		if err != nil {
-			log.Errorf("can't parse keyfile %s: %s", c.KeyPath, err.Error())
+			log.Infof("can't parse keyfile %s: %s", c.KeyPath, err.Error())
 		} else {
 			pubkeySigners = append(pubkeySigners, signer)
 		}


### PR DESCRIPTION
Following the discussion in k0sproject/k0sctl#374 This is a PR to reduce log level of `ParsePrivateKey` to `Infof`

```
ERRO can't parse keyfile /home/rtsp/.ssh/id_rsa: ssh: this private key is passphrase protected
ERRO can't parse keyfile /home/rtsp/.ssh/id_rsa: ssh: this private key is passphrase protected
```

Fixed k0sproject/k0sctl#374