### PR TITLE
fix: localhost connection closes fds before all output is read

### DIFF
--- a/localhost.go
+++ b/localhost.go
@@ -77,7 +77,7 @@ func (c *Localhost) ExecStreams(cmd string, stdin io.ReadCloser, stdout, stderr 
 }
 
 // Exec executes a command on the host
-func (c *Localhost) Exec(cmd string, opts ...exec.Option) error { //nolint:funlen
+func (c *Localhost) Exec(cmd string, opts ...exec.Option) error { //nolint:cyclop,funlen
 	execOpts := exec.Build(opts...)
 	command, err := c.command(cmd, execOpts)
 	if err != nil {

--- a/localhost.go
+++ b/localhost.go
@@ -115,6 +115,9 @@ func (c *Localhost) Exec(cmd string, opts ...exec.Option) error {
 			for outputScanner.Scan() {
 				execOpts.AddOutput(name, outputScanner.Text()+"\n", "")
 			}
+			if err := outputScanner.Err(); err != nil {
+				execOpts.LogErrorf("%s: failed to scan stdout: %v", c, err)
+			}
 		} else {
 			if _, err := io.Copy(execOpts.Writer, stdout); err != nil {
 				execOpts.LogErrorf("%s: failed to stream stdout: %v", c, err)
@@ -130,10 +133,13 @@ func (c *Localhost) Exec(cmd string, opts ...exec.Option) error {
 		for outputScanner.Scan() {
 			execOpts.AddOutput(name, "", outputScanner.Text()+"\n")
 		}
+		if err := outputScanner.Err(); err != nil {
+			execOpts.LogErrorf("%s: failed to scan stderr: %v", c, err)
+		}
 	}()
 
-	err = command.Wait()
 	wg.Wait()
+	err = command.Wait()
 	if err != nil {
 		return fmt.Errorf("command wait: %w", err)
 	}

--- a/localhost.go
+++ b/localhost.go
@@ -77,7 +77,7 @@ func (c *Localhost) ExecStreams(cmd string, stdin io.ReadCloser, stdout, stderr 
 }
 
 // Exec executes a command on the host
-func (c *Localhost) Exec(cmd string, opts ...exec.Option) error {
+func (c *Localhost) Exec(cmd string, opts ...exec.Option) error { //nolint:funlen
 	execOpts := exec.Build(opts...)
 	command, err := c.command(cmd, execOpts)
 	if err != nil {


### PR DESCRIPTION
When using the localhost connection in [k0sctl](https://github.com/k0sproject/k0sctl) 0.15.0 with [k0s](https://github.com/k0sproject/k0s) v1.26.0+k0s.0  I am seeing an error where the stdout from the command `status -o json` is truncated. Upon further investigation it seems that the exec pipe writer is closed prior to all output being read, resulting in error `read |0: file already closed` from the scanner.

Reading the go documentation for [func (*Cmd)](https://pkg.go.dev/os/exec#Cmd.StdoutPipe) it states:

> Wait will close the pipe after seeing the command exit, so most callers need not close the pipe themselves. It is thus incorrect to call Wait before all reads from the pipe have completed. 

```

INFO[0000] ==> Running phase: Gather k0s facts
DEBU[0000] [local] localhost: executing `/usr/local/bin/k0s version`
DEBU[0000] [local] localhost: v1.25.5+k0s.0
DEBU[0000] [local] localhost: has k0s binary version 1.25.5+k0s.0
DEBU[0000] [local] localhost: executing `/usr/local/bin/k0s status -o json`
DEBU[0000] [local] localhost: {
DEBU[0000] [local] localhost: "Version": "v1.25.5+k0s.0",
ERRO[0000] [local] localhost: failed to scan stderr: read |0: file already closed
DEBU[0000] [local] localhost: "Pid": 371503,
DEBU[0000] [local] localhost: "PPid": 0,
DEBU[0000] [local] localhost: "Role": "controller",
DEBU[0000] [local] localhost: "SysInit": "",
DEBU[0000] [local] localhost: "StubFile": "",
DEBU[0000] [local] localhost: "Output": "",
[TRUNCATED FOR BREVITY]...
DEBU[0000] [local] localhost: },
DEBU[0000] [local] localhost: "konnectivity": {
DEBU[0000] [local] localhost: "agentPort": 8132,
DEBU[0000] [local] localhost: "adminPort": 8133
DEBU[0000] [local] localhost: }
DEBU[0000] [local] localhost: },
DEBU[0000] [local] localhost: "status": {}
DEBU[0000] [local] localhost: },
DEBU[0000] [local] localhost: "K0sVars"
ERRO[0000] [local] localhost: failed to scan stdout: read |0: file already closed
{
   "Version": "v1.25.5+k0s.0",
   "Pid": 371503,
   "PPid": 0,
   "Role": "controller",
   "SysInit": "",
   "StubFile": "",
   "Output": "",
[TRUNCATED FOR BREVITY]...
         "konnectivity": {
            "agentPort": 8132,
            "adminPort": 8133
         }
      },
      "status": {}
   },
   "K0sVars"
WARN[0000] [local] localhost: failed to decode k0s status output: unexpected end of JSON input
DEBU[0000] [local] localhost: executing `test -e /var/lib/k0s/pki/admin.conf 2> /dev/null`
DEBU[0000] [local] localhost: executing `env "KUBECONFIG=/var/lib/k0s/pki/admin.conf" /usr/local/bin/k0s kubectl get --data-dir=/var/lib/k0s -n kube-system namespace kube-system -o template={{.metadata.uid}}`
DEBU[0000] [local] localhost: 583f3b93-66f8-4e0b-b468-b08ef6b402ba
DEBU[0000] Preparing phase 'Validate facts'
INFO[0000] ==> Running phase: Validate facts
```

This ultimately results in k0sctl incorrectly running the initialization phase on an already initialized cluster.

```
INFO[0001] ==> Running phase: Initialize the k0s cluster
INFO[0001] [local] localhost: installing k0s controller
DEBU[0001] [local] localhost: executing `sudo -s -- /usr/local/bin/k0s install controller --disable-components konnectivity-server --data-dir=/var/lib/k0s --enable-worker --no-taints --config "/etc/k0s/k0s.yaml"`
DEBU[0001] [local] localhost: (stderr) Error: failed to install k0s service: failed to install service: Init already exists: /etc/systemd/system/k0scontroller.service
HERE sudo -s -- /usr/local/bin/k0s install controller --disable-components konnectivity-server --data-dir=/var/lib/k0s --enable-worker --no-taints --config "/etc/k0s/k0s.yaml" command failed: client exec: command wait: exit status 1
INFO[0001] * Running clean-up for phase: Initialize the k0s cluster
ERRO[0001] apply failed - log file saved to /home/ethan/.cache/k0sctl/k0sctl.log
FATA[0001] command failed: client exec: command wait: exit status 1
exit status 1
```