### PR TITLE
Fix ssh with a keypath when ssh-agent is running without the key

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -12,6 +12,7 @@ import (
 	ps "github.com/k0sproject/rig/pkg/powershell"
 )
 
+// ResolveFunc A function which can resolve an OSVersion from a Connection
 type ResolveFunc func(*Connection) (OSVersion, error)
 
 var (
@@ -115,13 +116,16 @@ func unquote(s string) string {
 	return s
 }
 
+// ParseOSReleaseFile Parse the standart *nix release file contents, and add values to OSVersion
+//
+//nolint:cyclop
 func ParseOSReleaseFile(s string, version *OSVersion) error {
 	scanner := bufio.NewScanner(strings.NewReader(s))
 	for scanner.Scan() {
 		fields := strings.SplitN(scanner.Text(), "=", 2)
 		switch fields[0] {
 		case "":
-		        // Empty line in the file - unexpected but may happen
+			// Empty line in the file - unexpected but may happen
 		case "ID":
 			version.ID = unquote(fields[1])
 		case "ID_LIKE":

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -5,9 +5,6 @@ import (
 	"testing"
 )
 
-const (
-)
-
 func TestParseReleaseFile(t *testing.T) {
 	osReleaseRocky := `NAME="Rocky Linux"   
 VERSION="8.9 (Green Obsidian)"

--- a/ssh.go
+++ b/ssh.go
@@ -406,9 +406,6 @@ func (c *SSH) clientConfig() (*ssh.ClientConfig, error) { //nolint:cyclop
 	if len(c.AuthMethods) > 0 {
 		log.Tracef("%s: using %d passed-in auth methods", c, len(c.AuthMethods))
 		config.Auth = c.AuthMethods
-	} else if len(signers) > 0 {
-		log.Debugf("%s: using all keys (%d) from ssh agent because a keypath was not explicitly given", c, len(signers))
-		config.Auth = append(config.Auth, ssh.PublicKeys(signers...))
 	}
 
 	for _, keyPath := range c.keyPaths {
@@ -433,6 +430,11 @@ func (c *SSH) clientConfig() (*ssh.ClientConfig, error) { //nolint:cyclop
 			authMethodCache.Store(keyPath, privateKeyAuth)
 			config.Auth = append(config.Auth, privateKeyAuth)
 		}
+	}
+
+	if len(config.Auth) == 0 && len(signers) > 0 {
+		log.Debugf("%s: using all keys (%d) from ssh agent because a keypath was not explicitly given", c, len(signers))
+		config.Auth = append(config.Auth, ssh.PublicKeys(signers...))
 	}
 
 	if len(config.Auth) == 0 {


### PR DESCRIPTION
- https://github.com/k0sproject/rig/commit/0c0e31130db1f26f31ade67f8d6a49a063142894 introduces a change where ssh-agent keys are added before explicit path keys
	- this change broke fixed ssh-keys in scenarios where ssh-agent is running, with at least one key, but not the explicit key
- now ssh-agent keys are only added if no explicit keys are included

2nd commit has some linting fixes from https://github.com/k0sproject/rig/pull/169