### PR TITLE
Use path.Dir() instead of filepath.Dir() for remote paths 

### DIFF
--- a/pkg/rigfs/posixfsys.go
+++ b/pkg/rigfs/posixfsys.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -79,7 +79,7 @@ func (f *PosixFile) fsBlockSize() int {
 		return f.blockSize
 	}
 
-	out, err := f.fsys.conn.ExecOutput(fmt.Sprintf(`stat -c "%%s" %[1]s 2> /dev/null || stat -f "%%k" %[1]s`, shellescape.Quote(filepath.Dir(f.path))), f.fsys.opts...)
+	out, err := f.fsys.conn.ExecOutput(fmt.Sprintf(`stat -c "%%s" %[1]s 2> /dev/null || stat -f "%%k" %[1]s`, shellescape.Quote(path.Dir(f.path))), f.fsys.opts...)
 	if err != nil {
 		// fall back to default
 		f.blockSize = defaultBlockSize
@@ -536,7 +536,7 @@ func (fsys *PosixFsys) openNew(name string, flags int, perm fs.FileMode) (fs.Fil
 		return nil, &fs.PathError{Op: OpOpen, Path: name, Err: fs.ErrNotExist}
 	}
 
-	if _, err := fsys.Stat(filepath.Dir(name)); err != nil {
+	if _, err := fsys.Stat(path.Dir(name)); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil, &fs.PathError{Op: OpOpen, Path: name, Err: fmt.Errorf("%w: parent directory does not exist", fs.ErrNotExist)}
 		}

--- a/pkg/ssh/hostkey/callbacks.go
+++ b/pkg/ssh/hostkey/callbacks.go
@@ -132,14 +132,14 @@ func ensureDir(path string) error {
 	return nil
 }
 
-func ensureFile(filePath string) error {
+func ensureFile(path string) error {
 	if fileExists(filePath) {
 		return nil
 	}
-	if err := ensureDir(filepath.Dir(filePath)); err != nil {
+	if err := ensureDir(filepath.Dir(path)); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_APPEND, 0o600)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create known_hosts file: %w", err)
 	}

--- a/pkg/ssh/hostkey/callbacks.go
+++ b/pkg/ssh/hostkey/callbacks.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"sync"
 
@@ -132,14 +132,14 @@ func ensureDir(path string) error {
 	return nil
 }
 
-func ensureFile(path string) error {
-	if fileExists(path) {
+func ensureFile(filePath string) error {
+	if fileExists(filePath) {
 		return nil
 	}
-	if err := ensureDir(filepath.Dir(path)); err != nil {
+	if err := ensureDir(path.Dir(filePath)); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND, 0o600)
+	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create known_hosts file: %w", err)
 	}

--- a/pkg/ssh/hostkey/callbacks.go
+++ b/pkg/ssh/hostkey/callbacks.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -136,7 +136,7 @@ func ensureFile(filePath string) error {
 	if fileExists(filePath) {
 		return nil
 	}
-	if err := ensureDir(path.Dir(filePath)); err != nil {
+	if err := ensureDir(filepath.Dir(filePath)); err != nil {
 		return err
 	}
 	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_APPEND, 0o600)

--- a/pkg/ssh/hostkey/callbacks.go
+++ b/pkg/ssh/hostkey/callbacks.go
@@ -133,7 +133,7 @@ func ensureDir(path string) error {
 }
 
 func ensureFile(path string) error {
-	if fileExists(filePath) {
+	if fileExists(path) {
 		return nil
 	}
 	if err := ensureDir(filepath.Dir(path)); err != nil {


### PR DESCRIPTION
`filepath.Dir` uses the local `os.PathSeparator` to rebuild the path which makes it invalid for linux hosts when calling from windows.
