### PR TITLE
Pin test runner to ubuntu-20.04

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: install test dependencies
       run: |

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,17 +37,22 @@ $(footloose):
 	rm -f .ssh/identity
 	ssh-keygen -t $(KEY_TYPE) -b $(KEY_SIZE) -f .ssh/identity -N $(KEY_PASSPHRASE)
 
+.PHONY: docker-network
+docker-network:
+	docker network inspect footloose-cluster || docker network create footloose-cluster --subnet 172.16.86.0/24 --gateway 172.16.86.1 --attachable
+
 footloose.yaml: .ssh/identity $(footloose)
 	$(footloose) config create \
 		--config footloose.yaml \
 	  --image quay.io/footloose/ubuntu18.04 \
 		--name rigtest \
 	  --key .ssh/identity \
-		--replicas $(REPLICAS) \
-    --override
+		--networks footloose-cluster \
+    --override \
+		--replicas $(REPLICAS)
 
 .PHONY: create-host
-create-host: footloose.yaml
+create-host: footloose.yaml docker-network
 	$(footloose) create -c footloose.yaml
 
 .PHONY: delete-host
@@ -58,6 +63,7 @@ delete-host: footloose.yaml
 clean: delete-host
 	rm -f footloose.yaml identity rigtest
 	rm -rf .ssh
+	docker network rm footloose-cluster || true
 
 .PHONY: sshport
 sshport:


### PR DESCRIPTION
Footloose test suite fails with `kex_exchange_identification: read: Connection reset by peer` on ubuntu-22.04 (which ubuntu-latest now consistently gives) for an unknown reason.
