### PR TITLE
Don't quote env values

### DIFF
--- a/os/initsystem/openrc.go
+++ b/os/initsystem/openrc.go
@@ -3,7 +3,6 @@ package initsystem
 import (
 	"fmt"
 	"path"
-	"strconv"
 	"strings"
 
 	"github.com/k0sproject/rig/exec"
@@ -61,7 +60,7 @@ func (i OpenRC) ServiceEnvironmentPath(h Host, s string) (string, error) {
 func (i OpenRC) ServiceEnvironmentContent(env map[string]string) string {
 	var b strings.Builder
 	for k, v := range env {
-		_, _ = fmt.Fprintf(&b, "export %s=%s\n", k, strconv.Quote(v))
+		_, _ = fmt.Fprintf(&b, "export %s=%s\n", k, v)
 	}
 
 	return b.String()

--- a/os/initsystem/systemd.go
+++ b/os/initsystem/systemd.go
@@ -3,7 +3,6 @@ package initsystem
 import (
 	"fmt"
 	"path"
-	"strconv"
 	"strings"
 
 	"github.com/k0sproject/rig/exec"
@@ -67,7 +66,7 @@ func (i Systemd) ServiceEnvironmentContent(env map[string]string) string {
 	var b strings.Builder
 	fmt.Fprintln(&b, "[Service]")
 	for k, v := range env {
-		_, _ = fmt.Fprintf(&b, "Environment=%s=%s\n", k, strconv.Quote(v))
+		_, _ = fmt.Fprintf(&b, "Environment=%s=%s\n", k, v)
 	}
 
 	return b.String()


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <kimmo.lehto@gmail.com>

Don't quote shell variable values. The user should decide when they need to do so.

See: https://github.com/k0sproject/k0sctl/issues/399