### PR TITLE
Warn only on mismatch if StrictHostkeyChecking disabled in ssh config

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,11 +7,6 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - name: install test dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install expect
-
     - uses: actions/checkout@v2
 
     - name: Set up Go
@@ -48,6 +43,13 @@ jobs:
     needs: build
     runs-on: ubuntu-20.04
     steps:
+    - name: install test dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install expect
+
+    - uses: actions/checkout@v2
+
       - name: Run integration tests
         env:
           LINUX_IMAGE: ${{ matrix.image }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,6 +36,20 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-    - name: Run integration tests
-      run: make -C test test
+  integration:
+    strategy:
+      matrix:
+        image:
+          - quay.io/footloose/ubuntu18.04
+          - quay.io/footloose/centos7
+          - quay.io/footloose/amazonlinux2
+          - quay.io/footloose/debian10
+          - quay.io/footloose/fedora29
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Run integration tests
+        env:
+          LINUX_IMAGE: ${{ matrix.image }}
+        run: make -C test test
 

--- a/cmd/rigtest/rigtest.go
+++ b/cmd/rigtest/rigtest.go
@@ -90,7 +90,7 @@ func retry(fn func() error) error {
 		}
 		time.Sleep(2 * time.Second)
 	}
-	return nil
+	return err
 }
 
 func main() {
@@ -204,6 +204,8 @@ func main() {
 			}
 			return err
 		})
+
+		require.NoError(t, err, "connection failed")
 
 		t.Run("load os %s", h.Address())
 		require.NoError(t, h.LoadOS(), "load os")

--- a/cmd/rigtest/rigtest.go
+++ b/cmd/rigtest/rigtest.go
@@ -101,6 +101,7 @@ func main() {
 	pc := flag.Bool("askpass", false, "ask ssh passwords")
 	pwd := flag.String("pass", "", "winrm password")
 	https := flag.Bool("https", false, "use https for winrm")
+	connectOnly := flag.Bool("connect", false, "just connect and quit")
 
 	fn := fmt.Sprintf("test_%s.txt", time.Now().Format("20060102150405"))
 
@@ -206,6 +207,10 @@ func main() {
 		})
 
 		require.NoError(t, err, "connection failed")
+
+		if *connectOnly {
+			continue
+		}
 
 		t.Run("load os %s", h.Address())
 		require.NoError(t, h.LoadOS(), "load os")

--- a/log/log.go
+++ b/log/log.go
@@ -8,6 +8,7 @@ type Logger interface {
 	Tracef(string, ...interface{})
 	Debugf(string, ...interface{})
 	Infof(string, ...interface{})
+	Warnf(string, ...interface{})
 	Errorf(string, ...interface{})
 }
 
@@ -34,6 +35,11 @@ func Errorf(t string, args ...interface{}) {
 	Log.Errorf(t, args...)
 }
 
+// Warnf logs a warn level log message
+func Warnf(t string, args ...interface{}) {
+	Log.Warnf(t, args...)
+}
+
 // StdLog is a simplistic logger for rig
 type StdLog struct {
 	Logger
@@ -52,6 +58,11 @@ func (l *StdLog) Debugf(t string, args ...interface{}) {
 // Infof prints an info level log message
 func (l *StdLog) Infof(t string, args ...interface{}) {
 	fmt.Println("INFO ", fmt.Sprintf(t, args...))
+}
+
+// Warnf prints a warn level log message
+func (l *StdLog) Warnf(t string, args ...interface{}) {
+	fmt.Println("WARN", fmt.Sprintf(t, args...))
 }
 
 // Errorf prints an error level log message

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,6 +3,7 @@ KEY_SIZE ?= 4096
 KEY_PASSPHRASE ?= ""
 KEY_PATH ?= ".ssh/identity"
 REPLICAS ?= 1
+LINUX_IMAGE ?= "quay.io/footloose/centos7"
 
 .PHONY: test
 test: rigtest
@@ -44,7 +45,7 @@ docker-network:
 footloose.yaml: .ssh/identity $(footloose)
 	$(footloose) config create \
 		--config footloose.yaml \
-	  --image quay.io/footloose/centos7 \
+	  --image $(LINUX_IMAGE) \
 		--name rigtest \
 	  --key .ssh/identity \
 		--networks footloose-cluster \

--- a/test/test.sh
+++ b/test/test.sh
@@ -102,18 +102,26 @@ rig_test_ssh_config_strict() {
   make create-host
   local addr="127.0.0.1:$(ssh_port node0)"
   echo "Host ${addr}" > .ssh/config
+  echo "  IdentityFile .ssh/identity" >> .ssh/config
   echo "  UserKnownHostsFile $(pwd)/.ssh/known" >> .ssh/config
+  cat .ssh/config
   set +e
   HOME=. SSH_CONFIG=.ssh/config ./rigtest -host "${addr}" -user root
-  if [ $? -ne 0 ]; then
+  local exit_code=$?
+  set -e
+  if [ $exit_code -ne 0 ]; then
+    echo "  * Failed first checkpoint"
     return 1
   fi
+  echo "  * Passed first checkpoint"
+  cat .ssh/known
   # modify the known hosts file to make it mismatch
   echo "${addr} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBgejI9UJnRY/i4HNM/os57oFcRjE77gEbVfUkuGr5NRh3N7XxUnnBKdzrAiQNPttUjKmUm92BN7nCUxbwsoSPw=" > .ssh/known
+  cat .ssh/known
   HOME=. SSH_CONFIG=.ssh/config ./rigtest -host "${addr}" -user root
-  local exit_code=$?
-  rm -f .ssh/known
+  exit_code=$?
   set -e
+  rm -f .ssh/known
 
   if [ $exit_code -eq 0 ]; then
     # success is a failure

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+RET=0
 set -e
 
 color_echo() {
@@ -26,7 +27,7 @@ sanity_check() {
   local exit_code=$?
   set -e
   make clean
-  return $exit_code
+  RET=$exit_code
 }
 
 
@@ -37,13 +38,13 @@ rig_test_agent_with_public_key() {
   ssh-add .ssh/identity
   rm -f .ssh/identity
   set +e
-  HOME=$(pwd) SSH_AUTH_SOCK=$SSH_AUTH_SOCK ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root -keypath .ssh/identity.pub
+  HOME=$(pwd) SSH_AUTH_SOCK=$SSH_AUTH_SOCK ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root -keypath .ssh/identity.pub -connect
   local exit_code=$?
   set -e
   kill $SSH_AGENT_PID
   export SSH_AGENT_PID=
   export SSH_AUTH_SOCK=
-  return $exit_code
+  RET=$exit_code
 }
 
 rig_test_agent_with_private_key() {
@@ -58,13 +59,13 @@ rig_test_agent_with_private_key() {
   '
   set +e
   # path points to a private key, rig should try to look for the .pub for it 
-  HOME=$(pwd) SSH_AUTH_SOCK=$SSH_AUTH_SOCK ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root -keypath .ssh/identity
+  HOME=$(pwd) SSH_AUTH_SOCK=$SSH_AUTH_SOCK ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root -keypath .ssh/identity -connect
   local exit_code=$?
   set -e
   kill $SSH_AGENT_PID
   export SSH_AGENT_PID=
   export SSH_AUTH_SOCK=
-  return $exit_code
+  RET=$exit_code
 }
 
 rig_test_agent() {
@@ -75,13 +76,13 @@ rig_test_agent() {
   rm -f .ssh/identity
   set +e
   ssh-add -l
-  HOME=. SSH_AUTH_SOCK=$SSH_AUTH_SOCK ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root -keypath ""
+  HOME=. SSH_AUTH_SOCK=$SSH_AUTH_SOCK ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root -keypath "" -connect
   local exit_code=$?
   set -e
   kill $SSH_AGENT_PID
   export SSH_AGENT_PID=
   export SSH_AUTH_SOCK=
-  return $exit_code
+  RET=$exit_code
 }
 
 rig_test_ssh_config() {
@@ -91,10 +92,10 @@ rig_test_ssh_config() {
   echo "Host 127.0.0.1:$(ssh_port node0)" > .ssh/config
   echo "  IdentityFile .ssh/identity2" >> .ssh/config
   set +e
-  HOME=. SSH_CONFIG=.ssh/config ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root
+  HOME=. SSH_CONFIG=.ssh/config ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root -connect
   local exit_code=$?
   set -e
-  return $exit_code
+  RET=$exit_code
 }
 
 rig_test_ssh_config_strict() {
@@ -106,29 +107,31 @@ rig_test_ssh_config_strict() {
   echo "  UserKnownHostsFile $(pwd)/.ssh/known" >> .ssh/config
   cat .ssh/config
   set +e
-  HOME=. SSH_CONFIG=.ssh/config ./rigtest -host "${addr}" -user root
+  HOME=. SSH_CONFIG=.ssh/config ./rigtest -host "${addr}" -user root -connect
   local exit_code=$?
   set -e
   if [ $exit_code -ne 0 ]; then
     echo "  * Failed first checkpoint"
-    return 1
+    RET=1
+    return
   fi
   echo "  * Passed first checkpoint"
   cat .ssh/known
   # modify the known hosts file to make it mismatch
   echo "${addr} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBgejI9UJnRY/i4HNM/os57oFcRjE77gEbVfUkuGr5NRh3N7XxUnnBKdzrAiQNPttUjKmUm92BN7nCUxbwsoSPw=" > .ssh/known
   cat .ssh/known
-  HOME=. SSH_CONFIG=.ssh/config ./rigtest -host "${addr}" -user root
+  set +e
+  HOME=. SSH_CONFIG=.ssh/config ./rigtest -host "${addr}" -user root -connect
   exit_code=$?
   set -e
-  rm -f .ssh/known
 
   if [ $exit_code -eq 0 ]; then
+    echo "  * Failed second checkpoint"
     # success is a failure
-    return 1
+    RET=1
+    return
   fi
-
-  return 0
+  echo "  * Passed second checkpoint"
 }
 
 rig_test_ssh_config_no_strict() {
@@ -139,29 +142,32 @@ rig_test_ssh_config_no_strict() {
   echo "  UserKnownHostsFile $(pwd)/.ssh/known" >> .ssh/config
   echo "  StrictHostKeyChecking no" >> .ssh/config
   set +e
-  HOME=. SSH_CONFIG=.ssh/config ./rigtest -host "${addr}" -user root
+  HOME=. SSH_CONFIG=.ssh/config ./rigtest -host "${addr}" -user root -connect
+  local exit_code=$?
+  set -e
   if [ $? -ne 0 ]; then
-    return 1
+    RET=1
+    return
   fi
   # modify the known hosts file to make it mismatch
   echo "${addr} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBgejI9UJnRY/i4HNM/os57oFcRjE77gEbVfUkuGr5NRh3N7XxUnnBKdzrAiQNPttUjKmUm92BN7nCUxbwsoSPw=" > .ssh/known
-  HOME=. SSH_CONFIG=.ssh/config ./rigtest -host "${addr}" -user root
-  local exit_code=$?
-  rm -f .ssh/known
+  set +e
+  HOME=. SSH_CONFIG=.ssh/config ./rigtest -host "${addr}" -user root -connect
+  exit_code=$?
   set -e
-  return $exit_code
+  RET=$exit_code
 }
 
 
 rig_test_key_from_path() {
-  color_echo "- Testing regular keypath"
+  color_echo "- Testing regular keypath and host functions"
   make create-host
   mv .ssh/identity .ssh/identity2
   set +e
-  ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root -keypath .ssh/identity2
+  ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root -keypath .ssh/identity2 
   local exit_code=$?
   set -e
-  return $exit_code
+  RET=$exit_code
 }
 
 rig_test_protected_key_from_path() {
@@ -179,7 +185,7 @@ rig_test_protected_key_from_path() {
     set PORTB [read -nonewline $fp]
     close $fp
 
-    spawn ./rigtest -host 127.0.0.1:$PORTA,127.0.0.1:$PORTB -user root -keypath .ssh/identity -askpass true
+    spawn ./rigtest -host 127.0.0.1:$PORTA,127.0.0.1:$PORTB -user root -keypath .ssh/identity -askpass true -connect
     expect "Password:"
     send "testPhrase\n"
     expect eof"
@@ -188,7 +194,7 @@ rig_test_protected_key_from_path() {
   set -e
   rm footloose.yaml
   make delete-host REPLICAS=2
-  return $exit_code
+  RET=$exit_code
 }
 
 if ! sanity_check; then
@@ -203,6 +209,11 @@ for test in $(declare -F|grep rig_test_|cut -d" " -f3); do
   make clean
   make rigtest
   color_echo "\n###########################################################"
+  RET=0
   $test
+  if [ $RET -ne 0 ]; then
+    color_echo "Test $test failed"
+    exit 1
+  fi
   echo -e "\n\n\n"
 done


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #83 

When `StrictHostkeyChecking=no` has been set in ssh config for the host / globally, a hostkey mismatch now only displays a warning when a hostkey mismatch is encountered.
