### PR TITLE
Use agent when public key given in keypath

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,3 +32,7 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Run integration tests
+      run: make -C test test
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+test/rigtest
+test/Library
+test/.ssh

--- a/cmd/rigtest/rigtest.go
+++ b/cmd/rigtest/rigtest.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	goos "os"
+	"strings"
+	"time"
+
+	"github.com/k0sproject/rig"
+	"github.com/k0sproject/rig/exec"
+	"github.com/k0sproject/rig/os"
+	"github.com/k0sproject/rig/os/registry"
+	_ "github.com/k0sproject/rig/os/support"
+	"github.com/kevinburke/ssh_config"
+)
+
+type configurer interface {
+	WriteFile(os.Host, string, string, string) error
+	LineIntoFile(os.Host, string, string, string) error
+	ReadFile(os.Host, string) (string, error)
+	FileExist(os.Host, string) bool
+	DeleteFile(os.Host, string) error
+	Stat(os.Host, string, ...exec.Option) (*os.FileInfo, error)
+}
+
+// Host is a host that utilizes rig for connections
+type Host struct {
+	rig.Connection
+
+	Configurer configurer
+}
+
+// LoadOS is a function that assigns a OS support package to the host and
+// typecasts it to a suitable interface
+func (h *Host) LoadOS() error {
+	bf, err := registry.GetOSModuleBuilder(*h.OSVersion)
+	if err != nil {
+		return err
+	}
+
+	h.Configurer = bf().(configurer)
+
+	return nil
+}
+
+func main() {
+	dh := flag.String("host", "127.0.0.1", "target host")
+	dp := flag.Int("port", 22, "target host port")
+	usr := flag.String("user", "root", "user name")
+	kp := flag.String("keypath", "", "keypath")
+
+	fn := fmt.Sprintf("test_%s.txt", time.Now().Format("20060102150405"))
+
+	flag.Parse()
+
+	if *dh == "" {
+		println("see -help")
+		goos.Exit(1)
+	}
+
+	h := Host{
+		Connection: rig.Connection{
+			SSH: &rig.SSH{
+				Address: *dh,
+				Port:    *dp,
+				User:    *usr,
+			},
+		},
+	}
+
+	if *kp != "" {
+		h.SSH.KeyPath = *kp
+	}
+
+	if configPath := goos.Getenv("SSH_CONFIG"); configPath != "" {
+		f, err := goos.Open(configPath)
+		if err != nil {
+			panic(err)
+		}
+		cfg, err := ssh_config.Decode(f)
+		if err != nil {
+			panic(err)
+		}
+		rig.SSHConfigGetAll = func(dst, key string) []string {
+			res, err := cfg.GetAll(dst, key)
+			if err != nil {
+				return nil
+			}
+			return res
+		}
+	}
+
+	if err := h.Connect(); err != nil {
+		panic(err)
+	}
+
+	if err := h.LoadOS(); err != nil {
+		panic(err)
+	}
+
+	if err := h.Configurer.WriteFile(h, fn, "test\ntest2\ntest3", "0644"); err != nil {
+		panic(err)
+	}
+
+	if err := h.Configurer.LineIntoFile(h, fn, "test2", "test4"); err != nil {
+		panic(err)
+	}
+
+	if !h.Configurer.FileExist(h, fn) {
+		panic("file does not exist")
+	}
+
+	row, err := h.Configurer.ReadFile(h, fn)
+	if err != nil {
+		panic(err)
+	}
+	if row != "test\ntest4\ntest3" {
+		panic("file content is not correct")
+	}
+
+	stat, err := h.Configurer.Stat(h, fn)
+	if err != nil {
+		panic(err)
+	}
+	if !strings.HasSuffix(stat.FName, fn) {
+		panic("file stat is not correct")
+	}
+
+	if err := h.Configurer.DeleteFile(h, fn); err != nil {
+		panic(err)
+	}
+
+	if h.Configurer.FileExist(h, fn) {
+		panic("file still exists")
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -86,9 +86,8 @@ func (c *Connection) SetDefaults() {
 		if c.client == nil {
 			c.client = defaultClient()
 		}
+		_ = defaults.Set(c.client)
 	}
-
-	_ = defaults.Set(c.client)
 }
 
 // Protocol returns the connection protocol name
@@ -133,16 +132,11 @@ func (c *Connection) IsConnected() bool {
 // String returns a printable representation of the connection, which will look
 // like: `[ssh] address:port`
 func (c Connection) String() string {
-	client := c.client
-	if client == nil {
-		client = c.configuredClient()
-		_ = defaults.Set(c)
-	}
-	if client == nil {
-		client = defaultClient()
+	if c.client == nil {
+		return fmt.Sprintf("[%s] %s", c.Protocol(), c.Address())
 	}
 
-	return client.String()
+	return c.client.String()
 }
 
 // IsWindows returns true on windows hosts
@@ -311,9 +305,7 @@ func (c *Connection) configuredClient() client {
 }
 
 func defaultClient() client {
-	c := &Localhost{Enabled: true}
-	_ = defaults.Set(c)
-	return c
+	return &Localhost{Enabled: true}
 }
 
 // GroupParams separates exec.Options from other sprintf templating args

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/davidmz/go-pageant v1.0.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/kevinburke/ssh_config v1.2.0
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZ
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
+github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/ssh_agent.go
+++ b/ssh_agent.go
@@ -7,23 +7,19 @@ import (
 	"net"
 	"os"
 
-	ssh "golang.org/x/crypto/ssh"
+	"github.com/k0sproject/rig/log"
 	"golang.org/x/crypto/ssh/agent"
 )
 
-// getSshAgentSigners returns non empty list of signers from a SSH agent
-func getSshAgentSigners() ([]ssh.Signer, error) {
+func agentClient() (agent.Agent, error) {
 	sshAgentSock := os.Getenv("SSH_AUTH_SOCK")
 	if sshAgentSock == "" {
 		return nil, fmt.Errorf("SSH_AUTH_SOCK is empty")
 	}
+	log.Debugf("using SSH_AUTH_SOCK=%s", sshAgentSock)
 	sshAgent, err := net.Dial("unix", sshAgentSock)
 	if err != nil {
 		return nil, fmt.Errorf("can't connect to SSH agent: %w", err)
 	}
-	signers, err := agent.NewClient(sshAgent).Signers()
-	if err != nil {
-		return nil, fmt.Errorf("SSH agent new client: %w", err)
-	}
-	return signers, nil
+	return agent.NewClient(sshAgent), nil
 }

--- a/ssh_agent_windows.go
+++ b/ssh_agent_windows.go
@@ -16,45 +16,13 @@ const (
 	openSshAgentPipe = `\\.\pipe\openssh-ssh-agent`
 )
 
-// getSshAgentSigners returns non empty list of signers from a SSH agent
-func getSshAgentSigners() ([]ssh.Signer, error) {
-	var (
-		errors  []string
-		signers []ssh.Signer
-	)
-
+func agentClient() (agent.Agent, error) {
 	if pageant.Available() {
-		signersPageant, errGetSigners := pageant.New().Signers()
-		if errGetSigners != nil {
-			errors = append(errors, fmt.Sprintf("- Failed to get signers from Pageant: %s", errGetSigners))
-		} else {
-			if len(signersPageant) > 0 {
-				signers = append(signers, signersPageant...)
-			} else {
-				errors = append(errors, "- No keys loaded in Pageant")
-			}
-		}
-	} else {
-		errors = append(errors, "- Pageant is unavailable")
+		return pageant.New(), nil
 	}
-
 	sock, err := winio.DialPipe(openSshAgentPipe, nil)
 	if err != nil {
-		errors = append(errors, fmt.Sprintf("- Can't connect to openssh-agent: %s", err))
-	} else {
-		signersOpenSSHAgent, errGetSigners := agent.NewClient(sock).Signers()
-		if errGetSigners != nil {
-			errors = append(errors, fmt.Sprintf("- Failed to get signers from openssh-agent: %s", errGetSigners))
-		} else {
-			if len(signersOpenSSHAgent) > 0 {
-				signers = append(signers, signersOpenSSHAgent...)
-			} else {
-				errors = append(errors, "- No keys loaded in openssh-agent")
-			}
-		}
+		return nil, err
 	}
-	if len(signers) > 0 {
-		return signers, nil
-	}
-	return nil, fmt.Errorf("%s", strings.Join(errors, "\n"))
+	return agent.NewClient(sock), nil
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,70 @@
+KEY_TYPE ?= rsa
+KEY_SIZE ?= 4096
+KEY_PASSPHRASE ?= ""
+KEY_PATH ?= ".ssh/identity"
+
+footloose := $(shell which footloose)
+ifeq ($(footloose),)
+footloose := $(shell go env GOPATH)/bin/footloose
+endif
+
+envsubst := $(shell which envsubst)
+ifeq ($(envsubst),)
+$(error 'envsubst' NOT found in path, please install it and re-run)
+endif
+
+sshkeygen := $(shell which ssh-keygen)
+ifeq ($(sshkeygen),)
+$(error 'ssh-keygen' NOT found in path, please install it and re-run)
+endif
+
+.PHONY: rigtest
+rigtest:
+	go build -o rigtest ../cmd/rigtest
+
+$(footloose):
+	go install github.com/weaveworks/footloose/...@0.6.3
+
+.ssh:
+	mkdir -p .ssh
+
+.ssh/identity: .ssh
+	ssh-keygen -t $(KEY_TYPE) -b $(KEY_SIZE) -f .ssh/identity -N $(KEY_PASSPHRASE)
+
+footloose.yaml: .ssh/identity
+	$(footloose) config create \
+		--config footloose.yaml \
+	  --image quay.io/footloose/ubuntu18.04 \
+		--name rigtest \
+	  --key .ssh/identity \
+		--replicas 1 \
+    --override
+
+.PHONY: create-host
+create-host: footloose.yaml
+	$(footloose) create -c footloose.yaml
+
+.PHONY: delete-host
+delete-host: footloose.yaml
+	$(footloose) delete -c footloose.yaml
+
+.PHONY: clean
+clean: delete-host
+	rm -f footloose.yaml identity rigtest
+	rm -rf .ssh
+
+.PHONY: sshport
+sshport:
+	@$(footloose) show node0 -o json|grep hostPort|grep -oE "[0-9]+"
+
+.PHONY: run
+run: rigtest create-host
+	./rigtest \
+		-host 127.0.0.1 \
+		-port $(shell $(MAKE) sshport) \
+	  -keypath $(KEY_PATH) \
+		-user root
+
+.PHONY: test
+test: rigtest
+	./test.sh

--- a/test/footloose.yaml
+++ b/test/footloose.yaml
@@ -1,0 +1,11 @@
+cluster:
+  name: rigtest
+  privateKey: .ssh/identity
+machines:
+- count: 1
+  spec:
+    backend: docker
+    image: quay.io/footloose/ubuntu18.04
+    name: node%d
+    portMappings:
+    - containerPort: 22

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -e
+
+color_echo() {
+  echo -e "\033[1;31m$@\033[0m"
+}
+
+rig_test_agent_with_public_key() {
+  color_echo "- Testing connection using agent and providing a path to public key"
+  make create-host
+  eval $(ssh-agent -s)
+  ssh-add .ssh/identity
+  rm -f .ssh/identity
+  set +e
+  HOME=$(pwd) SSH_AUTH_SOCK=$SSH_AUTH_SOCK ./rigtest -port $(make sshport) -user root -keypath .ssh/identity.pub
+  local exit_code=$?
+  set -e
+  kill $SSH_AGENT_PID
+  export SSH_AGENT_PID=
+  export SSH_AUTH_SOCK=
+  return $exit_code
+}
+
+rig_test_agent() {
+  color_echo "- Testing connection using any key from agent (empty keypath)"
+  make create-host
+  eval $(ssh-agent -s)
+  ssh-add .ssh/identity
+  rm -f .ssh/identity
+  set +e
+  ssh-add -l
+  HOME=. SSH_AUTH_SOCK=$SSH_AUTH_SOCK ./rigtest -port $(make sshport) -user root -keypath ""
+  local exit_code=$?
+  set -e
+  kill $SSH_AGENT_PID
+  export SSH_AGENT_PID=
+  export SSH_AUTH_SOCK=
+  return $exit_code
+}
+
+rig_test_ssh_config() {
+  color_echo "- Testing getting identity path from ssh config"
+  make create-host
+  mv .ssh/identity .ssh/identity2
+  echo "Host 127.0.0.1:$(make sshport)" > .ssh/config
+  echo "  IdentityFile .ssh/identity2" >> .ssh/config
+  set +e
+  HOME=. SSH_CONFIG=.ssh/config ./rigtest -port $(make sshport) -user root
+  local exit_code=$?
+  set -e
+  return $exit_code
+}
+
+rig_test_key_from_path() {
+  color_echo "- Testing regular keypath"
+  make create-host
+  mv .ssh/identity .ssh/identity2
+  set +e
+  ./rigtest -port $(make sshport) -user root -keypath .ssh/identity2
+  local exit_code=$?
+  set -e
+  return $exit_code
+}
+
+for test in $(declare -F|grep rig_test_|cut -d" " -f3); do
+  make clean
+  make rigtest
+  color_echo "\n###########################################################"
+  $test
+  echo -e "\n\n\n"
+done


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #70
Helps resolve https://github.com/k0sproject/k0sctl/issues/422

- When using a path to a private key, agent will not be used. If parsing fails with passphrase missing, a passphrase may be asked (when the implementation provides a PasswordCallback function)
- Now you can also give a path to a public key -- if agent is available and a private key for that public key is available on the agent, use the agent to authenticate with that key
- If you give an empty key path, any IdentityFile (can be multiple) found for the host in ~/.ssh/config will have precedence over the default (outdated) ~/.ssh/id_rsa

Also added a simplistic integration test suite.
