### PR TITLE
Error redesign

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -70,8 +70,6 @@ func TestHostFunctions(t *testing.T) {
 	require.NoError(t, defaults.Set(&h))
 	require.Equal(t, "SSH", h.Protocol())
 	require.Equal(t, "127.0.0.1", h.Address())
-	_ = h.Connect()
-	h.Disconnect()
 }
 
 func TestOutputWriter(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,20 @@
+package rig
+
+import (
+	"github.com/k0sproject/rig/errstring"
+)
+
+var (
+	ErrOS               = errstring.New("local os")              // ErrOS is returned when an action fails on local OS
+	ErrInvalidPath      = errstring.New("invalid path")          // ErrInvalidPath is returned when a path is invalid
+	ErrValidationFailed = errstring.New("validation failed")     // ErrValidationFailed is returned when a validation fails
+	ErrSudoRequired     = errstring.New("sudo required")         // ErrSudoRequired is returned when sudo is required
+	ErrNotFound         = errstring.New("not found")             // ErrNotFound is returned when a resource is not found
+	ErrNotImplemented   = errstring.New("not implemented")       // ErrNotImplemented is returned when a feature is not implemented
+	ErrNotSupported     = errstring.New("not supported")         // ErrNotSupported is returned when a feature is not supported
+	ErrAuthFailed       = errstring.New("authentication failed") // ErrAuthFailed is returned when authentication fails
+	ErrUploadFailed     = errstring.New("upload failed")         // ErrUploadFailed is returned when an upload fails
+	ErrNotConnected     = errstring.New("not connected")         // ErrNotConnected is returned when a connection is not established
+	ErrCantConnect      = errstring.New("can't connect")         // ErrCantConnect is returned when a connection is not established and retrying will fail
+	ErrCommandFailed    = errstring.New("command failed")        // ErrCommandFailed is returned when a command fails
+)

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,75 @@
+package rig
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorStringer(t *testing.T) {
+	type testCase struct {
+		name     string
+		err      error
+		expected string
+	}
+
+	for _, scenario := range []testCase{
+		{
+			name:     "non-wrapped error",
+			err:      ErrOS,
+			expected: "local os",
+		},
+		{
+			name:     "error wrapped in error",
+			err:      ErrOS.Wrap(ErrInvalidPath),
+			expected: "local os: invalid path",
+		},
+		{
+			name:     "string wrapped error",
+			err:      ErrOS.Wrapf("test"),
+			expected: "local os: test",
+		},
+		{
+			name:     "double wrapped string error",
+			err:      ErrOS.Wrapf("test: %w", ErrInvalidPath),
+			expected: "local os: test: invalid path",
+		},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			require.Error(t, scenario.err)
+			require.Equal(t, scenario.expected, scenario.err.Error())
+		})
+	}
+}
+
+func TestUnwrap(t *testing.T) {
+	err := ErrOS.Wrap(ErrInvalidPath)
+	require.Equal(t, ErrInvalidPath, errors.Unwrap(err))
+}
+
+func TestErrorsIs(t *testing.T) {
+	err := ErrOS.Wrap(ErrInvalidPath.Wrap(ErrNotFound))
+	require.True(t, errors.Is(err, ErrOS))
+	require.True(t, errors.Is(err, ErrInvalidPath))
+	require.True(t, errors.Is(err, ErrNotFound))
+	require.False(t, errors.Is(err, ErrNotConnected))
+}
+
+type testErr struct {
+	msg string
+}
+
+func (t *testErr) Error() string {
+	return "foo " + t.msg
+}
+
+func TestErrorsAs(t *testing.T) {
+	err := ErrOS.Wrap(ErrInvalidPath.Wrap(&testErr{msg: "test"}))
+	var cmp *testErr
+	require.True(t, errors.As(err, &cmp))
+	require.Equal(t, "local os: invalid path: foo test", err.Error())
+	if errors.As(err, &cmp) {
+		require.Equal(t, "foo test", cmp.Error())
+	}
+}

--- a/errstring/errstring.go
+++ b/errstring/errstring.go
@@ -1,0 +1,61 @@
+// Package errstring defines a simple error struct
+package errstring
+
+import (
+	"fmt"
+)
+
+// Error is the base type for rig errors
+type Error struct {
+	msg string
+}
+
+// Error implements the error interface
+func (e *Error) Error() string {
+	return e.msg
+}
+
+func (e *Error) Unwrap() error {
+	return nil
+}
+
+// New creates a new error
+func New(msg string) *Error {
+	return &Error{msg}
+}
+
+// Wrap wraps another error with this error
+func (e *Error) Wrap(errB error) error {
+	return &wrappedError{
+		errA: e,
+		errB: errB,
+	}
+}
+
+// Wrapf is a shortcut for Wrap(fmt.Errorf("...", ...))
+func (e *Error) Wrapf(msg string, args ...any) error {
+	return &wrappedError{
+		errA: e,
+		errB: fmt.Errorf(msg, args...), //nolint:goerr113
+	}
+}
+
+type wrappedError struct {
+	errA error
+	errB error
+}
+
+func (e *wrappedError) Error() string {
+	return e.errA.Error() + ": " + e.errB.Error()
+}
+
+func (e *wrappedError) Is(err error) bool {
+	if err == nil {
+		return false
+	}
+	return e.errA == err //nolint:goerr113
+}
+
+func (e *wrappedError) Unwrap() error {
+	return e.errB
+}

--- a/exec/errors.go
+++ b/exec/errors.go
@@ -1,0 +1,8 @@
+package exec
+
+import "github.com/k0sproject/rig/errstring"
+
+var (
+	ErrRemote = errstring.New("remote exec error") // ErrRemote is returned when an action fails on remote host
+	ErrSudo   = errstring.New("sudo error")        // ErrSudo is returned when wrapping a command with sudo fails
+)

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -80,7 +80,7 @@ func (o *Options) Command(cmd string) (string, error) {
 
 	out, err := o.host.Sudo(cmd)
 	if err != nil {
-		return "", fmt.Errorf("failed to sudo: %w", err)
+		return "", ErrSudo.Wrap(err)
 	}
 	return out, nil
 }

--- a/localhost.go
+++ b/localhost.go
@@ -123,7 +123,7 @@ func (c *Localhost) Exec(cmd string, opts ...exec.Option) error {
 func (c *Localhost) command(cmd string, o *exec.Options) (*osexec.Cmd, error) {
 	cmd, err := o.Command(cmd)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build command: %w", err)
+		return nil, fmt.Errorf("build command: %w", err)
 	}
 
 	if c.IsWindows() {
@@ -148,7 +148,7 @@ func (c *Localhost) Upload(src, dst string, opts ...exec.Option) error {
 
 	inFile, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("failed to open source file %s: %w", src, err)
+		return ErrInvalidPath.Wrapf("failed to open local file %s: %w", src, err)
 	}
 	defer inFile.Close()
 
@@ -159,7 +159,7 @@ func (c *Localhost) Upload(src, dst string, opts ...exec.Option) error {
 	defer out.Close()
 	_, err = io.Copy(out, inFile)
 	if err != nil {
-		return fmt.Errorf("failed to copy file %s to %s: %w", src, dst, err)
+		return fmt.Errorf("failed to copy local file %s to remote %s: %w", src, dst, err)
 	}
 	return nil
 }

--- a/os/initsystem/openrc.go
+++ b/os/initsystem/openrc.go
@@ -14,7 +14,7 @@ type OpenRC struct{}
 // StartService starts a service
 func (i OpenRC) StartService(h Host, s string) error {
 	if err := h.Execf("rc-service %s start", s, exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to start service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to start service %s: %w", s, err)
 	}
 	return nil
 }
@@ -22,7 +22,7 @@ func (i OpenRC) StartService(h Host, s string) error {
 // StopService stops a service
 func (i OpenRC) StopService(h Host, s string) error {
 	if err := h.Execf("rc-service %s stop", s, exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to stop service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to stop service %s: %w", s, err)
 	}
 	return nil
 }
@@ -31,7 +31,7 @@ func (i OpenRC) StopService(h Host, s string) error {
 func (i OpenRC) ServiceScriptPath(h Host, s string) (string, error) {
 	out, err := h.ExecOutputf("rc-service -r %s 2> /dev/null", s, exec.Sudo(h))
 	if err != nil {
-		return "", fmt.Errorf("failed to get service script path for %s: %w", s, err)
+		return "", exec.ErrRemote.Wrapf("failed to get service script path for %s: %w", s, err)
 	}
 	return strings.TrimSpace(out), nil
 }
@@ -39,7 +39,7 @@ func (i OpenRC) ServiceScriptPath(h Host, s string) (string, error) {
 // RestartService restarts a service
 func (i OpenRC) RestartService(h Host, s string) error {
 	if err := h.Execf("rc-service %s restart", s, exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to restart service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to restart service %s: %w", s, err)
 	}
 	return nil
 }
@@ -52,7 +52,7 @@ func (i OpenRC) DaemonReload(_ Host) error {
 // EnableService enables a service
 func (i OpenRC) EnableService(h Host, s string) error {
 	if err := h.Execf("rc-update add %s", s, exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to enable service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to enable service %s: %w", s, err)
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func (i OpenRC) EnableService(h Host, s string) error {
 // DisableService disables a service
 func (i OpenRC) DisableService(h Host, s string) error {
 	if err := h.Execf("rc-update del %s", s, exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to disable service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to disable service %s: %w", s, err)
 	}
 	return nil
 }

--- a/os/initsystem/systemd.go
+++ b/os/initsystem/systemd.go
@@ -15,7 +15,7 @@ type Systemd struct{}
 // StartService starts a service
 func (i Systemd) StartService(h Host, s string) error {
 	if err := h.Execf("systemctl start %s 2> /dev/null", s, exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to start service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to start service %s: %w", s, err)
 	}
 	return nil
 }
@@ -23,7 +23,7 @@ func (i Systemd) StartService(h Host, s string) error {
 // EnableService enables a service
 func (i Systemd) EnableService(h Host, s string) error {
 	if err := h.Execf("systemctl enable %s 2> /dev/null", s, exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to enable service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to enable service %s: %w", s, err)
 	}
 	return nil
 }
@@ -31,7 +31,7 @@ func (i Systemd) EnableService(h Host, s string) error {
 // DisableService disables a service
 func (i Systemd) DisableService(h Host, s string) error {
 	if err := h.Execf("systemctl disable %s 2> /dev/null", s, exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to disable service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to disable service %s: %w", s, err)
 	}
 	return nil
 }
@@ -39,7 +39,7 @@ func (i Systemd) DisableService(h Host, s string) error {
 // StopService stops a service
 func (i Systemd) StopService(h Host, s string) error {
 	if err := h.Execf("systemctl stop %s 2> /dev/null", s, exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to stop service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to stop service %s: %w", s, err)
 	}
 	return nil
 }
@@ -47,7 +47,7 @@ func (i Systemd) StopService(h Host, s string) error {
 // RestartService restarts a service
 func (i Systemd) RestartService(h Host, s string) error {
 	if err := h.Execf("systemctl restart %s 2> /dev/null", s, exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to restart service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to restart service %s: %w", s, err)
 	}
 	return nil
 }
@@ -55,7 +55,7 @@ func (i Systemd) RestartService(h Host, s string) error {
 // DaemonReload reloads init system configuration
 func (i Systemd) DaemonReload(h Host) error {
 	if err := h.Execf("systemctl daemon-reload 2> /dev/null", exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to daemon-reload: %w", err)
+		return exec.ErrRemote.Wrapf("failed to daemon-reload: %w", err)
 	}
 	return nil
 }
@@ -69,7 +69,7 @@ func (i Systemd) ServiceIsRunning(h Host, s string) bool {
 func (i Systemd) ServiceScriptPath(h Host, s string) (string, error) {
 	out, err := h.ExecOutputf(`systemctl show -p FragmentPath %s.service 2> /dev/null | cut -d"=" -f2`, s, exec.Sudo(h))
 	if err != nil {
-		return "", fmt.Errorf("failed to get service %s script path: %w", s, err)
+		return "", exec.ErrRemote.Wrapf("failed to get service %s script path: %w", s, err)
 	}
 	return strings.TrimSpace(out), nil
 }

--- a/os/linux/archlinux.go
+++ b/os/linux/archlinux.go
@@ -1,7 +1,6 @@
 package linux
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/k0sproject/rig"
@@ -29,7 +28,7 @@ func init() {
 // InstallPackage installs packages via pacman
 func (c Archlinux) InstallPackage(h os.Host, s ...string) error {
 	if err := h.Execf("pacman -S --noconfirm --noprogressbar %s", strings.Join(s, " "), exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to install packages: %w", err)
+		return exec.ErrRemote.Wrapf("failed to install packages: %w", err)
 	}
 
 	return nil

--- a/os/linux/enterpriselinux.go
+++ b/os/linux/enterpriselinux.go
@@ -1,7 +1,6 @@
 package linux
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/k0sproject/rig/exec"
@@ -16,7 +15,7 @@ type EnterpriseLinux struct {
 // InstallPackage installs packages via yum
 func (c EnterpriseLinux) InstallPackage(h os.Host, s ...string) error {
 	if err := h.Execf("yum install -y %s", strings.Join(s, " "), exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to install packages: %w", err)
+		return exec.ErrRemote.Wrapf("failed to install packages: %w", err)
 	}
 
 	return nil

--- a/os/linux/sles.go
+++ b/os/linux/sles.go
@@ -1,7 +1,6 @@
 package linux
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/k0sproject/rig"
@@ -18,10 +17,10 @@ type SLES struct {
 // InstallPackage installs packages via zypper
 func (c SLES) InstallPackage(h os.Host, s ...string) error {
 	if err := h.Exec("zypper refresh", exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to refresh zypper: %w", err)
+		return exec.ErrRemote.Wrapf("failed to refresh zypper: %w", err)
 	}
 	if err := h.Execf("zypper -n install -y %s", strings.Join(s, " "), exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to install packages: %w", err)
+		return exec.ErrRemote.Wrapf("failed to install packages: %w", err)
 	}
 	return nil
 }

--- a/os/linux/ubuntu.go
+++ b/os/linux/ubuntu.go
@@ -2,7 +2,6 @@
 package linux
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/k0sproject/rig"
@@ -30,10 +29,10 @@ func init() {
 // InstallPackage installs packages via apt-get
 func (c Ubuntu) InstallPackage(h os.Host, s ...string) error {
 	if err := h.Execf("apt-get update", exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to update apt cache: %w", err)
+		return exec.ErrRemote.Wrapf("failed to update apt cache: %w", err)
 	}
 	if err := h.Execf("DEBIAN_FRONTEND=noninteractive apt-get install -y -q %s", strings.Join(s, " "), exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to install packages: %w", err)
+		return exec.ErrRemote.Wrapf("failed to install packages: %w", err)
 	}
 	return nil
 }

--- a/os/mac/darwin.go
+++ b/os/mac/darwin.go
@@ -2,8 +2,6 @@
 package darwin
 
 import (
-	"errors"
-	"fmt"
 	"io/fs"
 	"strconv"
 	"strings"
@@ -15,9 +13,6 @@ import (
 	"github.com/k0sproject/rig/os"
 	"github.com/k0sproject/rig/os/registry"
 )
-
-// ErrNotAvailableOnDarwin is returned when a feature is not available on the host
-var ErrNotAvailableOnDarwin = errors.New("not available on darwin")
 
 // Darwin provides OS support for macOS Darwin
 type Darwin struct {
@@ -32,7 +27,7 @@ func (c Darwin) Kind() string {
 // StartService starts a service
 func (c Darwin) StartService(h os.Host, s string) error {
 	if err := h.Execf(`launchctl start %s`, s); err != nil {
-		return fmt.Errorf("failed to start service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to start service %s: %w", s, err)
 	}
 	return nil
 }
@@ -40,25 +35,25 @@ func (c Darwin) StartService(h os.Host, s string) error {
 // StopService stops a service
 func (c Darwin) StopService(h os.Host, s string) error {
 	if err := h.Execf(`launchctl stop %s`, s); err != nil {
-		return fmt.Errorf("failed to stop service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to stop service %s: %w", s, err)
 	}
 	return nil
 }
 
 // ServiceScriptPath returns the path to a service configuration file
 func (c Darwin) ServiceScriptPath(s string) (string, error) {
-	return "", ErrNotAvailableOnDarwin
+	return "", exec.ErrRemote.Wrapf("service scripts are not supported on darwin")
 }
 
 // RestartService restarts a service
 func (c Darwin) RestartService(h os.Host, s string) error {
 	if err := h.Execf(`launchctl kickstart -k %s`, s); err != nil {
-		return fmt.Errorf("failed to restart service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to restart service %s: %w", s, err)
 	}
 	return nil
 }
 
-// DaemonReload reloads init system configuration
+// DaemonReload reloads init system configuration -- does nothing on darwin
 func (c Darwin) DaemonReload(_ os.Host) error {
 	return nil
 }
@@ -66,7 +61,7 @@ func (c Darwin) DaemonReload(_ os.Host) error {
 // EnableService enables a service
 func (c Darwin) EnableService(h os.Host, s string) error {
 	if err := h.Execf(`launchctl enable %s`, s); err != nil {
-		return fmt.Errorf("failed to enable service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to enable service %s: %w", s, err)
 	}
 	return nil
 }
@@ -74,7 +69,7 @@ func (c Darwin) EnableService(h os.Host, s string) error {
 // DisableService disables a service
 func (c Darwin) DisableService(h os.Host, s string) error {
 	if err := h.Execf(`launchctl disable %s`, s); err != nil {
-		return fmt.Errorf("failed to disable service %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to disable service %s: %w", s, err)
 	}
 	return nil
 }
@@ -87,7 +82,7 @@ func (c Darwin) ServiceIsRunning(h os.Host, s string) bool {
 // InstallPackage installs a package using brew
 func (c Darwin) InstallPackage(h os.Host, s ...string) error {
 	if err := h.Execf("brew install %s", strings.Join(s, " ")); err != nil {
-		return fmt.Errorf("failed to install packages %s: %w", s, err)
+		return exec.ErrRemote.Wrapf("failed to install packages %s: %w", s, err)
 	}
 	return nil
 }
@@ -97,22 +92,22 @@ func (c Darwin) Stat(h os.Host, path string, opts ...exec.Option) (*os.FileInfo,
 	info := &os.FileInfo{FName: path}
 	out, err := h.ExecOutput(`stat -f "%z/%m/%p/%HT" `+shellescape.Quote(path), opts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat %s: %w", path, err)
+		return nil, exec.ErrRemote.Wrapf("failed to stat %s: %w", path, err)
 	}
 	fields := strings.SplitN(out, "/", 4)
 	size, err := strconv.ParseInt(fields[0], 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse size %s: %w", fields[0], err)
+		return nil, exec.ErrRemote.Wrapf("failed to parse size %s: %w", fields[0], err)
 	}
 	info.FSize = size
 	modtime, err := strconv.ParseInt(fields[1], 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse modtime %s: %w", fields[1], err)
+		return nil, exec.ErrRemote.Wrapf("failed to parse modtime %s: %w", fields[1], err)
 	}
 	info.FModTime = time.Unix(modtime, 0)
 	mode, err := strconv.ParseUint(fields[2], 8, 32)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse mode %s: %w", fields[2], err)
+		return nil, exec.ErrRemote.Wrapf("failed to parse mode %s: %w", fields[2], err)
 	}
 	info.FMode = fs.FileMode(mode)
 	info.FIsDir = strings.Contains(fields[3], "directory")
@@ -123,7 +118,7 @@ func (c Darwin) Stat(h os.Host, path string, opts ...exec.Option) (*os.FileInfo,
 // Touch creates a file if it doesn't exist, or updates the modification time if it does
 func (c Darwin) Touch(h os.Host, path string, ts time.Time, opts ...exec.Option) error {
 	if err := c.Linux.Touch(h, path, ts, opts...); err != nil {
-		return fmt.Errorf("failed to touch %s: %w", path, err)
+		return exec.ErrRemote.Wrapf("failed to touch %s: %w", path, err)
 	}
 	return nil
 }

--- a/os/registry/registry.go
+++ b/os/registry/registry.go
@@ -2,13 +2,12 @@
 package registry
 
 import (
-	"errors"
-
 	"github.com/k0sproject/rig"
+	"github.com/k0sproject/rig/errstring"
 )
 
 // ErrOSModuleNotFound is returned when no suitable OS support module is found
-var ErrOSModuleNotFound = errors.New("os support module not found")
+var ErrOSModuleNotFound = errstring.New("os support module not found")
 
 type (
 	buildFunc = func() interface{}

--- a/ssh_agent.go
+++ b/ssh_agent.go
@@ -3,26 +3,26 @@
 package rig
 
 import (
-	"fmt"
 	"net"
 	"os"
 
+	"github.com/k0sproject/rig/errstring"
 	"github.com/k0sproject/rig/log"
 	"golang.org/x/crypto/ssh/agent"
 )
 
-// ErrNoSSHAgent is returned when SSH_AUTH_SOCK is not set
-var ErrNoSSHAgent = fmt.Errorf("no ssh agent found")
+// ErrSSHAgent is returned when connection to SSH agent fails
+var ErrSSHAgent = errstring.New("connect ssh agent")
 
 func agentClient() (agent.Agent, error) {
 	sshAgentSock := os.Getenv("SSH_AUTH_SOCK")
 	if sshAgentSock == "" {
-		return nil, ErrNoSSHAgent
+		return nil, ErrSSHAgent.Wrapf("SSH_AUTH_SOCK is not set")
 	}
 	log.Debugf("using SSH_AUTH_SOCK=%s", sshAgentSock)
 	sshAgent, err := net.Dial("unix", sshAgentSock)
 	if err != nil {
-		return nil, fmt.Errorf("can't connect to SSH agent: %w", err)
+		return nil, ErrSSHAgent.Wrapf("can't connect to ssh agent: %w", err)
 	}
 	return agent.NewClient(sshAgent), nil
 }

--- a/ssh_agent_windows.go
+++ b/ssh_agent_windows.go
@@ -5,6 +5,7 @@ package rig
 import (
 	"github.com/Microsoft/go-winio"
 	"github.com/davidmz/go-pageant"
+	"github.com/k0sproject/rig/errstring"
 	"golang.org/x/crypto/ssh/agent"
 )
 
@@ -12,13 +13,16 @@ const (
 	openSshAgentPipe = `\\.\pipe\openssh-ssh-agent`
 )
 
+// ErrSSHAgent is returned when connection to SSH agent fails
+var ErrSSHAgent = errstring.New("connect win ssh agent")
+
 func agentClient() (agent.Agent, error) {
 	if pageant.Available() {
 		return pageant.New(), nil
 	}
 	sock, err := winio.DialPipe(openSshAgentPipe, nil)
 	if err != nil {
-		return nil, err
+		return nil, ErrSSHAgent.Wrapf("can't connect to ssh agent: %w", err)
 	}
 	return agent.NewClient(sock), nil
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -44,7 +44,7 @@ docker-network:
 footloose.yaml: .ssh/identity $(footloose)
 	$(footloose) config create \
 		--config footloose.yaml \
-	  --image quay.io/footloose/ubuntu18.04 \
+	  --image quay.io/footloose/centos7 \
 		--name rigtest \
 	  --key .ssh/identity \
 		--networks footloose-cluster \

--- a/test/test.sh
+++ b/test/test.sh
@@ -130,6 +130,8 @@ rig_test_protected_key_from_path() {
   ' $port1 $port2
   local exit_code=$?
   set -e
+  rm footloose.yaml
+  make delete-host REPLICAS=2
   return $exit_code
 }
 


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Better error design and usable error categories, such as `ErrCantConnect` which is a clear indicator that `Connect()` should not be retried. The oddly specific single-use errors are now wrapped under more meaningful top level errors.

