### PR TITLE
Fix /etc/environment row duplication

### DIFF
--- a/os/linux.go
+++ b/os/linux.go
@@ -266,7 +266,7 @@ func (c Linux) LineIntoFile(h Host, path, matcher, newLine string) error {
 // UpdateEnvironment updates the hosts's environment variables
 func (c Linux) UpdateEnvironment(h Host, env map[string]string) error {
 	for k, v := range env {
-		err := c.LineIntoFile(h, "/etc/environment", fmt.Sprintf("^%s=", k), fmt.Sprintf("%s=%s", k, v))
+		err := c.LineIntoFile(h, "/etc/environment", fmt.Sprintf("%s=", k), fmt.Sprintf("%s=%s", k, v))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The UpdateEnvironment function was using the regex caret `^`, but the `LineIntoFile` uses simple `HasPrefix` instead of regexes. This caused a duplication in /etc/environment.
