### PR TITLE
BusyBox/Alpine support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,6 +34,7 @@ jobs:
 
   integration:
     strategy:
+      fail-fast: false
       matrix:
         image:
           - quay.io/footloose/ubuntu18.04
@@ -41,6 +42,7 @@ jobs:
           # - quay.io/footloose/amazonlinux2  ( not recognized )
           - quay.io/footloose/debian10
           # - quay.io/footloose/fedora29 ( not recognized )
+          - alpine-3.18.iid
     needs: build
     runs-on: ubuntu-20.04
     steps:
@@ -57,8 +59,21 @@ jobs:
         sudo apt-get update
         sudo apt-get install expect
 
+    - name: Prepare footloose image
+      id: prepare-footloose-image
+      env:
+        IMAGE: ${{ matrix.image }}
+      run: |
+        case "$IMAGE" in
+        *.iid)
+          make -C test "$IMAGE"
+          IMAGE="$(cat "test/$IMAGE")"
+          ;;
+        esac
+        echo image="$IMAGE" >> $GITHUB_OUTPUT
+
     - name: Run integration tests
       env:
-        LINUX_IMAGE: ${{ matrix.image }}
+        LINUX_IMAGE: ${{ steps.prepare-footloose-image.outputs.image }}
       run: make -C test test
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ test/rigtest
 test/footloose.yaml
 test/Library
 test/.ssh
+test/*.iid

--- a/localhost.go
+++ b/localhost.go
@@ -156,7 +156,7 @@ func (c *Localhost) command(cmd string, o *exec.Options) (*osexec.Cmd, error) {
 		return osexec.Command("cmd.exe", "/c", cmd), nil
 	}
 
-	return osexec.Command("bash", "-c", "--", cmd), nil
+	return osexec.Command("sh", "-c", "--", cmd), nil
 }
 
 // ExecInteractive executes a command on the host and copies stdin/stdout/stderr from local host

--- a/os/linux/alpine.go
+++ b/os/linux/alpine.go
@@ -1,0 +1,52 @@
+package linux
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alessio/shellescape"
+	"github.com/k0sproject/rig"
+	"github.com/k0sproject/rig/exec"
+	"github.com/k0sproject/rig/os"
+	"github.com/k0sproject/rig/os/registry"
+)
+
+// Alpine provides OS support for Alpine Linux.
+type Alpine struct {
+	os.Linux
+}
+
+func init() {
+	registry.RegisterOSModule(
+		func(os rig.OSVersion) bool {
+			return os.ID == "alpine"
+		},
+		func() interface{} {
+			return &Alpine{}
+		},
+	)
+}
+
+// InstallPackage installs packages via apk.
+func (l Alpine) InstallPackage(host os.Host, pkgs ...string) error {
+	if err := host.Execf("apk update", exec.Sudo(host)); err != nil {
+		return fmt.Errorf("failed to update apk cache: %w", err)
+	}
+
+	if len(pkgs) < 1 {
+		return nil
+	}
+
+	var cmd strings.Builder
+	cmd.WriteString("apk add --")
+	for _, pkg := range pkgs {
+		cmd.WriteRune(' ')
+		cmd.WriteString(shellescape.Quote(pkg))
+	}
+
+	if err := host.Exec(cmd.String(), exec.Sudo(host)); err != nil {
+		return fmt.Errorf("failed to install apk packages: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/rigfs/posixfsys.go
+++ b/pkg/rigfs/posixfsys.go
@@ -19,7 +19,7 @@ import (
 // rigHelper is a helper script to avoid having to write complex bash oneliners in Go
 // it's not a read-loop "daemon" like the windows counterpart rigrcp.ps1
 //
-//go:embed righelper.bash
+//go:embed righelper.sh
 var rigHelper string
 
 var (
@@ -278,7 +278,7 @@ func (fsys *PosixFsys) helper(args ...string) (*helperResponse, error) {
 	var res helperResponse
 	opts := fsys.opts
 	opts = append(opts, exec.Stdin(rigHelper))
-	out, err := fsys.conn.ExecOutput(fmt.Sprintf("bash -s -- %s", shellescape.QuoteCommand(args)), opts...)
+	out, err := fsys.conn.ExecOutput(fmt.Sprintf("sh -s -- %s", shellescape.QuoteCommand(args)), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to execute helper: %w", ErrCommandFailed, err)
 	}

--- a/test/Dockerfile.alpine-3.18
+++ b/test/Dockerfile.alpine-3.18
@@ -1,0 +1,13 @@
+FROM docker.io/library/alpine:3.18.3
+
+RUN apk add --no-cache \
+  alpine-base \
+  openssh-server \
+  bash \
+  && rc-update add syslog boot \
+  && rc-update add sshd default \
+  && rc-update add local default \
+# disable ttys
+  && sed -i -e 's/^\(tty[0-9]\)/# \1/' /etc/inittab \
+# no greetings
+  && truncate -c -s0 /etc/issue /etc/motd

--- a/test/Makefile
+++ b/test/Makefile
@@ -52,6 +52,9 @@ footloose.yaml: .ssh/identity $(footloose)
     --override \
 		--replicas $(REPLICAS)
 
+%.iid: Dockerfile.%
+	docker build --iidfile '$@' - < '$<'
+
 .PHONY: create-host
 create-host: footloose.yaml docker-network
 	$(footloose) create -c footloose.yaml
@@ -63,7 +66,7 @@ delete-host: footloose.yaml
 .PHONY: clean
 clean: delete-host
 	rm -f footloose.yaml identity rigtest
-	rm -rf .ssh
+	rm -rf .ssh *.iid
 	docker network rm footloose-cluster || true
 
 .PHONY: sshport


### PR DESCRIPTION
The BusyBox stat and touch binaries differ from their GNU counterparts in some ways that are relevant to rig:

The stat binary won't accept the --printf flag, but it accepts the -c flag in the same way GNU stat does. The -c command won't accept backslash escapes, though. Hence fall back to the pipe character as delimiter.

The touch binary won't parse time zones and sub-second precision times. Accommodate for that by normalizing the time to UTC and only use sub- second precision timestamps if it's not BusyBox touch. This will loose precision, but that's probably better than failing completely.

Make localhost connections use the SHELL instead of hard-coding bash. Make the rigfs helper shell script POSIX compatible.

Add an OS support package for Alpine that uses apk for package installations.

Add a minimal footloose-compatible Dockerfile for Alpine 3.18 to the tests and execute it as part of the CI.