### PR TITLE
Fix doas support

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -276,13 +276,13 @@ func sudoSudo(cmd string) string {
 }
 
 func sudoDoas(cmd string) string {
-	return "doas -s -- " + cmd
+	return `doas -n -- "${SHELL-sh}" -c ` + shellescape.Quote(cmd)
 }
 
 var sudoChecks = map[string]sudofn{
-	`[ "$(id -u)" = 0 ]`: sudoNoop,
-	"sudo -n true":       sudoSudo,
-	"doas -n true":       sudoDoas,
+	`[ "$(id -u)" = 0 ]`:               sudoNoop,
+	"sudo -n true":                     sudoSudo,
+	`doas -n -- "${SHELL-sh}" -c true`: sudoDoas,
 }
 
 const sudoCheckWindows = `whoami | findstr /i "administrator"`

--- a/test/Dockerfile.alpine-3.18
+++ b/test/Dockerfile.alpine-3.18
@@ -4,10 +4,14 @@ RUN apk add --no-cache \
   alpine-base \
   openssh-server \
   bash \
+  shadow \
+  doas \
   && rc-update add syslog boot \
   && rc-update add sshd default \
   && rc-update add local default \
 # disable ttys
   && sed -i -e 's/^\(tty[0-9]\)/# \1/' /etc/inittab \
+# prevent start-stop-daemon from hanging when max_fds is huge
+  && sed -Ei -e 's/^[# ](rc_ulimit)=.*/\1="-n 16384"/' /etc/rc.conf \
 # no greetings
   && truncate -c -s0 /etc/issue /etc/motd


### PR DESCRIPTION
The doas binary doesn't support passing commands if asked to run a shell. Fix this by manually invoking a shell instead.

Add a new test for regular users, so that the sudo/doas wrapper code is actually exercised in the test.