### PR TITLE
Add fsys directory operations

### DIFF
--- a/cmd/rigtest/rigtest.go
+++ b/cmd/rigtest/rigtest.go
@@ -290,9 +290,22 @@ func main() {
 			require.True(t, bytes.Equal(readSha.Sum(nil), shasum.Sum(nil)), "sha256 mismatch after io.copy from remote to local after seek")
 
 			require.NoError(t, destf.Close(), "close after seek + read")
-			require.NoError(t, fsys.Delete(fn), "remove file")
+			require.NoError(t, fsys.Remove(fn), "remove file")
 			_, err = destf.Stat()
 			require.ErrorIs(t, err, fs.ErrNotExist, "file still exists")
+
+			// fsys dirops
+			require.NoError(t, fsys.MkDirAll("tmpdir/nested", 0644), "make nested dir")
+			_, err = fsys.Stat("tmpdir")
+			require.NoError(t, err, "tmpdir was not created")
+			_, err = fsys.Stat("tmpdir/nested")
+			require.NoError(t, err, "tmpdir/nested was not created")
+
+			require.NoError(t, fsys.RemoveAll("tmpdir"), "remove recursive")
+			_, err = fsys.Stat("tmpdir/nested")
+			require.ErrorIs(t, err, fs.ErrNotExist, "nested dir still exists")
+			_, err = fsys.Stat("tmpdir")
+			require.ErrorIs(t, err, fs.ErrNotExist, "dir still exists")
 
 			require.NoError(t, h.Configurer.MkDir(h, "tmp/testdir/subdir"), "make dir")
 			require.NoError(t, h.Configurer.WriteFile(h, "tmp/testdir/subdir/testfile1", "test", "0644"), "write file")

--- a/pkg/rigfs/types.go
+++ b/pkg/rigfs/types.go
@@ -38,7 +38,9 @@ type Fsys interface {
 	OpenFile(string, FileMode, FileMode) (File, error)
 	Sha256(string) (string, error)
 	Stat(string) (fs.FileInfo, error)
-	Delete(string) error
+	Remove(string) error
+	RemoveAll(string) error
+	MkDirAll(string, FileMode) error
 }
 
 // FileMode is used to set the type of allowed operations when opening remote files

--- a/pkg/rigfs/winfsys.go
+++ b/pkg/rigfs/winfsys.go
@@ -427,10 +427,49 @@ func (fsys *WinFsys) ReadDir(name string) ([]fs.DirEntry, error) {
 	return entries, nil
 }
 
-// Delete removes the named file or (empty) directory.
-func (fsys *WinFsys) Delete(name string) error {
-	if err := fsys.conn.Exec(fmt.Sprintf("del %s", ps.DoubleQuote(filepath.FromSlash(name)))); err != nil {
-		return fmt.Errorf("%w: delete %s: %w", ErrCommandFailed, name, err)
+// Remove deletes the named file or (empty) directory.
+func (fsys *WinFsys) Remove(name string) error {
+	if existing, err := fsys.Stat(name); err == nil && existing.IsDir() {
+		return fsys.removeDir(name)
 	}
+
+	if err := fsys.conn.Exec(fmt.Sprintf("del %s", ps.DoubleQuote(filepath.FromSlash(name)))); err != nil {
+		return fmt.Errorf("%w: remove %s: %w", ErrCommandFailed, name, err)
+	}
+	return nil
+}
+
+// RemoveAll deletes the named file or directory and all its child items
+func (fsys *WinFsys) RemoveAll(name string) error {
+	if existing, err := fsys.Stat(name); err == nil && existing.IsDir() {
+		return fsys.removeDirAll(name)
+	}
+
+	if err := fsys.conn.Exec(fmt.Sprintf("del %s", ps.DoubleQuote(filepath.FromSlash(name)))); err != nil {
+		return fmt.Errorf("%w: remove all %s: %w", ErrCommandFailed, name, err)
+	}
+	return nil
+}
+
+func (fsys *WinFsys) removeDir(name string) error {
+	if err := fsys.conn.Exec(fmt.Sprintf("rmdir /q %s", ps.DoubleQuote(filepath.FromSlash(name)))); err != nil {
+		return fmt.Errorf("%w: rmdir %s: %w", ErrCommandFailed, name, err)
+	}
+	return nil
+}
+
+func (fsys *WinFsys) removeDirAll(name string) error {
+	if err := fsys.conn.Exec(fmt.Sprintf("rmdir /s /q %s", ps.DoubleQuote(filepath.FromSlash(name)))); err != nil {
+		return fmt.Errorf("%w: rmdir %s: %w", ErrCommandFailed, name, err)
+	}
+	return nil
+}
+
+// MkDirAll creates a directory named path, along with any necessary parents. The permission bits perm are ignored on Windows.
+func (fsys *WinFsys) MkDirAll(path string, _ FileMode) error {
+	if err := fsys.conn.Exec(fmt.Sprintf("mkdir -p %s", ps.DoubleQuote(filepath.FromSlash(path)))); err != nil {
+		return fmt.Errorf("%w: mkdir %s: %w", ErrCommandFailed, path, err)
+	}
+
 	return nil
 }

--- a/pkg/rigfs/winfsys.go
+++ b/pkg/rigfs/winfsys.go
@@ -360,8 +360,8 @@ func (fsys *WinFsys) Open(name string) (fs.File, error) {
 	return f, nil
 }
 
-// OpenFile opens the named remote file with the specified FileMode. perm is ignored on Windows.
-func (fsys *WinFsys) OpenFile(name string, mode FileMode, perm FileMode) (File, error) {
+// OpenFile opens the named remote file with the specified FileMode. Permission bits are ignored on Windows.
+func (fsys *WinFsys) OpenFile(name string, mode FileMode, _ FileMode) (File, error) {
 	var modeStr string
 	switch mode {
 	case ModeRead:
@@ -378,7 +378,7 @@ func (fsys *WinFsys) OpenFile(name string, mode FileMode, perm FileMode) (File, 
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fmt.Errorf("%w: invalid mode: %d", ErrRcpCommandFailed, mode)}
 	}
 
-	log.Debugf("opening remote file %s (mode %s)", name, modeStr, perm)
+	log.Debugf("opening remote file %s (mode %s)", name, modeStr)
 	_, err := fsys.rcp.command(fmt.Sprintf("o %s %s", modeStr, filepath.FromSlash(name)))
 	if err != nil {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}


### PR DESCRIPTION
Fixes #107 

- `Delete(path)` was renamed to `Remove` to match `os.Remove`
- `Remove(path)` will now also remove dirs
- Added `RemoveAll(path)` which recursively removes object at path (can be a non-empty dir or a file).
- Added `MkDirAll(path, perm)` which creates a nested dir structure. No plain `MkDir` for now as IMO it's rarely needed.
