### PR TITLE
Fix mutex lock on openssh control master close

### DIFF
--- a/cmd/rigtest/rigtest.go
+++ b/cmd/rigtest/rigtest.go
@@ -214,8 +214,8 @@ func main() {
 			h = &Host{
 				Connection: rig.Connection{
 					OpenSSH: &rig.OpenSSH{
-						Address: address,
-						KeyPath: kp,
+						Address:             address,
+						KeyPath:             kp,
 						DisableMultiplexing: !*multiplex,
 					},
 				},
@@ -395,5 +395,7 @@ func main() {
 			require.Equal(t, "testfile1", foundFiles[2].Name(), "walk dir found testfile1")
 			require.Equal(t, "testfile2", foundFiles[3].Name(), "walk dir found testfile2")
 		}
+		t.Run("disconnect %s", h.Address())
+		h.Disconnect()
 	}
 }

--- a/openssh.go
+++ b/openssh.go
@@ -390,13 +390,6 @@ func (c *OpenSSH) Disconnect() {
 		return
 	}
 
-	c.controlMutex.Lock()
-	defer c.controlMutex.Unlock()
-
-	if !c.isConnected {
-		return
-	}
-
 	if err := c.closeControl(); err != nil {
 		log.Warnf("%s: failed to close control master: %v", c, err)
 	}


### PR DESCRIPTION
OpenSSH's `Disconnect()` was trying to acquire `controlMutex.Lock()` twice and therefore hung up forever.

