### PR TITLE
Detect windows SSH from server header

### DIFF
--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -215,6 +215,10 @@ func (c *Connection) Disconnect() {
 	c.client.Close()
 }
 
+func boolptr(b bool) *bool {
+	return &b
+}
+
 // IsWindows is true when the host is running windows.
 func (c *Connection) IsWindows() bool {
 	if c.isWindows != nil {
@@ -225,21 +229,23 @@ func (c *Connection) IsWindows() bool {
 		return false
 	}
 
-	var isWin bool
-	if strings.Contains(string(c.client.ServerVersion()), "Windows") {
-		isWin = true
-		c.isWindows = &isWin
-		return true
+	serverVersion := strings.ToLower(string(c.client.ServerVersion()))
+	log.Trace(context.Background(), "checking if host is windows", "server_version", serverVersion)
+
+	switch {
+	case strings.Contains(serverVersion, "windows"):
+		c.isWindows = boolptr(true)
+	case isKnownPosix(serverVersion):
+		c.isWindows = boolptr(false)
+	default:
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		isWinProc, err := c.StartProcess(ctx, "ver.exe", nil, nil, nil)
+		c.isWindows = boolptr(err == nil && isWinProc.Wait() == nil)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	isWinProc, err := c.StartProcess(ctx, "cmd.exe /c exit 0", nil, nil, nil)
-	isWin = err == nil && isWinProc.Wait() == nil
-
-	c.isWindows = &isWin
-	log.Trace(context.Background(), fmt.Sprintf("host is windows: %t", *c.isWindows), log.KeyHost, c)
+	log.Trace(context.Background(), fmt.Sprintf("host is windows: %t", *c.isWindows))
 
 	return *c.isWindows
 }

--- a/protocol/ssh/knownposix.go
+++ b/protocol/ssh/knownposix.go
@@ -1,0 +1,45 @@
+package ssh
+
+import "strings"
+
+// A list of known ssh server version substrings that are used to aid in
+// identifying if a server is windows or not.
+
+var knownPosix = []string{
+	"linux",
+	"darwin",
+	"bsd",
+	"unix",
+	"alpine",
+	"ubuntu",
+	"debian",
+	"suse",
+	"oracle",
+	"rhel",
+	"rocky",
+	"sles",
+	"fedora",
+	"amzn",
+	"arch",
+	"centos",
+	"bodhi",
+	"elementary",
+	"gentoo",
+	"kali",
+	"mageia",
+	"manjaro",
+	"slackware",
+	"solaris",
+	"illumos",
+	"aix",
+	"dragonfly",
+}
+
+func isKnownPosix(s string) bool {
+	for _, v := range knownPosix {
+		if strings.Contains(s, v) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
A cherry-pick from #92 

Uses a list of known posix ssh server version response strings to rule out the host being windows before resorting to executing a command like `ver.exe`.
