### PR TITLE
breaking: Fix fsys.OpenFile confusion of flags and permissions

### DIFF
--- a/cmd/rigtest/rigtest.go
+++ b/cmd/rigtest/rigtest.go
@@ -302,7 +302,7 @@ func main() {
 				shasum := sha256.New()
 				reader := io.TeeReader(origin, shasum)
 
-				destf, err := fsys.OpenFile(fn, rigfs.ModeCreate, 0644)
+				destf, err := fsys.OpenFile(fn, goos.O_CREATE|goos.O_WRONLY, 0644)
 				require.NoError(t, err, "open file")
 
 				n, err := io.Copy(destf, reader)
@@ -320,7 +320,7 @@ func main() {
 
 				require.Equal(t, fmt.Sprintf("%x", shasum.Sum(nil)), destSum, "sha256 mismatch after io.copy from local to remote")
 
-				destf, err = fsys.OpenFile(fn, rigfs.ModeRead, 0644)
+				destf, err = fsys.OpenFile(fn, goos.O_RDONLY, 0)
 				require.NoError(t, err, "open file for read")
 
 				readSha := sha256.New()

--- a/connection.go
+++ b/connection.go
@@ -372,7 +372,7 @@ func (c *Connection) Upload(src, dst string, _ ...exec.Option) error {
 	shasum := sha256.New()
 
 	fsys := c.Fsys()
-	remote, err := fsys.OpenFile(dst, rigfs.ModeCreate, rigfs.FileMode(stat.Mode()))
+	remote, err := fsys.OpenFile(dst, os.O_CREATE|os.O_WRONLY, stat.Mode())
 	if err != nil {
 		return fmt.Errorf("%w: open remote file %s for writing: %w", ErrInvalidPath, dst, err)
 	}

--- a/pkg/rigfs/fileinfo.go
+++ b/pkg/rigfs/fileinfo.go
@@ -36,29 +36,6 @@ func (f *FileInfo) UnmarshalJSON(b []byte) error {
 	}
 	f.FModTime = time.Unix(f.ModtimeS, 0)
 	f.FName = strings.ReplaceAll(f.FName, "\\", "/")
-
-	var newmode fs.FileMode
-
-	if f.FMode&1 != 0 { // "Readonly"
-		newmode = 0o444
-	}
-	if f.FMode&16 != 0 { // "Directory"
-		newmode |= fs.ModeDir | 0o544
-	}
-	if f.FMode&64 != 0 { // "Device"
-		newmode |= fs.ModeCharDevice
-	}
-	if f.FMode&4096 != 0 { // "Offline"
-		newmode |= fs.ModeIrregular
-	}
-	if f.FMode&1024 != 0 { // "ReparsePoint"
-		newmode |= fs.ModeIrregular
-		newmode |= fs.ModeSymlink
-	}
-	if f.FMode&256 != 0 { // "Temporary"
-		newmode |= fs.ModeTemporary
-	}
-	f.FMode = newmode
 	return nil
 }
 

--- a/pkg/rigfs/types.go
+++ b/pkg/rigfs/types.go
@@ -35,21 +35,10 @@ type File interface {
 // Fsys is a filesystem on the remote host
 type Fsys interface {
 	fs.FS
-	OpenFile(path string, mode FileMode, perm FileMode) (File, error)
+	OpenFile(path string, flag int, perm fs.FileMode) (File, error)
 	Sha256(path string) (string, error)
 	Stat(path string) (fs.FileInfo, error)
 	Remove(path string) error
 	RemoveAll(path string) error
-	MkDirAll(path string, perm FileMode) error
+	MkDirAll(path string, perm fs.FileMode) error
 }
-
-// FileMode is used to set the type of allowed operations when opening remote files
-type FileMode int
-
-const (
-	ModeRead      FileMode = 1                    // ModeRead = Read only
-	ModeWrite     FileMode = 2                    // ModeWrite = Write only
-	ModeReadWrite FileMode = ModeRead | ModeWrite // ModeReadWrite = Read and Write
-	ModeCreate    FileMode = 4 | ModeWrite        // ModeCreate = Create a new file or truncate an existing one. Includes write permission.
-	ModeAppend    FileMode = 8 | ModeCreate       // ModeAppend = Append to an existing file. Includes create and write permissions.
-)


### PR DESCRIPTION
OpenFile used to accept `FileMode` twice, as in:

```go
func (f *PosixFsys) OpenFile(path string, mode FileMode, perm FileMode)
  (*PosixFile, error)
```

The correct (or stdlib equivalent) signature is to accept an integer for the status flags and fs.FileMode for the permissions, as in:

```go
func (f *PosixFsys) OpenFile(path string, flags int, perm fs.FileMode)
  (*PosixFile, error)
```

The status flags are:

File access:
- O_RDONLY - open the file read-only. The value is `0x0`, you can pass a zero if you just want to read a  file (this is what `fsys.Open` does and it should be used instead for that purpose.).
- O_WRONLY - open the file write-only.
- O_RDWR - open the file read-write.
- O_SYNC is implied, all operations are synchronous.

File creation:
- O_APPEND - append data to the file when writing.
- O_CREATE - create a new file if none exists.
- O_TRUNC  - truncate the file if it exists
- O_EXCL   - used in conjunction with O_CREATE, file must not already exist.

*Usage:*

    // Explanation of the flags:
    // - Create a new file if one doesn't exist
    // - Truncate an existing file if one exist (keeps
    //   existing permissions)
    // - Open the file for writing
    fsys.OpenFile("/tmp/example", rigfs.O_CREATE|rigfs.O_TRUNC|rigfs.O_WRONLY,
        fs.FileMode(0644))

The `rigfs.FileMode` was retired, you're now expected to use fs.FileMode from `"io/fs"`.

There were some other omissions and logical errors in the previous implementation of the function.

