### PR TITLE
Add ssh.AuthMethods for passing in custom authentication

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -170,6 +170,17 @@ rig_test_key_from_path() {
   RET=$exit_code
 }
 
+rig_test_key_from_memory() {
+  color_echo "- Testing connecting using a key from string"
+  make create-host
+  mv .ssh/identity .ssh/identity2
+  set +e
+  ./rigtest -host 127.0.0.1:$(ssh_port node0) -user root -ssh-private-key "$(cat .ssh/identity2)" -connect
+  local exit_code=$?
+  set -e
+  RET=$exit_code
+}
+
 rig_test_key_from_default_location() {
   color_echo "- Testing keypath from default location"
   make create-host


### PR DESCRIPTION
Allows passing in custom `[]ssh.AuthMethod` in `rig.SSH{AuthMethods: ...}`.

A convenience wrapper has been added to make it easier to use for authenticating with a private key in a `[]byte` or string:

```go
authMethods, err := rig.ParseSSHPrivateKey([]byte("xxxxx"), rig.DefaultPassphraseCallback)
if err != nil {
  return err
}
c := &rig.Connection{
  SSH: &rig.SSH{
    Address: 127.0.0.1,
    AuthMethods: authMethods
  }
}
```