### PR TITLE
Add CopyFrom / CopyTo to fsys.Files

### DIFF
--- a/pkg/rigfs/bytecounter.go
+++ b/pkg/rigfs/bytecounter.go
@@ -1,0 +1,18 @@
+package rigfs
+
+// ByteCounter is a simple io.Writer that counts the number of bytes written to it, to be used in
+// conjunction with io.MultiWriter / io.TeeReader
+type ByteCounter struct {
+	count int64
+}
+
+// Write implements io.Writer
+func (bc *ByteCounter) Write(p []byte) (int, error) {
+	bc.count += int64(len(p))
+	return len(p), nil
+}
+
+// Count returns the number of bytes written to the ByteCounter
+func (bc *ByteCounter) Count() int64 {
+	return bc.count
+}

--- a/pkg/rigfs/types.go
+++ b/pkg/rigfs/types.go
@@ -18,12 +18,19 @@ type connection interface {
 	ExecStreams(cmd string, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer, opts ...exec.Option) (exec.Waiter, error)
 }
 
+// Copier is a file-like struct that can copy data to and from io.Reader and io.Writer
+type Copier interface {
+	CopyFrom(src io.Reader) (int64, error)
+	CopyTo(dst io.Writer) (int64, error)
+}
+
 // File is a file in the remote filesystem
 type File interface {
 	fs.File
 	io.Seeker
 	io.ReadCloser
 	io.Writer
+	Copier
 }
 
 // Fsys is a filesystem on the remote host

--- a/pkg/rigfs/windir.go
+++ b/pkg/rigfs/windir.go
@@ -3,6 +3,7 @@ package rigfs
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 
@@ -29,6 +30,14 @@ func (f *winDir) Seek(_ int64, _ int) (int64, error) {
 }
 
 func (f *winDir) Write(_ []byte) (int, error) {
+	return 0, f.pathErr("write", fmt.Errorf("%w: is a directory", fs.ErrInvalid))
+}
+
+func (f *winDir) CopyTo(_ io.Writer) (int64, error) {
+	return 0, f.pathErr("write", fmt.Errorf("%w: is a directory", fs.ErrInvalid))
+}
+
+func (f *winDir) CopyFrom(_ io.Reader) (int64, error) {
 	return 0, f.pathErr("write", fmt.Errorf("%w: is a directory", fs.ErrInvalid))
 }
 

--- a/pkg/rigfs/withname.go
+++ b/pkg/rigfs/withname.go
@@ -3,12 +3,14 @@ package rigfs
 import "io/fs"
 
 const (
-	OpClose = "close" // OpClose Close operation
-	OpOpen  = "open"  // OpOpen Open operation
-	OpRead  = "read"  // OpRead Read operation
-	OpSeek  = "seek"  // OpSeek Seek operation
-	OpStat  = "stat"  // OpStat Stat operation
-	OpWrite = "write" // OpWrite Write operation
+	OpClose    = "close"     // OpClose Close operation
+	OpOpen     = "open"      // OpOpen Open operation
+	OpRead     = "read"      // OpRead Read operation
+	OpSeek     = "seek"      // OpSeek Seek operation
+	OpStat     = "stat"      // OpStat Stat operation
+	OpWrite    = "write"     // OpWrite Write operation
+	OpCopyTo   = "copy-to"   // OpCopyTo CopyTo operation
+	OpCopyFrom = "copy-from" // OpCopyFrom CopyFrom operation
 )
 
 type withPath struct {


### PR DESCRIPTION
Full file reads / writes can be done faster than doing the same in bufSize chunks using the regular `Write()`/`Read()`.
