### PR TITLE
Fix windows fsys path formatting

### DIFF
--- a/pkg/rigfs/winfsys.go
+++ b/pkg/rigfs/winfsys.go
@@ -432,7 +432,7 @@ func (fsys *WinFsys) Remove(name string) error {
 		return fsys.removeDir(name)
 	}
 
-	if err := fsys.conn.Exec(fmt.Sprintf("del %s", ps.DoubleQuote(fsys.formatPath(name)))); err != nil {
+	if err := fsys.conn.Exec(fmt.Sprintf("del %s", fsys.formatPath(name))); err != nil {
 		return fmt.Errorf("%w: remove %s: %w", ErrCommandFailed, name, err)
 	}
 	return nil
@@ -444,21 +444,21 @@ func (fsys *WinFsys) RemoveAll(name string) error {
 		return fsys.removeDirAll(name)
 	}
 
-	if err := fsys.conn.Exec(fmt.Sprintf("del %s", ps.DoubleQuote(fsys.formatPath(name)))); err != nil {
+	if err := fsys.conn.Exec(fmt.Sprintf("del %s", fsys.formatPath(name))); err != nil {
 		return fmt.Errorf("%w: remove all %s: %w", ErrCommandFailed, name, err)
 	}
 	return nil
 }
 
 func (fsys *WinFsys) removeDir(name string) error {
-	if err := fsys.conn.Exec(fmt.Sprintf("rmdir /q %s", ps.DoubleQuote(fsys.formatPath(name)))); err != nil {
+	if err := fsys.conn.Exec(fmt.Sprintf("rmdir /q %s", fsys.formatPath(name))); err != nil {
 		return fmt.Errorf("%w: rmdir %s: %w", ErrCommandFailed, name, err)
 	}
 	return nil
 }
 
 func (fsys *WinFsys) removeDirAll(name string) error {
-	if err := fsys.conn.Exec(fmt.Sprintf("rmdir /s /q %s", ps.DoubleQuote(fsys.formatPath(name)))); err != nil {
+	if err := fsys.conn.Exec(fmt.Sprintf("rmdir /s /q %s", fsys.formatPath(name))); err != nil {
 		return fmt.Errorf("%w: rmdir %s: %w", ErrCommandFailed, name, err)
 	}
 	return nil
@@ -466,7 +466,7 @@ func (fsys *WinFsys) removeDirAll(name string) error {
 
 // MkDirAll creates a directory named path, along with any necessary parents. The permission bits perm are ignored on Windows.
 func (fsys *WinFsys) MkDirAll(path string, _ FileMode) error {
-	if err := fsys.conn.Exec(fmt.Sprintf("mkdir -p %s", ps.DoubleQuote(fsys.formatPath(path)))); err != nil {
+	if err := fsys.conn.Exec(fmt.Sprintf("mkdir -p %s", fsys.formatPath(path))); err != nil {
 		return fmt.Errorf("%w: mkdir %s: %w", ErrCommandFailed, path, err)
 	}
 
@@ -476,7 +476,7 @@ func (fsys *WinFsys) MkDirAll(path string, _ FileMode) error {
 // formatPath takes a path, either in windows\format or unix/format and returns a windows\format path.
 func (fsys *WinFsys) formatPath(elem ...string) string {
 	if strings.Contains(elem[0], ":") {
-		return strings.Join(elem, "\\")
+		return ps.DoubleQuote(strings.Join(elem, "\\"))
 	}
 
 	var elems []string
@@ -487,5 +487,5 @@ func (fsys *WinFsys) formatPath(elem ...string) string {
 			elems = append(elems, strings.Split(e, "/")...)
 		}
 	}
-	return strings.Join(elems, "\\")
+	return ps.DoubleQuote(strings.Join(elems, "\\"))
 }

--- a/pkg/rigfs/winfsys.go
+++ b/pkg/rigfs/winfsys.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -379,7 +378,7 @@ func (fsys *WinFsys) OpenFile(name string, mode FileMode, _ FileMode) (File, err
 	}
 
 	log.Debugf("opening remote file %s (mode %s)", name, modeStr)
-	_, err := fsys.rcp.command(fmt.Sprintf("o %s %s", modeStr, filepath.FromSlash(name)))
+	_, err := fsys.rcp.command(fmt.Sprintf("o %s %s", modeStr, fsys.formatPath(name)))
 	if err != nil {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
 	}
@@ -388,7 +387,7 @@ func (fsys *WinFsys) OpenFile(name string, mode FileMode, _ FileMode) (File, err
 
 // Stat returns fs.FileInfo for the remote file.
 func (fsys *WinFsys) Stat(name string) (fs.FileInfo, error) {
-	resp, err := fsys.rcp.command(fmt.Sprintf("stat %s", filepath.FromSlash(name)))
+	resp, err := fsys.rcp.command(fmt.Sprintf("stat %s", fsys.formatPath(name)))
 	if err != nil {
 		return nil, &fs.PathError{Op: "stat", Path: name, Err: fmt.Errorf("%w: stat %s: %w", ErrRcpCommandFailed, name, err)}
 	}
@@ -400,7 +399,7 @@ func (fsys *WinFsys) Stat(name string) (fs.FileInfo, error) {
 
 // Sha256 returns the SHA256 hash of the remote file.
 func (fsys *WinFsys) Sha256(name string) (string, error) {
-	resp, err := fsys.rcp.command(fmt.Sprintf("sum %s", filepath.FromSlash(name)))
+	resp, err := fsys.rcp.command(fmt.Sprintf("sum %s", fsys.formatPath(name)))
 	if err != nil {
 		return "", &fs.PathError{Op: "sum", Path: name, Err: fmt.Errorf("%w: sha256sum: %w", ErrRcpCommandFailed, err)}
 	}
@@ -413,7 +412,7 @@ func (fsys *WinFsys) Sha256(name string) (string, error) {
 // ReadDir reads the directory named by dirname and returns a list of directory entries.
 func (fsys *WinFsys) ReadDir(name string) ([]fs.DirEntry, error) {
 	name = strings.ReplaceAll(name, "/", "\\")
-	resp, err := fsys.rcp.command(fmt.Sprintf("dir %s", filepath.FromSlash(name)))
+	resp, err := fsys.rcp.command(fmt.Sprintf("dir %s", fsys.formatPath(name)))
 	if err != nil {
 		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fmt.Errorf("%w: readdir: %w: %w", ErrRcpCommandFailed, err, fs.ErrNotExist)}
 	}
@@ -433,7 +432,7 @@ func (fsys *WinFsys) Remove(name string) error {
 		return fsys.removeDir(name)
 	}
 
-	if err := fsys.conn.Exec(fmt.Sprintf("del %s", ps.DoubleQuote(filepath.FromSlash(name)))); err != nil {
+	if err := fsys.conn.Exec(fmt.Sprintf("del %s", ps.DoubleQuote(fsys.formatPath(name)))); err != nil {
 		return fmt.Errorf("%w: remove %s: %w", ErrCommandFailed, name, err)
 	}
 	return nil
@@ -445,21 +444,21 @@ func (fsys *WinFsys) RemoveAll(name string) error {
 		return fsys.removeDirAll(name)
 	}
 
-	if err := fsys.conn.Exec(fmt.Sprintf("del %s", ps.DoubleQuote(filepath.FromSlash(name)))); err != nil {
+	if err := fsys.conn.Exec(fmt.Sprintf("del %s", ps.DoubleQuote(fsys.formatPath(name)))); err != nil {
 		return fmt.Errorf("%w: remove all %s: %w", ErrCommandFailed, name, err)
 	}
 	return nil
 }
 
 func (fsys *WinFsys) removeDir(name string) error {
-	if err := fsys.conn.Exec(fmt.Sprintf("rmdir /q %s", ps.DoubleQuote(filepath.FromSlash(name)))); err != nil {
+	if err := fsys.conn.Exec(fmt.Sprintf("rmdir /q %s", ps.DoubleQuote(fsys.formatPath(name)))); err != nil {
 		return fmt.Errorf("%w: rmdir %s: %w", ErrCommandFailed, name, err)
 	}
 	return nil
 }
 
 func (fsys *WinFsys) removeDirAll(name string) error {
-	if err := fsys.conn.Exec(fmt.Sprintf("rmdir /s /q %s", ps.DoubleQuote(filepath.FromSlash(name)))); err != nil {
+	if err := fsys.conn.Exec(fmt.Sprintf("rmdir /s /q %s", ps.DoubleQuote(fsys.formatPath(name)))); err != nil {
 		return fmt.Errorf("%w: rmdir %s: %w", ErrCommandFailed, name, err)
 	}
 	return nil
@@ -467,9 +466,26 @@ func (fsys *WinFsys) removeDirAll(name string) error {
 
 // MkDirAll creates a directory named path, along with any necessary parents. The permission bits perm are ignored on Windows.
 func (fsys *WinFsys) MkDirAll(path string, _ FileMode) error {
-	if err := fsys.conn.Exec(fmt.Sprintf("mkdir -p %s", ps.DoubleQuote(filepath.FromSlash(path)))); err != nil {
+	if err := fsys.conn.Exec(fmt.Sprintf("mkdir -p %s", ps.DoubleQuote(fsys.formatPath(path)))); err != nil {
 		return fmt.Errorf("%w: mkdir %s: %w", ErrCommandFailed, path, err)
 	}
 
 	return nil
+}
+
+// formatPath takes a path, either in windows\format or unix/format and returns a windows\format path.
+func (fsys *WinFsys) formatPath(elem ...string) string {
+	if strings.Contains(elem[0], ":") {
+		return strings.Join(elem, "\\")
+	}
+
+	var elems []string
+	for _, e := range elem {
+		if strings.Contains(e, "\\") {
+			elems = append(elems, strings.Split(e, "\\")...)
+		} else {
+			elems = append(elems, strings.Split(e, "/")...)
+		}
+	}
+	return strings.Join(elems, "\\")
 }

--- a/pkg/rigfs/winfsys_test.go
+++ b/pkg/rigfs/winfsys_test.go
@@ -1,0 +1,18 @@
+package rigfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatPath(t *testing.T) {
+	fsys := NewWindowsFsys(nil)
+	require.Equal(t, "C:\\Users\\Public\\Documents\\foo.txt", fsys.formatPath("C:\\Users\\Public", "Documents\\foo.txt"))
+	require.Equal(t, "C:\\Users\\Public\\Documents\\foo.txt", fsys.formatPath("C:\\Users\\Public\\Documents\\foo.txt"))
+	require.Equal(t, "Users\\Public\\Documents\\foo.txt", fsys.formatPath("Users\\Public\\Documents\\foo.txt"))
+	require.Equal(t, "Users\\Public\\Documents\\foo.txt", fsys.formatPath("Users\\Public", "Documents\\foo.txt"))
+
+	require.Equal(t, "\\Users\\Public\\Documents\\foo.txt", fsys.formatPath("/Users/Public/Documents/foo.txt"))
+	require.Equal(t, "Users\\Public\\Documents\\foo.txt", fsys.formatPath("Users/Public", "Documents/foo.txt"))
+}


### PR DESCRIPTION
Fixes #108 

Added a `formatPath` function that will format any incoming paths as `\` separated and doublequoted.

