### PR TITLE
[ci] Remove skip-go-installation to stop warnings

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,6 @@ jobs:
       uses: golangci/golangci-lint-action@v3.1.0
       with:
         version: latest
-        skip-go-installation: true
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <kimmo.lehto@gmail.com>

The github workflow gives warnings:

![image](https://user-images.githubusercontent.com/224971/183843600-4ad97890-4465-4a0a-b74b-04fa9fabe9ee.png)

This PR removes that setting.
