### PR TITLE
Fix ssh keypath defaulting

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -170,6 +170,17 @@ rig_test_key_from_path() {
   RET=$exit_code
 }
 
+rig_test_key_from_default_location() {
+  color_echo "- Testing keypath from default location"
+  make create-host
+  mv .ssh/identity .ssh/id_ecdsa
+  set +e
+  HOME=$(pwd) ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root
+  local exit_code=$?
+  set -e
+  RET=$exit_code
+}
+
 rig_test_protected_key_from_path() {
   color_echo "- Testing regular keypath to encrypted key, two hosts"
   make create-host KEY_PASSPHRASE=testPhrase REPLICAS=2


### PR DESCRIPTION
Related: https://github.com/k0sproject/k0sctl/issues/462

The `ssh_config` library has a TODO comment: https://github.com/kevinburke/ssh_config/blob/master/config.go#L254

```go
// TODO: IdentityFile has multiple default values that we should return
```

Using this makes rig only try `~/.ssh/identity` which can be considered a legacy path since it's for a SSH v1 key.

This PR detects when keypaths from ssh config IdentityFile query includes only `~/.ssh/identity` and if that is the case, uses the hardcoded defaultKeypaths instead.

This should be done more elegantly in V2 (#92).
