### PR TITLE
Implement an SSH config parser

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,11 +70,6 @@ linters-settings:
     max-complexity: 12
 
 issues:
-  exclude-rules:
-    - path: protocol/ssh/sshconfig/options.go
-      linters:
-        - errname # lots of false positives for unknown reason
-        - revive # no need for comments on obvious vars.
   include:
     - EXC0002
     - EXC0012

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,7 @@ linters-settings:
     ignore-decls:
       - w http.ResponseWriter
       - r *http.Request
+      - r io.Reader
       - i int
       - n int
       - j int
@@ -69,6 +70,11 @@ linters-settings:
     max-complexity: 12
 
 issues:
+  exclude-rules:
+    - path: protocol/ssh/sshconfig/options.go
+      linters:
+        - errname # lots of false positives for unknown reason
+        - revive # no need for comments on obvious vars.
   include:
     - EXC0002
     - EXC0012

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,8 @@ linters:
     - forbidigo
     - gochecknoinits
     - gochecknoglobals
+    - gocognit # cyclop is used instead
+    - gocyclo # cyclop is used instead
     - godox
     - golint
     - interfacer
@@ -52,6 +54,8 @@ linters-settings:
       - r *http.Request
       - i int
       - n int
+      - j int
+      - ok bool
       - p []byte
       - mu sync.Mutex
       - wg sync.WaitGroup
@@ -73,3 +77,9 @@ issues:
     - EXC0015
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+    - linters: 
+      - errname # lots of false positives for an unknown reason
+      - revive # no need for comments on obvious vars like BooleanOptionYes
+      path: 'options/options\.go'
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Rig
 
-[![GoDoc](https://godoc.org/github.com/k0sproject/rig?status.svg)](https://godoc.org/github.com/k0sproject/rig)
+[![GoDoc](https://godoc.org/github.com/k0sproject/rig/v2/?status.svg)](https://godoc.org/github.com/k0sproject/rig/v2)
 [![Go Report Card](https://goreportcard.com/badge/github.com/k0sproject/rig)](https://goreportcard.com/report/github.com/k0sproject/rig)
 [![Build Status](https://travis-ci.com/k0sproject/rig.svg?branch=main)](https://travis-ci.com/k0sproject/rig)
 [![codecov](https://codecov.io/gh/k0sproject/rig/branch/main/graph/badge.svg)](https://codecov.io/gh/k0sproject/rig)

--- a/homedir/expand.go
+++ b/homedir/expand.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -13,12 +14,12 @@ import (
 var errNotImplemented = errors.New("not implemented")
 
 // Expand does ~/ style path expansion for files under current user home. ~user/ style paths are not supported.
-func Expand(path string) (string, error) {
-	if !strings.HasPrefix(path, "~") {
-		return path, nil
+func Expand(dir string) (string, error) {
+	if !strings.HasPrefix(dir, "~") {
+		return dir, nil
 	}
 
-	parts := strings.Split(path, string(os.PathSeparator))
+	parts := strings.Split(dir, string(os.PathSeparator))
 	if parts[0] != "~" {
 		return "", fmt.Errorf("%w: ~user/ style paths not supported", errNotImplemented)
 	}
@@ -27,8 +28,9 @@ func Expand(path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("homedir expand: %w", err)
 	}
+	home = strings.ReplaceAll(filepath.Clean(home), "\\", "/")
 
 	parts[0] = home
 
-	return filepath.Join(parts...), nil
+	return path.Join(parts...), nil
 }

--- a/homedir/expand_windows.go
+++ b/homedir/expand_windows.go
@@ -9,6 +9,9 @@ import (
 
 // Expand does ~/ style path expansion for files under current user home. On windows, this supports paths like %USERPROFILE%\path.
 func Expand(path string) (string, error) {
+	if strings.Contains(path, "/") {
+		path = filepath.FromSlash(path)
+	}
 	parts := strings.Split(path, string(os.PathSeparator))
 	if parts[0] != "~" && parts[0] != "%USERPROFILE%" && parts[0] != "%userprofile%" && parts[0] != "%HOME%" && parts[0] != "%home%" {
 		return path, nil

--- a/log/logger.go
+++ b/log/logger.go
@@ -58,6 +58,11 @@ func SetTraceLogger(l TraceLogger) {
 	trace = sync.OnceValue(func() TraceLogger { return l })
 }
 
+// GetTraceLogger gets the current value of trace logger.
+func GetTraceLogger() TraceLogger {
+	return trace()
+}
+
 // TraceLogger is a logger for rig's internal trace logging.
 type TraceLogger interface {
 	Log(ctx context.Context, level slog.Level, msg string, keysAndValues ...any)

--- a/sh/shellescape/README.md
+++ b/sh/shellescape/README.md
@@ -2,9 +2,11 @@
 
 A drop-in replacement for [alessio/shellescape](https://github.com/alessio/shellescape) / ["gopkg.in/alessio/shellescape.v1"]("gopkg.in/alessio/shellescape.v1").
 
-It's a bit faster and allocates a little bit less. It's quite unlikely that anyone will notice any difference in a real-world application, the is here just to reduce dependencies of the `rig` package.
+It's a tiny bit faster and allocates a tiny bit less. It's quite unlikely that anyone will notice any difference in a real-world application, the is here just to reduce dependencies of the `rig` package.
 
 To use, replace `alessio/shellescape` with `github.com/k0sproject/rig/v2/sh/shellescape` in your imports.
+
+In addition to the original package, this package also includes `Unquote`, `Split` and `Expand` (which supports `${var}`, `$var`, `$(cmd)` and `${var:-word}` and some other expansions).
 
 ## Benchmarks
 

--- a/sh/shellescape/expand.go
+++ b/sh/shellescape/expand.go
@@ -121,7 +121,7 @@ func (s *builderStack) Dump() {
 // Expand expands the input string according to the rules of a posix shell. It supports parameter expansion, command
 // substitution and simple $envvar expansion. It does not support arithmetic expansion, tilde expansion, or any of
 // the other expansions and it doesn't support backticks.
-func Expand(input string, opts ...ExpandOption) (string, error) { //nolint:gocognit,cyclop
+func Expand(input string, opts ...ExpandOption) (string, error) { //nolint:cyclop,funlen
 	options := newExpandOptions(opts...)
 	var inDollar, inCurly, inParen, inEscape bool
 	stack := builderStack{}

--- a/sh/shellescape/expand.go
+++ b/sh/shellescape/expand.go
@@ -1,0 +1,409 @@
+package shellescape
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+var (
+	errInvalidInput   = errors.New("invalid input")
+	errNotImplemented = errors.New("not implemented")
+)
+
+type expandOptions struct {
+	params bool
+	exec   bool
+	// TODO execbacktick
+}
+
+func newExpandOptions(options ...ExpandOption) *expandOptions {
+	opts := &expandOptions{}
+	for _, o := range options {
+		o(opts)
+	}
+	return opts
+}
+
+// ExpandOption is a functional option for Expand.
+type ExpandOption func(*expandOptions)
+
+// ExpandExec enables command substitution, as in $(command).
+func ExpandExec() ExpandOption {
+	return func(o *expandOptions) {
+		o.exec = true
+	}
+}
+
+// ExpandParam enables parameter expansion, as in ${parameter:...} and some other patterns. If this is not set,
+// only simple ${VAR} expansion is performed.
+func ExpandParam() ExpandOption {
+	return func(o *expandOptions) {
+		o.params = true
+	}
+}
+
+type builderStack []*strings.Builder
+
+func (s *builderStack) push() {
+	*s = append(*s, &strings.Builder{})
+}
+
+func (s *builderStack) pop() {
+	if len(*s) == 0 {
+		return
+	}
+	(*s)[len(*s)-1].Reset()
+	*s = append((*s)[:len(*s)-1], (*s)[len(*s):]...)
+}
+
+func (s *builderStack) top() *strings.Builder {
+	if len(*s) == 0 {
+		s.push()
+	}
+	return (*s)[len(*s)-1]
+}
+
+func (s *builderStack) String() string {
+	str := s.top().String()
+	s.pop()
+	return str
+}
+
+func (s *builderStack) WriteByte(b byte) error {
+	if err := s.top().WriteByte(b); err != nil {
+		return fmt.Errorf("builder stack: %w", err)
+	}
+	return nil
+}
+
+func (s *builderStack) WriteString(str string) (int, error) {
+	n, err := s.top().WriteString(str)
+	if err != nil {
+		return n, fmt.Errorf("builder stack: %w", err)
+	}
+	return n, nil
+}
+
+func (s *builderStack) Write(p []byte) (int, error) {
+	n, err := s.top().Write(p)
+	if err != nil {
+		return n, fmt.Errorf("builder stack: %w", err)
+	}
+	return n, nil
+}
+
+func (s *builderStack) WriteRune(r rune) (int, error) {
+	n, err := s.top().WriteRune(r)
+	if err != nil {
+		return n, fmt.Errorf("builder stack: %w", err)
+	}
+	return n, nil
+}
+
+func (s *builderStack) Len() int {
+	return s.top().Len()
+}
+
+func (s *builderStack) Size() int {
+	return len(*s)
+}
+
+func (s *builderStack) Dump() {
+	for i, b := range *s {
+		fmt.Printf("%s- stack[%d]: %q\n", strings.Repeat(" ", i), i, b.String())
+	}
+}
+
+// Expand expands the input string according to the rules of a posix shell. It supports parameter expansion, command
+// substitution and simple $envvar expansion. It does not support arithmetic expansion, tilde expansion, or any of
+// the other expansions and it doesn't support backticks.
+func Expand(input string, opts ...ExpandOption) (string, error) { //nolint:gocognit,cyclop
+	options := newExpandOptions(opts...)
+	var inDollar, inCurly, inParen, inEscape bool
+	stack := builderStack{}
+	openParen := 0
+
+	for i := 0; i < len(input); i++ {
+		currCh := input[i]
+
+		if inEscape {
+			_ = stack.WriteByte(currCh)
+			inEscape = false
+			continue
+		}
+
+		if currCh == '\\' {
+			inEscape = true
+			continue
+		}
+
+		if !inDollar && !inCurly && !inEscape && currCh == '$' {
+			inDollar = true
+			stack.push()
+			continue
+		}
+
+		if inDollar {
+			if currCh == '$' {
+				inDollar = false
+				_ = stack.WriteByte(currCh)
+				continue
+			}
+			if currCh == '{' {
+				inDollar = false
+				inCurly = true
+				continue
+			}
+			if currCh == '(' && options.exec {
+				inDollar = false
+				inParen = true
+				openParen++
+				continue
+			}
+
+			if isValidVarNameChar(currCh, stack.Len() == 0) {
+				_ = stack.WriteByte(currCh)
+				continue
+			}
+
+			// Finish processing variable
+			inDollar = false
+			_, _ = stack.WriteString(os.Getenv(stack.String()))
+			_ = stack.WriteByte(currCh)
+			continue
+		}
+
+		if inCurly { //nolint:nestif
+			if currCh == '}' {
+				inCurly = false
+				var result string
+				if options.params {
+					res, err := expandCurly(stack.String())
+					if err != nil {
+						return "", err
+					}
+					result = res
+				} else {
+					result = os.Getenv(stack.String())
+				}
+				_, _ = stack.WriteString(result)
+				continue
+			}
+			_ = stack.WriteByte(currCh)
+			continue
+		}
+
+		if inParen && currCh == ')' {
+			openParen--
+			if openParen == 0 {
+				inParen = false
+			}
+			res, err := evalCmd(stack.String())
+			if err != nil {
+				return "", err
+			}
+			_, _ = stack.WriteString(res)
+			continue
+		}
+
+		_ = stack.WriteByte(currCh)
+	}
+
+	for stack.Size() > 1 {
+		_, _ = stack.WriteString(stack.String())
+	}
+
+	if inCurly || inParen {
+		return "", fmt.Errorf("%w: expand: unclosed ${ or $( in %q", errInvalidInput, input)
+	}
+
+	return stack.String(), nil
+}
+
+func isValidVarNameChar(ch byte, isFirstChar bool) bool {
+	return ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z' || ch == '_' || (!isFirstChar && ch >= '0' && ch <= '9')
+}
+
+func evalCmd(input string) (string, error) {
+	if input == "" {
+		return "", nil
+	}
+	parts, err := Split(input)
+	if err != nil {
+		return "", fmt.Errorf("eval: split %q: %w", input, err)
+	}
+	cmd := exec.Command(parts[0], parts[1:]...) //nolint:gosec
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("eval %q: %w", input, err)
+	}
+	return strings.TrimSuffix(string(out), "\n"), nil
+}
+
+func expandOffsetLength(val, offsetStr, lengthStr string) (string, error) {
+	offset, err := strconv.Atoi(strings.TrimSpace(offsetStr))
+	if err != nil {
+		return "", fmt.Errorf("%w: bad substitution: offset: %w", errInvalidInput, err)
+	}
+	length, err := strconv.Atoi(strings.TrimSpace(lengthStr))
+	if err != nil {
+		return "", fmt.Errorf("%w: bad substitution: length: %w", errInvalidInput, err)
+	}
+	if val == "" {
+		return "", nil
+	}
+	if offset < 0 {
+		if offset*-1 > len(val) {
+			return "", nil
+		}
+		offset = len(val) + offset
+		if offset+length < 0 {
+			return "", nil
+		}
+	}
+	if offset < 0 {
+		length += offset
+		offset = 0
+	}
+	if offset > len(val) {
+		return "", nil
+	}
+	return val[offset : offset+length], nil
+}
+
+func expandOffset(val, offsetStr string) (string, error) {
+	offset, err := strconv.Atoi(strings.TrimSpace(offsetStr))
+	if err != nil {
+		return "", fmt.Errorf("%w: bad substitution: offset: %w", errInvalidInput, err)
+	}
+	if val == "" {
+		return "", nil
+	}
+	if offset < 0 {
+		if offset*-1 > len(val) {
+			return "", nil
+		}
+		offset = len(val) + offset
+		if offset < 0 {
+			return "", nil
+		}
+	}
+	return val[offset:], nil
+}
+
+func expandColon(val, pattern string) (string, error) {
+	if pattern == "" {
+		return "", fmt.Errorf("%w: bad substitution - empty pattern after ':'", errInvalidInput)
+	}
+
+	parts := strings.Split(pattern, ":")
+	if len(parts) == 2 {
+		// ${parameter:offset:length}
+		return expandOffsetLength(val, parts[0], parts[1])
+	}
+
+	if strings.HasPrefix(pattern, " -") {
+		// ${parameter: -offset}
+		return expandOffset(val, pattern[1:])
+	}
+
+	if pattern[0] >= '0' && pattern[0] <= '9' {
+		// ${parameter:offset}
+		return expandOffset(val, pattern)
+	}
+
+	switch pattern[0] {
+	case '-':
+		if val == "" {
+			return pattern[1:], nil
+		}
+		return val, nil
+	case '+':
+		if val == "" {
+			return "", nil
+		}
+		return pattern[1:], nil
+	}
+
+	return "", fmt.Errorf("%w: bad substitution (${%s}) - invalid pattern after ':'", errInvalidInput, pattern)
+}
+
+func expandVarNames(input string) (string, error) {
+	suffix := input[len(input)-1]
+	if suffix != '*' && suffix != '@' {
+		return "", nil
+	}
+	input = input[:len(input)-1]
+	var varnames []string
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, input) {
+			idx := strings.Index(env, "=")
+			if idx == -1 {
+				continue
+			}
+			varnames = append(varnames, env[:idx])
+		}
+	}
+	sep := ' '
+	if ifs := os.Getenv("IFS"); ifs != "" {
+		sep = rune(ifs[0])
+	}
+	return strings.Join(varnames, string(sep)), nil
+}
+
+func expandCurly(input string) (string, error) {
+	if input == "" {
+		return "", nil
+	}
+
+	if input[0] == '#' {
+		// ${#parameter} - The length in characters of its value.
+		if len(input) == 1 {
+			return "", fmt.Errorf("%w: bad substitution (${%s}) - lone '#'", errInvalidInput, input)
+		}
+		return strconv.Itoa(len(os.Getenv(input[1:]))), nil
+	}
+
+	if input[0] == '!' {
+		// ${!prefix*} or ${!prefix@} -- list of var names matching prefix
+		return expandVarNames(input[1:])
+	}
+
+	idx := -1
+	for i := 0; i < len(input); i++ {
+		idx = i
+		if !isValidVarNameChar(input[i], i == 0) {
+			break
+		}
+	}
+
+	if idx == 0 {
+		return "", fmt.Errorf("%w: bad substitution (${%s}) - operator at beginning", errInvalidInput, input)
+	}
+
+	if idx == len(input)-1 {
+		// no separator, just a simple variable
+		return os.Getenv(input), nil
+	}
+
+	// operator + value must be at least 2 chars after the variable name
+	if len(input) < idx+2 {
+		return "", fmt.Errorf("%w: bad substitution (${%s}) - no operator after variable name", errInvalidInput, input)
+	}
+
+	name := input[:idx]
+	val := os.Getenv(name)
+	patternCh := input[idx:][0]
+	pattern := input[idx:][1:]
+
+	switch patternCh {
+	case ':':
+		return expandColon(val, pattern)
+	default:
+		return "", fmt.Errorf("%w: support for pattern ${%s} not implemented", errNotImplemented, input)
+	}
+}

--- a/sh/shellescape/expand_test.go
+++ b/sh/shellescape/expand_test.go
@@ -1,0 +1,138 @@
+package shellescape_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/sh/shellescape"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpand(t *testing.T) {
+	originalValue := os.Getenv("TEST_VAR")
+	defer os.Setenv("TEST_VAR", originalValue)
+	os.Setenv("TEST_VAR", "test value")
+
+	t.Run("dollar", func(t *testing.T) {
+		result, err := shellescape.Expand("show me the $TEST_VAR.")
+		require.NoError(t, err)
+		require.Equal(t, "show me the test value.", result)
+	})
+	t.Run("curly", func(t *testing.T) {
+		result, err := shellescape.Expand("show me the ${TEST_VAR}.")
+		require.NoError(t, err)
+		require.Equal(t, "show me the test value.", result)
+	})
+	t.Run("command", func(t *testing.T) {
+		result, err := shellescape.Expand("show me the $(echo test $(echo value)).")
+		require.NoError(t, err)
+		require.Equal(t, "show me the test value.", result)
+	})
+	t.Run("command with curly", func(t *testing.T) {
+		result, err := shellescape.Expand("show me the $(echo $(echo ${TEST_VAR})).")
+		require.NoError(t, err)
+		require.Equal(t, "show me the test value.", result)
+	})
+}
+
+func TestExpandParamExpansion(t *testing.T) {
+	originalValue := os.Getenv("TEST_VAR")
+	defer os.Setenv("TEST_VAR", originalValue)
+	os.Setenv("TEST_VAR", "test value")
+
+	originalValue2 := os.Getenv("TEST_VAR2")
+	defer os.Setenv("TEST_VAR2", originalValue2)
+	os.Unsetenv("TEST_VAR2")
+
+	t.Run("simple", func(t *testing.T) {
+		result, err := shellescape.Expand("show me the ${TEST_VAR}.")
+		require.NoError(t, err)
+		require.Equal(t, "show me the test value.", result)
+	})
+
+	t.Run("colon", func(t *testing.T) {
+		t.Run("default", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${TEST_VAR:-default}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the test value.", result)
+		})
+		t.Run("default with empty", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${TEST_VAR:-}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the test value.", result)
+		})
+		t.Run("default with empty and space", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${TEST_VAR:- }.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the test value.", result)
+		})
+		t.Run("default with unset", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${TEST_VAR2:-default}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the default.", result)
+		})
+		t.Run("anti-default with unset", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${TEST_VAR2:+default}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the .", result)
+			result, err = shellescape.Expand("show me the ${TEST_VAR:+default}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the default.", result)
+		})
+		t.Run("offset", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${TEST_VAR:2}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the st value.", result)
+		})
+		t.Run("offset with empty", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${TEST_VAR2:2}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the .", result)
+		})
+		t.Run("offset with negative", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${TEST_VAR: -2}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the ue.", result)
+		})
+		t.Run("offset with negative and length", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${TEST_VAR: -3:2}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the lu.", result)
+		})
+		t.Run("offset with length", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${TEST_VAR:2:2}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the st.", result)
+		})
+	})
+
+	t.Run("length", func(t *testing.T) {
+		t.Run("length", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${#TEST_VAR}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the 10.", result)
+		})
+		t.Run("length with empty", func(t *testing.T) {
+			result, err := shellescape.Expand("show me the ${#TEST_VAR2}.")
+			require.NoError(t, err)
+			require.Equal(t, "show me the 0.", result)
+		})
+	})
+
+	t.Run("variable names", func(t *testing.T) {
+		if orig, ok := os.LookupEnv("TEST_VAR2"); ok {
+			defer os.Setenv("TEST_VAR2", orig)
+		} else {
+			defer os.Unsetenv("TEST_VAR2")
+		}
+		os.Setenv("TEST_VAR2", "test value2")
+		result, err := shellescape.Expand("show me the ${!TEST_VA*}")
+		require.NoError(t, err)
+		result = strings.TrimPrefix(result, "show me the ")
+		result = strings.TrimSuffix(result, ".")
+		items := strings.Split(result, " ")
+		require.Contains(t, items, "TEST_VAR")
+		require.Contains(t, items, "TEST_VAR2")
+	})
+}

--- a/sh/shellescape/expand_test.go
+++ b/sh/shellescape/expand_test.go
@@ -25,12 +25,12 @@ func TestExpand(t *testing.T) {
 		require.Equal(t, "show me the test value.", result)
 	})
 	t.Run("command", func(t *testing.T) {
-		result, err := shellescape.Expand("show me the $(echo test $(echo value)).")
+		result, err := shellescape.Expand("show me the $(echo test $(echo value)).", shellescape.ExpandExec())
 		require.NoError(t, err)
 		require.Equal(t, "show me the test value.", result)
 	})
 	t.Run("command with curly", func(t *testing.T) {
-		result, err := shellescape.Expand("show me the $(echo $(echo ${TEST_VAR})).")
+		result, err := shellescape.Expand("show me the $(echo $(echo ${TEST_VAR})).", shellescape.ExpandExec())
 		require.NoError(t, err)
 		require.Equal(t, "show me the test value.", result)
 	})
@@ -46,62 +46,62 @@ func TestExpandParamExpansion(t *testing.T) {
 	os.Unsetenv("TEST_VAR2")
 
 	t.Run("simple", func(t *testing.T) {
-		result, err := shellescape.Expand("show me the ${TEST_VAR}.")
+		result, err := shellescape.Expand("show me the ${TEST_VAR}.", shellescape.ExpandParam())
 		require.NoError(t, err)
 		require.Equal(t, "show me the test value.", result)
 	})
 
 	t.Run("colon", func(t *testing.T) {
 		t.Run("default", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${TEST_VAR:-default}.")
+			result, err := shellescape.Expand("show me the ${TEST_VAR:-default}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the test value.", result)
 		})
 		t.Run("default with empty", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${TEST_VAR:-}.")
+			result, err := shellescape.Expand("show me the ${TEST_VAR:-}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the test value.", result)
 		})
 		t.Run("default with empty and space", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${TEST_VAR:- }.")
+			result, err := shellescape.Expand("show me the ${TEST_VAR:- }.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the test value.", result)
 		})
 		t.Run("default with unset", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${TEST_VAR2:-default}.")
+			result, err := shellescape.Expand("show me the ${TEST_VAR2:-default}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the default.", result)
 		})
 		t.Run("anti-default with unset", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${TEST_VAR2:+default}.")
+			result, err := shellescape.Expand("show me the ${TEST_VAR2:+default}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the .", result)
-			result, err = shellescape.Expand("show me the ${TEST_VAR:+default}.")
+			result, err = shellescape.Expand("show me the ${TEST_VAR:+default}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the default.", result)
 		})
 		t.Run("offset", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${TEST_VAR:2}.")
+			result, err := shellescape.Expand("show me the ${TEST_VAR:2}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the st value.", result)
 		})
 		t.Run("offset with empty", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${TEST_VAR2:2}.")
+			result, err := shellescape.Expand("show me the ${TEST_VAR2:2}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the .", result)
 		})
 		t.Run("offset with negative", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${TEST_VAR: -2}.")
+			result, err := shellescape.Expand("show me the ${TEST_VAR: -2}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the ue.", result)
 		})
 		t.Run("offset with negative and length", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${TEST_VAR: -3:2}.")
+			result, err := shellescape.Expand("show me the ${TEST_VAR: -3:2}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the lu.", result)
 		})
 		t.Run("offset with length", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${TEST_VAR:2:2}.")
+			result, err := shellescape.Expand("show me the ${TEST_VAR:2:2}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the st.", result)
 		})
@@ -109,12 +109,12 @@ func TestExpandParamExpansion(t *testing.T) {
 
 	t.Run("length", func(t *testing.T) {
 		t.Run("length", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${#TEST_VAR}.")
+			result, err := shellescape.Expand("show me the ${#TEST_VAR}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the 10.", result)
 		})
 		t.Run("length with empty", func(t *testing.T) {
-			result, err := shellescape.Expand("show me the ${#TEST_VAR2}.")
+			result, err := shellescape.Expand("show me the ${#TEST_VAR2}.", shellescape.ExpandParam())
 			require.NoError(t, err)
 			require.Equal(t, "show me the 0.", result)
 		})
@@ -127,7 +127,7 @@ func TestExpandParamExpansion(t *testing.T) {
 			defer os.Unsetenv("TEST_VAR2")
 		}
 		os.Setenv("TEST_VAR2", "test value2")
-		result, err := shellescape.Expand("show me the ${!TEST_VA*}")
+		result, err := shellescape.Expand("show me the ${!TEST_VA*}", shellescape.ExpandParam())
 		require.NoError(t, err)
 		result = strings.TrimPrefix(result, "show me the ")
 		result = strings.TrimSuffix(result, ".")

--- a/sshconfig/README.md
+++ b/sshconfig/README.md
@@ -1,0 +1,142 @@
+## sshconfig
+
+[![GoDoc](https://godoc.org/github.com/k0sproject/rig/v2/sshconfig/?status.svg)](https://godoc.org/github.com/k0sproject/rig/v2/sshconfig)
+
+This directory contains an implementation of a parser for OpenSSH's [`ssh_config`](https://man7.org/linux/man-pages/man5/ssh_config.5.html) file format. 
+
+The format and its parsing rules are slightly complicated. 
+
+Further reading:
+
+- [The ssh_config(5) man page](https://man.openbsd.org/ssh_config)
+- [readconf.c](https://github.com/openssh/openssh-portable/blob/master/readconf.c) from the openssh source code.
+- [Quirks of parsing SSH configs](https://sthbrx.github.io/blog/2023/08/04/quirks-of-parsing-ssh-configs/)
+
+### This implementation
+
+Implemented features:
+
+- All of the fields listed in the [ssh_config(5)](https://man.openbsd.org/ssh_config) man page (and two additional Apple specific fields).
+- Partial [`Match`](https://man.openbsd.org/ssh_config#Match) directive support. `Address`, `LocalAddress`, `LocalPort` and `RDomain` are not implemented (because they require an established connection, which could be achievable later if needed).
+- Partial [`TOKENS`](https://man.openbsd.org/ssh_config#TOKENS) expansion support. Like above, expanding some of the tokens would require an established connection to the host while parsing the config.
+- `Include` directive support, the parser will follow the `Include` directives as expected, in lexical order like the OpenSSH implementation. It will also detect circular includes.
+- Expansion of `~` and environment variables in the values for the supported fields listed on the man page.
+- Support for list modifier prefixes for fields like `HostKeyAlgorithms` or `KexAlgorithms` where you can use a `+` prefix to append to the default list, a `-` prefix to remove from the default list, or `^` to prepend to the default list.
+- Support and validation for "multistate fields" as they are called in OpenSSH's `readconf.c` which can act like booleans but can also contain other string values, such as `yes`, `no`, `ask`, `always`, `none`, etc. 
+- A "strict" mode for supporting the [`IgnoreUnknown`](https://man.openbsd.org/ssh_config#IgnoreUnknown) directive. When enabled, the parser will throw an error when it encounters an unknown directive. To enable, use the `sshconfig.WithStrict()` option when creating the parser.
+- The origin based value precedence is correctly implemented as described in the specification and as observed in the OpenSSH implementation.
+- [Hostname canonicalization](https://sleeplessbeastie.eu/2020/08/24/how-to-perform-hostname-canonicalization/).
+- Original-like unquoting and splitting of values based on `argv_split` from the original C source converted to go.
+
+### Status
+
+The parser has not been tested outside of the development environment **at all** yet.
+
+If there's interest, the parser can be extracted from the `rig` repository and published as a separate module.
+
+### Usage
+
+Typically you first create a parser via `sshconfig.NewParser(nil)` and then call `Apply` on it with a struct that you want to populate with the values for a given host from the system's ssh configuration files.
+
+You can use the provided `sshconfig.Config` which includes all the known configuration fields or you can define a struct with a subset of the fields. The object must have the same field names as the `ssh_config` man page describes them and at least a "Host (string)" field must exist.
+
+```go
+package main
+
+import(
+    "fmt"
+    "github.com/k0sproject/rig/v2/sshconfig"
+)
+
+func main() {
+    // this will read the configurations from the default locations.
+	parser, err := sshconfig.NewParser(nil) 
+    // To read from a specific file or a string, pass in an io.Reader like:
+    // parser, err := sshconfig.NewParser(strings.NewReader("Host example.com\nIdentityFile ~/.ssh/id_rsa\n"))
+
+    if err != nil {
+        panic(err)
+    }
+    host := &sshconfig.Config{}
+    if err := parser.Apply(host, "example.com"); err != nil {
+        panic(err)
+    }
+    fmt.Println(host.IdentityFile[0])
+}
+```
+
+There's also a `sshconfig.ConfigFor` shorthand for when you're not expecting to need the configuration for more than one host:
+
+```go
+package main
+
+import(
+    "fmt"
+    "github.com/k0sproject/rig/v2/sshconfig"
+)
+
+func main() {
+	config, err := sshconfig.ConfigFor("example.com") 
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(config.IdentityFile[0])
+}
+```
+
+You can output a `ssh_config` formatted string using `sshconfig.Dump`:
+
+```go
+package main
+
+import(
+    "fmt"
+    "github.com/k0sproject/rig/v2/sshconfig"
+)
+
+func main() {
+	config, err := sshconfig.ConfigFor("example.com") 
+    if err != nil {
+        panic(err)
+    }
+    str, err := sshconfig.Dump(config)
+    fmt.Println(str)
+}
+```
+
+This will output something like:
+
+```text
+Host example.com
+    AddKeysToAgent no
+    AddressFamily any
+    BatchMode no
+    ...
+```
+
+### Alternatives
+
+Currently there seems to exist two alternatives:
+
+- [`kevinburke/ssh_config`](https://github.com/kevinburke/ssh_config)
+
+  This is a rather complete implementation but there are some issues with it:
+
+	- Does not support [`Match`](https://man.openbsd.org/ssh_config#Match) directives at all.
+	- Does not support [Hostname canonicalization](https://man.openbsd.org/ssh_config#CanonicalizeHostname).
+	- Not all of the Boolean fields listed [here](https://github.com/kevinburke/ssh_config/blob/1d09c0b50564c4a7f8c56c9d5d6d935e06ee94da/validators.go#L19) are actually strictly boolean. For example, `ForwardAgent` can be a path to agent socket or an environment variable name.
+	- Not all of the default values are correct or set. In fact, [the list of defaults](https://github.com/kevinburke/ssh_config/blame/1d09c0b50564c4a7f8c56c9d5d6d935e06ee94da/validators.go#L18) is from 2017. The default for `IdentityFile` is `~/.ssh/identity` which started to phase out upon the release of OpenSSH 3.0 in 2001 which started defaulting to `~/.ssh/id_dsa`.
+	- It does not support the list modifier prefixes for fields like `HostKeyAlgorithms` or `KexAlgorithms` where you can use `+` prefix to append to the existing list or `-` prefix to remove from the existing list.
+	- When you need to know multiple settings for a given host, you need to query for each setting separately. There doesn't seem to be a function that returns a list of settings that apply to a given host alias.
+	- Values need to be unquoted and expanded manually and values for comma separated list fields need to be split manually.
+	- No expansion of `~/` or environment variables in the values (there's a [pull request](https://github.com/kevinburke/ssh_config/pull/31) from 2021).
+	- No expansion of the [TOKENS](https://man.openbsd.org/ssh_config#TOKENS) (there's a [pull request](https://github.com/kevinburke/ssh_config/pull/49) from 2022).
+    - Doesn't seem to be actively maintained, there are open unanswered issues and unmerged pull requests from several years ago.
+
+- [`mikkeloscar/sshconfig`](https://github.com/mikkeloscar/sshconfig)
+
+	This is a newer arrival. It supports a very limited subset of fields (`Host, HostName, User, Port, IdentityFile, HostKeyAlgorithms, ProxyCommand, LocalForward, RemoteForward, DynamicForward, Ciphers and MACs`). It implements even less features and quirks of the syntax.
+
+### Contributing
+
+Issues and PRs are welcome. Especially ones that eliminate any of the `//nolint` comments.

--- a/sshconfig/README.md
+++ b/sshconfig/README.md
@@ -36,32 +36,32 @@ If there's interest, the parser can be extracted from the `rig` repository and p
 
 ### Usage
 
-Typically you first create a parser via `sshconfig.NewParser(nil)` and then call `Apply` on it with a struct that you want to populate with the values for a given host from the system's ssh configuration files.
+Typically you first create a parser via `sshconfig.NewParser(nil)` and then call `Apply(obj)` on it with a struct that you want to populate with the values for a given host from the system's ssh configuration files. You can also pass in an `io.Reader` to `NewParser` to read from a custom source instead of the default locations.
 
-You can use the provided `sshconfig.Config` which includes all the known configuration fields or you can define a struct with a subset of the fields. The object must have the same field names as the `ssh_config` man page describes them and at least a "Host (string)" field must exist.
+You can use the provided `sshconfig.Config` which includes all the known configuration fields or you can define a struct with only a subset of the fields. The object must have the same field names as listed in the `ssh_config` man page and at least a `Host string` field must exist for the parsing to work.
 
 ```go
 package main
 
 import(
-    "fmt"
-    "github.com/k0sproject/rig/v2/sshconfig"
+  "fmt"
+  "github.com/k0sproject/rig/v2/sshconfig"
 )
 
 func main() {
-    // this will read the configurations from the default locations.
-	parser, err := sshconfig.NewParser(nil) 
-    // To read from a specific file or a string, pass in an io.Reader like:
-    // parser, err := sshconfig.NewParser(strings.NewReader("Host example.com\nIdentityFile ~/.ssh/id_rsa\n"))
+  // this will read the configurations from the default locations.
+  parser, err := sshconfig.NewParser(nil) 
+  // To read from a specific file or a string, pass in an io.Reader like:
+  // parser, err := sshconfig.NewParser(strings.NewReader("Host example.com\nIdentityFile ~/.ssh/id_rsa\n"))
 
-    if err != nil {
-        panic(err)
-    }
-    host := &sshconfig.Config{}
-    if err := parser.Apply(host, "example.com"); err != nil {
-        panic(err)
-    }
-    fmt.Println(host.IdentityFile[0])
+  if err != nil {
+    panic(err)
+  }
+  host := &sshconfig.Config{}
+  if err := parser.Apply(host, "example.com"); err != nil {
+    panic(err)
+  }
+  fmt.Println(host.IdentityFile[0])
 }
 ```
 
@@ -71,16 +71,16 @@ There's also a `sshconfig.ConfigFor` shorthand for when you're not expecting to 
 package main
 
 import(
-    "fmt"
-    "github.com/k0sproject/rig/v2/sshconfig"
+  "fmt"
+  "github.com/k0sproject/rig/v2/sshconfig"
 )
 
 func main() {
-	config, err := sshconfig.ConfigFor("example.com") 
-    if err != nil {
-        panic(err)
-    }
-    fmt.Println(config.IdentityFile[0])
+  config, err := sshconfig.ConfigFor("example.com") 
+  if err != nil {
+    panic(err)
+  }
+  fmt.Println(config.IdentityFile[0])
 }
 ```
 
@@ -90,17 +90,17 @@ You can output a `ssh_config` formatted string using `sshconfig.Dump`:
 package main
 
 import(
-    "fmt"
-    "github.com/k0sproject/rig/v2/sshconfig"
+  "fmt"
+  "github.com/k0sproject/rig/v2/sshconfig"
 )
 
 func main() {
-	config, err := sshconfig.ConfigFor("example.com") 
-    if err != nil {
-        panic(err)
-    }
-    str, err := sshconfig.Dump(config)
-    fmt.Println(str)
+  config, err := sshconfig.ConfigFor("example.com") 
+  if err != nil {
+    panic(err)
+  }
+  str, err := sshconfig.Dump(config)
+  fmt.Println(str)
 }
 ```
 
@@ -108,10 +108,10 @@ This will output something like:
 
 ```text
 Host example.com
-    AddKeysToAgent no
-    AddressFamily any
-    BatchMode no
-    ...
+  AddKeysToAgent no
+  AddressFamily any
+  BatchMode no
+  ...
 ```
 
 ### Alternatives
@@ -120,22 +120,22 @@ Currently there seems to exist two alternatives:
 
 - [`kevinburke/ssh_config`](https://github.com/kevinburke/ssh_config)
 
-  This is a rather complete implementation but there are some issues with it:
+  This is a somewhat complete implementation but there are several issues with it:
 
-	- Does not support [`Match`](https://man.openbsd.org/ssh_config#Match) directives at all.
-	- Does not support [Hostname canonicalization](https://man.openbsd.org/ssh_config#CanonicalizeHostname).
-	- Not all of the Boolean fields listed [here](https://github.com/kevinburke/ssh_config/blob/1d09c0b50564c4a7f8c56c9d5d6d935e06ee94da/validators.go#L19) are actually strictly boolean. For example, `ForwardAgent` can be a path to agent socket or an environment variable name.
-	- Not all of the default values are correct or set. In fact, [the list of defaults](https://github.com/kevinburke/ssh_config/blame/1d09c0b50564c4a7f8c56c9d5d6d935e06ee94da/validators.go#L18) is from 2017. The default for `IdentityFile` is `~/.ssh/identity` which started to phase out upon the release of OpenSSH 3.0 in 2001 which started defaulting to `~/.ssh/id_dsa`.
-	- It does not support the list modifier prefixes for fields like `HostKeyAlgorithms` or `KexAlgorithms` where you can use `+` prefix to append to the existing list or `-` prefix to remove from the existing list.
-	- When you need to know multiple settings for a given host, you need to query for each setting separately. There doesn't seem to be a function that returns a list of settings that apply to a given host alias.
-	- Values need to be unquoted and expanded manually and values for comma separated list fields need to be split manually.
-	- No expansion of `~/` or environment variables in the values (there's a [pull request](https://github.com/kevinburke/ssh_config/pull/31) from 2021).
-	- No expansion of the [TOKENS](https://man.openbsd.org/ssh_config#TOKENS) (there's a [pull request](https://github.com/kevinburke/ssh_config/pull/49) from 2022).
-    - Doesn't seem to be actively maintained, there are open unanswered issues and unmerged pull requests from several years ago.
+  - Does not support [`Match`](https://man.openbsd.org/ssh_config#Match) directives at all.
+  - Does not support [Hostname canonicalization](https://man.openbsd.org/ssh_config#CanonicalizeHostname), which requires an additional pass of parsing if the hostname gets changed.
+  - Not all of the Boolean fields listed [here](https://github.com/kevinburke/ssh_config/blob/1d09c0b50564c4a7f8c56c9d5d6d935e06ee94da/validators.go#L19) are actually regular booleans. For example, `ForwardAgent` can be a path to an agent socket or an environment variable name.
+  - Not all of the default values are correct or set. In fact, [the list of defaults](https://github.com/kevinburke/ssh_config/blame/1d09c0b50564c4a7f8c56c9d5d6d935e06ee94da/validators.go#L18) is from 2017. The default for `IdentityFile` is [`~/.ssh/identity`](https://github.com/kevinburke/ssh_config/blob/1d09c0b50564c4a7f8c56c9d5d6d935e06ee94da/validators.go#L120) which started to phase out upon the release of OpenSSH 3.0 in 2001 which started defaulting to `~/.ssh/id_dsa`. The list of [`defaultProtocol2Identities`](https://github.com/kevinburke/ssh_config/blob/1d09c0b50564c4a7f8c56c9d5d6d935e06ee94da/validators.go#L165-L170) is not used and is missing a couple of entries.
+  - It does not support the list modifier prefixes for fields like `HostKeyAlgorithms` or `KexAlgorithms` where you can use the `+` or `^` prefixes to append or prepend to the default list or the `-` prefix to remove from it.
+  - When you need to know multiple settings for a given host, you have to query for each setting separately.
+  - Values need to be unquoted and expanded and converted to correct types manually and values for white-space or comma separated list fields need to be split manually.
+  - No expansion of `~/` or environment variables in the values (there's a [pull request](https://github.com/kevinburke/ssh_config/pull/31) from 2021).
+  - No expansion of the [TOKENS](https://man.openbsd.org/ssh_config#TOKENS) (there's a [pull request](https://github.com/kevinburke/ssh_config/pull/49) from 2022).
+  - Doesn't seem to be actively maintained, there are open unanswered issues and unmerged pull requests from several years ago. See [PR comment](https://github.com/kevinburke/ssh_config/pull/37#issuecomment-1095599334).
 
 - [`mikkeloscar/sshconfig`](https://github.com/mikkeloscar/sshconfig)
 
-	This is a newer arrival. It supports a very limited subset of fields (`Host, HostName, User, Port, IdentityFile, HostKeyAlgorithms, ProxyCommand, LocalForward, RemoteForward, DynamicForward, Ciphers and MACs`). It implements even less features and quirks of the syntax.
+  A simplistic implementation that only supports a very limited subset of fields (`Host, HostName, User, Port, IdentityFile, HostKeyAlgorithms, ProxyCommand, LocalForward, RemoteForward, DynamicForward, Ciphers and MACs`). It implements even less features and quirks of the syntax. The GPL-3 license may be problematic for some.
 
 ### Contributing
 

--- a/sshconfig/config.go
+++ b/sshconfig/config.go
@@ -1,0 +1,1581 @@
+package sshconfig
+
+import (
+	"time"
+
+	"github.com/k0sproject/rig/v2/sshconfig/options"
+)
+
+/*
+Copied from the ssh_config man page for reference:
+
+   Unless noted otherwise, for each parameter, the first obtained
+   value will be used.  The configuration files contain sections
+   separated by Host specifications, and that section is only
+   applied for hosts that match one of the patterns given in the
+   specification.  The matched host name is usually the one given on
+   the command line (see the CanonicalizeHostname option for
+   exceptions).
+
+   Since the first obtained value for each parameter is used, more
+   host-specific declarations should be given near the beginning of
+   the file, and general defaults at the end.
+
+   The file contains keyword-argument pairs, one per line.  Lines
+   starting with `#' and empty lines are interpreted as comments.
+   Arguments may optionally be enclosed in double quotes (") in
+   order to represent arguments containing spaces.  Configuration
+   options may be separated by whitespace or optional whitespace and
+   exactly one `='; the latter format is useful to avoid the need to
+   quote whitespace when specifying configuration options using the
+   ssh, scp, and sftp -o option.
+
+   The possible keywords and their meanings are as follows (note
+   that keywords are case-insensitive and arguments are case-
+   sensitive):
+
+   Host
+   Restricts the following declarations (up to the next Host
+   or Match keyword) to be only for those hosts that match
+   one of the patterns given after the keyword.  If more
+   than one pattern is provided, they should be separated by
+   whitespace.  A single `*' as a pattern can be used to
+   provide global defaults for all hosts.  The host is
+   usually the hostname argument given on the command line
+   (see the CanonicalizeHostname keyword for exceptions).
+
+   A pattern entry may be negated by prefixing it with an
+   exclamation mark (`!').  If a negated entry is matched,
+   then the Host entry is ignored, regardless of whether any
+   other patterns on the line match.  Negated matches are
+   therefore useful to provide exceptions for wildcard
+   matches.
+
+   See "PATTERNS" for more information on patterns.
+
+   Match
+   Restricts the following declarations (up to the next Host
+   or Match keyword) to be used only when the conditions
+   following the Match keyword are satisfied.  Match
+   conditions are specified using one or more criteria or
+   the single token all which always matches.  The available
+   criteria keywords are: canonical, final, exec,
+   localnetwork, host, originalhost, Tag, user, and
+   localuser.  The all criteria must appear alone or
+   immediately after canonical or final.  Other criteria may
+   be combined arbitrarily.  All criteria but all,
+   canonical, and final require an argument.  Criteria may
+   be negated by prepending an exclamation mark (`!').
+
+   The canonical keyword matches only when the configuration
+   file is being re-parsed after hostname canonicalization
+   (see the CanonicalizeHostname option).  This may be
+   useful to specify conditions that work with canonical
+   host names only.
+
+   The final keyword requests that the configuration be re-
+   parsed (regardless of whether CanonicalizeHostname is
+   enabled), and matches only during this final pass.  If
+   CanonicalizeHostname is enabled, then canonical and final
+   match during the same pass.
+
+   The exec keyword executes the specified command under the
+   user's shell.  If the command returns a zero exit status
+   then the condition is considered true.  Commands
+   containing whitespace characters must be quoted.
+   Arguments to exec accept the tokens described in the
+   "TOKENS" section.
+
+   The localnetwork keyword matches the addresses of active
+   local network interfaces against the supplied list of
+   networks in CIDR format.  This may be convenient for
+   varying the effective configuration on devices that roam
+   between networks.  Note that network address is not a
+   trustworthy criteria in many situations (e.g. when the
+   network is automatically configured using DHCP) and so
+   caution should be applied if using it to control
+   security-sensitive configuration.
+
+   The other keywords' criteria must be single entries or
+   comma-separated lists and may use the wildcard and
+   negation operators described in the "PATTERNS" section.
+   The criteria for the host keyword are matched against the
+   target hostname, after any substitution by the Hostname
+   or CanonicalizeHostname options.  The originalhost
+   keyword matches against the hostname as it was specified
+   on the command-line.  The tagged keyword matches a tag
+   name specified by a prior Tag directive or on the ssh(1)
+   command-line using the -P flag.  The user keyword matches
+   against the target username on the remote host.  The
+   localuser keyword matches against the name of the local
+   user running ssh(1) (this keyword may be useful in
+   system-wide files).
+
+   Include
+   Includes the specified configuration file(s).  Multiple
+   pathnames may be specified and each pathname may contain
+   glob(7) wildcards and, for user configurations, shell-
+   like `~' references to user home directories.  Wildcards
+   will be expanded and processed in lexical order.  Files
+   without absolute paths are assumed to be in ~/.ssh if
+   included in a user configuration file or /etc/ssh if
+   included from the system configuration file.  Include
+   directive may appear inside a Match or Host block to
+   perform conditional inclusion.
+
+PATTERNS
+
+   A pattern consists of zero or more non-whitespace characters, `*'
+   (a wildcard that matches zero or more characters), or `?' (a
+   wildcard that matches exactly one character).  For example, to
+   specify a set of declarations for any host in the ".co.uk" set of
+   domains, the following pattern could be used:
+
+   Host *.co.uk
+
+   The following pattern would match any host in the 192.168.0.[0-9]
+   network range:
+
+   Host 192.168.0.?
+
+   A pattern-list is a comma-separated list of patterns.  Patterns
+   within pattern-lists may be negated by preceding them with an
+   exclamation mark (`!').  For example, to allow a key to be used
+   from anywhere within an organization except from the "dialup"
+   pool, the following entry (in authorized_keys) could be used:
+
+   from="!*.dialup.example.com,*.example.com"
+
+   Note that a negated match will never produce a positive result by
+   itself.  For example, attempting to match "host3" against the
+   following pattern-list will fail:
+
+   from="!host1,!host2"
+
+   The solution here is to include a term that will yield a positive
+   match, such as a wildcard:
+
+   from="!host1,!host2,*"
+
+TOKENS
+
+   Arguments to some keywords can make use of tokens, which are
+   expanded at runtime:
+
+   %%    A literal `%'.
+   %C    Hash of %l%h%p%r%j.
+   %d    Local user's home directory.
+   %f    The fingerprint of the server's host key.
+   %H    The known_hosts hostname or address that is being
+   searched for.
+   %h    The remote hostname.
+   %I    A string describing the reason for a
+   KnownHostsCommand execution: either ADDRESS when
+   looking up a host by address (only when CheckHostIP
+   is enabled), HOSTNAME when searching by hostname, or
+   ORDER when preparing the host key algorithm
+   preference list to use for the destination host.
+   %i    The local user ID.
+   %j    The contents of the ProxyJump option, or the empty
+   string if this option is unset.
+   %K    The base64 encoded host key.
+   %k    The host key alias if specified, otherwise the
+   original remote hostname given on the command line.
+   %L    The local hostname.
+   %l    The local hostname, including the domain name.
+   %n    The original remote hostname, as given on the command
+   line.
+   %p    The remote port.
+   %r    The remote username.
+   %T    The local tun(4) or tap(4) network interface assigned
+   if tunnel forwarding was requested, or "NONE"
+   otherwise.
+   %t    The type of the server host key, e.g.  ssh-ed25519.
+   %u    The local username.
+
+   CertificateFile, ControlPath, IdentityAgent, IdentityFile,
+   KnownHostsCommand, LocalForward, Match exec, RemoteCommand,
+   RemoteForward, RevokedHostKeys, and UserKnownHostsFile accept the
+   tokens %%, %C, %d, %h, %i, %j, %k, %L, %l, %n, %p, %r, and %u.
+
+   KnownHostsCommand additionally accepts the tokens %f, %H, %I, %K
+   and %t.
+
+   Hostname accepts the tokens %% and %h.
+
+   LocalCommand accepts all tokens.
+
+   ProxyCommand and ProxyJump accept the tokens %%, %h, %n, %p, and
+   %r.
+
+   Note that some of these directives build commands for execution
+   via the shell.  Because ssh(1) performs no filtering or escaping
+   of characters that have special meaning in shell commands (e.g.
+   quotes), it is the user's responsibility to ensure that the
+   arguments passed to ssh(1) do not contain such characters and
+   that tokens are appropriately quoted when used.
+
+ENVIRONMENT VARIABLES
+
+   Arguments to some keywords can be expanded at runtime from
+   environment variables on the client by enclosing them in ${}, for
+   example ${HOME}/.ssh would refer to the user's .ssh directory.
+   If a specified environment variable does not exist then an error
+   will be returned and the setting for that keyword will be
+   ignored.
+
+   The keywords CertificateFile, ControlPath, IdentityAgent,
+   IdentityFile, KnownHostsCommand, and UserKnownHostsFile support
+   environment variables.  The keywords LocalForward and
+   RemoteForward support environment variables only for Unix domain
+   socket paths.
+
+FILES
+
+   ~/.ssh/config
+   This is the per-user configuration file.  The format of
+   this file is described above.  This file is used by the
+   SSH client.  Because of the potential for abuse, this
+   file must have strict permissions: read/write for the
+   user, and not writable by others.
+
+   /etc/ssh/ssh_config
+   Systemwide configuration file.  This file provides
+   defaults for those values that are not specified in the
+   user's configuration file, and for those users who do not
+   have a configuration file.  This file must be world-
+   readable.
+*/
+
+// Config contains every keyword known to exist in the
+// ssh_config specification. The comments are taken from
+// the manual page for ssh_config(5) and are used to
+// describe the purpose of each keyword.
+//
+// Please note that rig itself only supports a very limited
+// subset of these settings.
+type Config struct {
+	// Host is the host alias that is used to match suitable confirguration blocks, it holds
+	// the value as it would have been given when running "ssh hostalias".
+	//
+	// It is used as the endpoint for the connection unless overridden by the Hostname
+	// field.
+	Host string
+
+	// Specifies the user to log in as.  This can be useful when
+	// a different user name is used on different machines.
+	// This saves the trouble of having to remember to give the
+	// user name on the command line.
+	User string
+
+	// Specifies the real host name to log into.  This can be
+	// used to specify nicknames or abbreviations for hosts.
+	// Arguments to Hostname accept the tokens described in the
+	// "TOKENS" section.  Numeric IP addresses are also
+	// permitted (both on the command line and in Hostname
+	// specifications).  The default is the name given on the
+	// command line.
+	Hostname string
+
+	// Controls whether explicit hostname canonicalization is
+	// performed.  The default, no, is not to perform any name
+	// rewriting and let the system resolver handle all hostname
+	// lookups.  If set to yes then, for connections that do not
+	// use a ProxyCommand or ProxyJump, ssh(1) will attempt to
+	// canonicalize the hostname specified on the command line
+	// using the CanonicalDomains suffixes and
+	// CanonicalizePermittedCNAMEs rules.  If
+	// CanonicalizeHostname is set to always, then
+	// canonicalization is applied to proxied connections too.
+	//
+	// If this option is enabled, then the configuration files
+	// are processed again using the new target name to pick up
+	// any new configuration in matching Host and Match stanzas.
+	// A value of none disables the use of a ProxyJump host.
+	CanonicalizeHostname options.CanonicalizeHostnameOption
+
+	// When CanonicalizeHostname is enabled, this option
+	// specifies the list of domain suffixes in which to search
+	// for the specified destination host.
+	CanonicalDomains []string
+
+	// Specifies the maximum number of dot characters in a
+	// hostname before canonicalization is disabled.  The
+	// default, 1, allows a single dot (i.e.
+	// hostname.subdomain).
+	CanonicalizeMaxDots int
+
+	// Specifies whether to fail with an error when hostname
+	// canonicalization fails.  The default, yes, will attempt
+	// to look up the unqualified hostname using the system
+	// resolver's search rules.  A value of no will cause ssh(1)
+	// to fail instantly if CanonicalizeHostname is enabled and
+	// the target hostname cannot be found in any of the domains
+	// specified by CanonicalDomains.
+	CanonicalizeFallbackLocal options.BooleanOption
+
+	// Specifies rules to determine whether CNAMEs should be
+	// followed when canonicalizing hostnames.  The rules
+	// consist of one or more arguments of
+	// source_domain_list:target_domain_list, where
+	// source_domain_list is a pattern-list of domains that may
+	// follow CNAMEs in canonicalization, and target_domain_list
+	// is a pattern-list of domains that they may resolve to.
+	//
+	// For example,
+	// "*.a.example.com:*.b.example.com,*.c.example.com" will
+	// allow hostnames matching "*.a.example.com" to be
+	// canonicalized to names in the "*.b.example.com" or
+	// "*.c.example.com" domains.
+	//
+	// A single argument of "none" causes no CNAMEs to be
+	// considered for canonicalization.  This is the default
+	// behaviour.
+	CanonicalizePermittedCNAMEs []string
+
+	// Specifies whether keys should be automatically added to a
+	// running ssh-agent(1).  If this option is set to yes and a
+	// key is loaded from a file, the key and its passphrase are
+	// added to the agent with the default lifetime, as if by
+	// ssh-add(1).  If this option is set to ask, ssh(1) will
+	// require confirmation using the SSH_ASKPASS program before
+	// adding a key (see ssh-add(1) for details).  If this
+	// option is set to confirm, each use of the key must be
+	// confirmed, as if the -c option was specified to
+	// ssh-add(1).  If this option is set to no, no keys are
+	// added to the agent.  Alternately, this option may be
+	// specified as a time interval using the format described
+	// in the "TIME FORMATS" section of sshd_config(5) to
+	// specify the key's lifetime in ssh-agent(1), after which
+	// it will automatically be removed.  The argument must be
+	// no (the default), yes, confirm (optionally followed by a
+	// time interval), ask or a time interval.
+	AddKeysToAgent options.AddKeysToAgentOption
+
+	// Use apple's MPTCP. Mac only option.
+	AppleMultiPath options.BooleanOption
+
+	// When adding identities, each passphrase will also be stored in the user's keychain.
+	// (this is a mac only option)
+	UseKeychain options.BooleanOption
+
+	// Specifies which address family to use when connecting.
+	// Valid arguments are any (the default), inet (use IPv4
+	// only), or inet6 (use IPv6 only).
+	AddressFamily string // use enum setter
+
+	// If set to yes, user interaction such as password prompts
+	// and host key confirmation requests will be disabled.
+	// This option is useful in scripts and other batch jobs
+	// where no user is present to interact with ssh(1).  The
+	// argument must be yes or no (the default).
+	BatchMode options.BooleanOption
+
+	// Use the specified address on the local machine as the
+	// source address of the connection.  Only useful on systems
+	// with more than one address.
+	BindAddress string
+
+	// Use the address of the specified interface on the local
+	// machine as the source address of the connection.
+	BindInterface string
+
+	// Specifies which algorithms are allowed for signing of
+	// certificates by certificate authorities (CAs).  The
+	// default is:
+	//
+	// ssh-ed25519,ecdsa-sha2-nistp256,
+	// ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,
+	// sk-ssh-ed25519@openssh.com,
+	// sk-ecdsa-sha2-nistp256@openssh.com,
+	// rsa-sha2-512,rsa-sha2-256
+	//
+	// If the specified list begins with a `+' character, then
+	// the specified algorithms will be appended to the default
+	// set instead of replacing them.  If the specified list
+	// begins with a `-' character, then the specified
+	// algorithms (including wildcards) will be removed from the
+	// default set instead of replacing them.
+	//
+	// ssh(1) will not accept host certificates signed using
+	// algorithms other than those specified.
+	CASignatureAlgorithms []string // modifier prefixes
+
+	// Specifies a file from which the user's certificate is
+	// read.  A corresponding private key must be provided
+	// separately in order to use this certificate either from
+	// an IdentityFile directive or -i flag to ssh(1), via
+	// ssh-agent(1), or via a PKCS11Provider or
+	// SecurityKeyProvider.
+	//
+	// Arguments to CertificateFile may use the tilde syntax to
+	// refer to a user's home directory, the tokens described in
+	// the "TOKENS" section and environment variables as
+	// described in the "ENVIRONMENT VARIABLES" section.
+	//
+	// It is possible to have multiple certificate files
+	// specified in configuration files; these certificates will
+	// be tried in sequence.  Multiple CertificateFile
+	// directives will add to the list of certificates used for
+	// authentication.
+	CertificateFile []string // always append
+
+	// Specifies whether and how quickly ssh(1) should close
+	// inactive channels.  Timeouts are specified as one or more
+	// "type=interval" pairs separated by whitespace, where the
+	// "type" must be a channel type name (as described in the
+	// table below), optionally containing wildcard characters.
+	//
+	// The timeout value "interval" is specified in seconds or
+	// may use any of the units documented in the "TIME FORMATS"
+	// section.  For example, "session=5m" would cause the
+	// interactive session to terminate after five minutes of
+	// inactivity.  Specifying a zero value disables the
+	// inactivity timeout.
+	//
+	// The available channel types include:
+	//
+	// agent-connection
+	// Open connections to ssh-agent(1).
+	//
+	// direct-tcpip, direct-streamlocal@openssh.com
+	// Open TCP or Unix socket (respectively)
+	// connections that have been established from a
+	// ssh(1) local forwarding, i.e. LocalForward or
+	// DynamicForward.
+	//
+	// forwarded-tcpip, forwarded-streamlocal@openssh.com
+	// Open TCP or Unix socket (respectively)
+	// connections that have been established to a
+	// sshd(8) listening on behalf of a ssh(1) remote
+	// forwarding, i.e. RemoteForward.
+	//
+	// session
+	// The interactive main session, including shell
+	// session, command execution, scp(1), sftp(1), etc.
+	//
+	// tun-connection
+	// Open TunnelForward connections.
+	//
+	// x11-connection
+	// Open X11 forwarding sessions.
+	//
+	// Note that in all the above cases, terminating an inactive
+	// session does not guarantee to remove all resources
+	// associated with the session, e.g. shell processes or X11
+	// clients relating to the session may continue to execute.
+	//
+	// Moreover, terminating an inactive channel or session does
+	// not necessarily close the SSH connection, nor does it
+	// prevent a client from requesting another channel of the
+	// same type.  In particular, expiring an inactive
+	// forwarding session does not prevent another identical
+	// forwarding from being subsequently created.
+	//
+	// The default is not to expire channels of any type for
+	// inactivity.
+	ChannelTimeout map[string]time.Duration // special key-value syntax
+
+	// If set to yes, ssh(1) will additionally check the host IP
+	// address in the known_hosts file.  This allows it to
+	// detect if a host key changed due to DNS spoofing and will
+	// add addresses of destination hosts to ~/.ssh/known_hosts
+	// in the process, regardless of the setting of
+	// StrictHostKeyChecking.  If the option is set to no (the
+	// default), the check will not be executed.
+	CheckHostIP options.BooleanOption
+
+	// Specifies the ciphers allowed and their order of
+	// preference.  Multiple ciphers must be comma-separated.
+	// If the specified list begins with a `+' character, then
+	// the specified ciphers will be appended to the default set
+	// instead of replacing them.  If the specified list begins
+	// with a `-' character, then the specified ciphers
+	// (including wildcards) will be removed from the default
+	// set instead of replacing them.  If the specified list
+	// begins with a `^' character, then the specified ciphers
+	// will be placed at the head of the default set.
+	//
+	// The supported ciphers are:
+	//
+	// 3des-cbc
+	// aes128-cbc
+	// aes192-cbc
+	// aes256-cbc
+	// aes128-ctr
+	// aes192-ctr
+	// aes256-ctr
+	// aes128-gcm@openssh.com
+	// aes256-gcm@openssh.com
+	// chacha20-poly1305@openssh.com
+	//
+	// The default is:
+	//
+	// chacha20-poly1305@openssh.com,
+	// aes128-ctr,aes192-ctr,aes256-ctr,
+	// aes128-gcm@openssh.com,aes256-gcm@openssh.com
+	//
+	// The list of available ciphers may also be obtained using
+	// "ssh -Q cipher".
+	Ciphers []string // modifier prefixes, defaults need to be set first (oh no.)
+
+	// Specifies that all local, remote, and dynamic port
+	// forwardings specified in the configuration files or on
+	// the command line be cleared.  This option is primarily
+	// useful when used from the ssh(1) command line to clear
+	// port forwardings set in configuration files, and is
+	// automatically set by scp(1) and sftp(1).  The argument
+	// must be yes or no (the default).
+	ClearAllForwardings options.BooleanOption
+
+	// Specifies whether to use compression.  The argument must
+	// be yes or no (the default).
+	Compression options.BooleanOption
+
+	// Specifies the number of tries (one per second) to make
+	// before exiting.  The argument must be an integer.  This
+	// may be useful in scripts if the connection sometimes
+	// fails.  The default is 1.
+	ConnectionAttempts int
+
+	// Specifies the timeout (in seconds) used when connecting
+	// to the SSH server, instead of using the default system
+	// TCP timeout.  This timeout is applied both to
+	// establishing the connection and to performing the initial
+	// SSH protocol handshake and key exchange.
+	ConnectTimeout time.Duration
+
+	// Enables the sharing of multiple sessions over a single
+	// network connection.  When set to yes, ssh(1) will listen
+	// for connections on a control socket specified using the
+	// ControlPath argument.  Additional sessions can connect to
+	// this socket using the same ControlPath with ControlMaster
+	// set to no (the default).  These sessions will try to
+	// reuse the master instance's network connection rather
+	// than initiating new ones, but will fall back to
+	// connecting normally if the control socket does not exist,
+	// or is not listening.
+	//
+	// Setting this to ask will cause ssh(1) to listen for
+	// control connections, but require confirmation using
+	// ssh-askpass(1).  If the ControlPath cannot be opened,
+	// ssh(1) will continue without connecting to a master
+	// instance.
+	//
+	// X11 and ssh-agent(1) forwarding is supported over these
+	// multiplexed connections, however the display and agent
+	// forwarded will be the one belonging to the master
+	// connection i.e. it is not possible to forward multiple
+	// displays or agents.
+	//
+	// Two additional options allow for opportunistic
+	// multiplexing: try to use a master connection but fall
+	// back to creating a new one if one does not already exist.
+	// These options are: auto and autoask.  The latter requires
+	// confirmation like the ask option.
+	ControlMaster options.ControlMasterOption // yes, no, ask, auto, autoask
+
+	// Specify the path to the control socket used for
+	// connection sharing as described in the ControlMaster
+	// section above or the string none to disable connection
+	// sharing.  Arguments to ControlPath may use the tilde
+	// syntax to refer to a user's home directory, the tokens
+	// described in the "TOKENS" section and environment
+	// variables as described in the "ENVIRONMENT VARIABLES"
+	// section.  It is recommended that any ControlPath used for
+	// opportunistic connection sharing include at least %h, %p,
+	// and %r (or alternatively %C) and be placed in a directory
+	// that is not writable by other users.  This ensures that
+	// shared connections are uniquely identified.
+	ControlPath string // path, supports tokens and environment variables
+
+	// When used in conjunction with ControlMaster, specifies
+	// that the master connection should remain open in the
+	// background (waiting for future client connections) after
+	// the initial client connection has been closed.  If set to
+	// no (the default), then the master connection will not be
+	// placed into the background, and will close as soon as the
+	// initial client connection is closed.  If set to yes or 0,
+	// then the master connection will remain in the background
+	// indefinitely (until killed or closed via a mechanism such
+	// as the "ssh -O exit").  If set to a time in seconds, or a
+	// time in any of the formats documented in sshd_config(5),
+	// then the backgrounded master connection will
+	// automatically terminate after it has remained idle (with
+	// no client connections) for the specified time.
+	ControlPersist options.ControlPersistOption
+
+	// Specifies that a TCP port on the local machine be
+	// forwarded over the secure channel, and the application
+	// protocol is then used to determine where to connect to
+	// from the remote machine.
+	//
+	// The argument must be [bind_address:]port.  IPv6 addresses
+	// can be specified by enclosing addresses in square
+	// brackets.  By default, the local port is bound in
+	// accordance with the GatewayPorts setting.  However, an
+	// explicit bind_address may be used to bind the connection
+	// to a specific address.  The bind_address of localhost
+	// indicates that the listening port be bound for local use
+	// only, while an empty address or `*' indicates that the
+	// port should be available from all interfaces.
+	//
+	// Currently the SOCKS4 and SOCKS5 protocols are supported,
+	// and ssh(1) will act as a SOCKS server.  Multiple
+	// forwardings may be specified, and additional forwardings
+	// can be given on the command line.  Only the superuser can
+	// forward privileged ports.
+	DynamicForward []string // always append
+
+	// Enables the command line option in the EscapeChar menu
+	// for interactive sessions (default `~C').  By default, the
+	// command line is disabled.
+	EnableEscapeCommandline options.BooleanOption
+
+	// Setting this option to yes in the global client
+	// configuration file /etc/ssh/ssh_config enables the use of
+	// the helper program ssh-keysign(8) during
+	// HostbasedAuthentication.  The argument must be yes or no
+	// (the default).  This option should be placed in the non-
+	// hostspecific section.  See ssh-keysign(8) for more
+	// information.
+	EnableSSHKeysign options.BooleanOption
+
+	// Sets the escape character (default: `~').  The escape
+	// character can also be set on the command line.  The
+	// argument should be a single character, `^' followed by a
+	// letter, or none to disable the escape character entirely
+	// (making the connection transparent for binary data).
+	EscapeChar options.EscapeCharOption
+
+	// Specifies whether ssh(1) should terminate the connection
+	// if it cannot set up all requested dynamic, tunnel, local,
+	// and remote port forwardings, (e.g. if either end is
+	// unable to bind and listen on a specified port).  Note
+	// that ExitOnForwardFailure does not apply to connections
+	// made over port forwardings and will not, for example,
+	// cause ssh(1) to exit if TCP connections to the ultimate
+	// forwarding destination fail.  The argument must be yes or
+	// no (the default).
+	ExitOnForwardFailure options.BooleanOption
+
+	// Specifies the hash algorithm used when displaying key
+	// fingerprints.  Valid options are: md5 and sha256 (the
+	// default).
+	FingerprintHash options.FingerprintHashOption
+
+	// Requests ssh to go to background just before command
+	// execution.  This is useful if ssh is going to ask for
+	// passwords or passphrases, but the user wants it in the
+	// background.  This implies the StdinNull configuration
+	// option being set to "yes".  The recommended way to start
+	// X11 programs at a remote site is with something like ssh
+	// -f host xterm, which is the same as ssh host xterm if the
+	// ForkAfterAuthentication configuration option is set to
+	// "yes".
+	//
+	// If the ExitOnForwardFailure configuration option is set
+	// to "yes", then a client started with the
+	// ForkAfterAuthentication configuration option being set to
+	// "yes" will wait for all remote port forwards to be
+	// successfully established before placing itself in the
+	// background.  The argument to this keyword must be yes
+	// (same as the -f option) or no (the default).
+	ForkAfterAuthentication options.BooleanOption
+
+	// Specifies whether the connection to the authentication
+	// agent (if any) will be forwarded to the remote machine.
+	// The argument may be yes, no (the default), an explicit
+	// path to an agent socket or the name of an environment
+	// variable (beginning with `$') in which to find the path.
+	//
+	// Agent forwarding should be enabled with caution.  Users
+	// with the ability to bypass file permissions on the remote
+	// host (for the agent's Unix-domain socket) can access the
+	// local agent through the forwarded connection.  An
+	// attacker cannot obtain key material from the agent,
+	// however they can perform operations on the keys that
+	// enable them to authenticate using the identities loaded
+	// into the agent.
+	ForwardAgent options.ForwardAgentOption
+
+	// Specifies whether X11 connections will be automatically
+	// redirected over the secure channel and DISPLAY set.  The
+	// argument must be yes or no (the default).
+	//
+	// X11 forwarding should be enabled with caution.  Users
+	// with the ability to bypass file permissions on the remote
+	// host (for the user's X11 authorization database) can
+	// access the local X11 display through the forwarded
+	// connection.  An attacker may then be able to perform
+	// activities such as keystroke monitoring if the
+	// ForwardX11Trusted option is also enabled.
+	ForwardX11 options.BooleanOption
+
+	// Specify a timeout for untrusted X11 forwarding using the
+	// format described in the "TIME FORMATS" section of
+	// sshd_config(5).  X11 connections received by ssh(1) after
+	// this time will be refused.  Setting ForwardX11Timeout to
+	// zero will disable the timeout and permit X11 forwarding
+	// for the life of the connection.  The default is to
+	// disable untrusted X11 forwarding after twenty minutes has
+	// elapsed.
+	ForwardX11Timeout time.Duration
+
+	// If this option is set to yes, remote X11 clients will
+	// have full access to the original X11 display.
+	//
+	// If this option is set to no (the default), remote X11
+	// clients will be considered untrusted and prevented from
+	// stealing or tampering with data belonging to trusted X11
+	// clients.  Furthermore, the xauth(1) token used for the
+	// session will be set to expire after 20 minutes.  Remote
+	// clients will be refused access after this time.
+	//
+	// See the X11 SECURITY extension specification for full
+	// details on the restrictions imposed on untrusted clients.
+	ForwardX11Trusted options.BooleanOption
+
+	// Specifies whether remote hosts are allowed to connect to
+	// local forwarded ports.  By default, ssh(1) binds local
+	// port forwardings to the loopback address.  This prevents
+	// other remote hosts from connecting to forwarded ports.
+	// GatewayPorts can be used to specify that ssh should bind
+	// local port forwardings to the wildcard address, thus
+	// allowing remote hosts to connect to forwarded ports.  The
+	// argument must be yes or no (the default).
+	GatewayPorts options.BooleanOption
+
+	// Specifies one or more files to use for the global host
+	// key database, separated by whitespace.  The default is
+	// /etc/ssh/ssh_known_hosts, /etc/ssh/ssh_known_hosts2.
+	GlobalKnownHostsFile []string // paths
+
+	// Specifies whether user authentication based on GSSAPI is
+	// allowed.  The default is no.
+	GSSAPIAuthentication options.BooleanOption
+
+	// Forward (delegate) credentials to the server.  The
+	// default is no.
+	GSSAPIDelegateCredentials options.BooleanOption
+
+	// Indicates that ssh(1) should hash host names and
+	// addresses when they are added to ~/.ssh/known_hosts.
+	// These hashed names may be used normally by ssh(1) and
+	// sshd(8), but they do not visually reveal identifying
+	// information if the file's contents are disclosed.  The
+	// default is no.  Note that existing names and addresses in
+	// known hosts files will not be converted automatically,
+	// but may be manually hashed using ssh-keygen(1).
+	HashKnownHosts options.BooleanOption
+
+	// Specifies the signature algorithms that will be used for
+	// hostbased authentication as a comma-separated list of
+	// patterns.  Alternately if the specified list begins with
+	// a `+' character, then the specified signature algorithms
+	// will be appended to the default set instead of replacing
+	// them.  If the specified list begins with a `-' character,
+	// then the specified signature algorithms (including
+	// wildcards) will be removed from the default set instead
+	// of replacing them.  If the specified list begins with a
+	// `^' character, then the specified signature algorithms
+	// will be placed at the head of the default set.  The
+	// default for this option is:
+	//
+	// ssh-ed25519-cert-v01@openssh.com,
+	// ecdsa-sha2-nistp256-cert-v01@openssh.com,
+	// ecdsa-sha2-nistp384-cert-v01@openssh.com,
+	// ecdsa-sha2-nistp521-cert-v01@openssh.com,
+	// sk-ssh-ed25519-cert-v01@openssh.com,
+	// sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,
+	// rsa-sha2-512-cert-v01@openssh.com,
+	// rsa-sha2-256-cert-v01@openssh.com,
+	// ssh-ed25519,
+	// ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,
+	// sk-ssh-ed25519@openssh.com,
+	// sk-ecdsa-sha2-nistp256@openssh.com,
+	// rsa-sha2-512,rsa-sha2-256
+	//
+	// The -Q option of ssh(1) may be used to list supported
+	// signature algorithms.  This was formerly named
+	// HostbasedKeyTypes.
+	HostbasedAcceptedAlgorithms []string // modifier prefixes, defaults need to be set first
+
+	// Specifies whether to try rhosts based authentication with
+	// public key authentication.  The argument must be yes or
+	// no (the default).
+	HostbasedAuthentication options.BooleanOption
+
+	// Specifies the host key signature algorithms that the
+	// client wants to use in order of preference.  Alternately
+	// if the specified list begins with a `+' character, then
+	// the specified signature algorithms will be appended to
+	// the default set instead of replacing them.  If the
+	// specified list begins with a `-' character, then the
+	// specified signature algorithms (including wildcards) will
+	// be removed from the default set instead of replacing
+	// them.  If the specified list begins with a `^' character,
+	// then the specified signature algorithms will be placed at
+	// the head of the default set.  The default for this option
+	// is:
+	//
+	// ssh-ed25519-cert-v01@openssh.com,
+	// ecdsa-sha2-nistp256-cert-v01@openssh.com,
+	// ecdsa-sha2-nistp384-cert-v01@openssh.com,
+	// ecdsa-sha2-nistp521-cert-v01@openssh.com,
+	// sk-ssh-ed25519-cert-v01@openssh.com,
+	// sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,
+	// rsa-sha2-512-cert-v01@openssh.com,
+	// rsa-sha2-256-cert-v01@openssh.com,
+	// ssh-ed25519,
+	// ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,
+	// sk-ecdsa-sha2-nistp256@openssh.com,
+	// sk-ssh-ed25519@openssh.com,
+	// rsa-sha2-512,rsa-sha2-256
+	//
+	// If hostkeys are known for the destination host then this
+	// default is modified to prefer their algorithms.
+	//
+	// The list of available signature algorithms may also be
+	// obtained using "ssh -Q HostKeyAlgorithms".
+	HostKeyAlgorithms []string // modifier prefixes, defaults need to be set first
+
+	// Specifies an alias that should be used instead of the
+	// real host name when looking up or saving the host key in
+	// the host key database files and when validating host
+	// certificates.  This option is useful for tunneling SSH
+	// connections or for multiple servers running on a single
+	// host.
+	HostKeyAlias string
+
+	// Specifies that ssh(1) should only use the configured
+	// authentication identity and certificate files (either the
+	// default files, or those explicitly configured in the
+	// files or passed on the ssh(1) command-line), even if
+	// ssh-agent(1) or a PKCS11Provider or SecurityKeyProvider
+	// offers more identities.  The argument to this keyword
+	// must be yes or no (the default).  This option is intended
+	// for situations where ssh-agent offers many different
+	// identities.
+	IdentitiesOnly options.BooleanOption
+
+	// Specifies the Unix-domain socket used to communicate with
+	// the authentication agent.
+	//
+	// This option overrides the SSH_AUTH_SOCK environment
+	// variable and can be used to select a specific agent.
+	// Setting the socket name to none disables the use of an
+	// authentication agent.  If the string "SSH_AUTH_SOCK" is
+	// specified, the location of the socket will be read from
+	// the SSH_AUTH_SOCK environment variable.  Otherwise if the
+	// specified value begins with a `$' character, then it will
+	// be treated as an environment variable containing the
+	// location of the socket.
+	//
+	// Arguments to IdentityAgent may use the tilde syntax to
+	// refer to a user's home directory, the tokens described in
+	// the "TOKENS" section and environment variables as
+	// described in the "ENVIRONMENT VARIABLES" section.
+	IdentityAgent options.IdentityAgentOption
+
+	// Specifies a file from which the user's DSA, ECDSA,
+	// authenticator-hosted ECDSA, Ed25519, authenticator-hosted
+	// Ed25519 or RSA authentication identity is read.  You can
+	// also specify a public key file to use the corresponding
+	// private key that is loaded in ssh-agent(1) when the
+	// private key file is not present locally.  The default is
+	// ~/.ssh/id_rsa, ~/.ssh/id_ecdsa, ~/.ssh/id_ecdsa_sk,
+	// ~/.ssh/id_ed25519, ~/.ssh/id_ed25519_sk and
+	// ~/.ssh/id_dsa.  Additionally, any identities represented
+	// by the authentication agent will be used for
+	// authentication unless IdentitiesOnly is set.  If no
+	// certificates have been explicitly specified by
+	// CertificateFile, ssh(1) will try to load certificate
+	// information from the filename obtained by appending
+	// -cert.pub to the path of a specified IdentityFile.
+	//
+	// Arguments to IdentityFile may use the tilde syntax to
+	// refer to a user's home directory or the tokens described
+	// in the "TOKENS" section.  Alternately an argument of none
+	// may be used to indicate no identity files should be
+	// loaded.
+	//
+	// It is possible to have multiple identity files specified
+	// in configuration files; all these identities will be
+	// tried in sequence.  Multiple IdentityFile directives will
+	// add to the list of identities tried (this behaviour
+	// differs from that of other configuration directives).
+	//
+	// IdentityFile may be used in conjunction with
+	// IdentitiesOnly to select which identities in an agent are
+	// offered during authentication.  IdentityFile may also be
+	// used in conjunction with CertificateFile in order to
+	// provide any certificate also needed for authentication
+	// with the identity.
+	IdentityFile []string // always append, supports none, paths, and tokens
+
+	// Specifies a pattern-list of unknown options to be ignored
+	// if they are encountered in configuration parsing.  This
+	// may be used to suppress errors if contains options that
+	// are unrecognised by ssh(1).  It is recommended that
+	// IgnoreUnknown be listed early in the configuration file
+	// as it will not be applied to unknown options that appear
+	// before it.
+	IgnoreUnknown []string // patterns
+
+	// Specifies the IPv4 type-of-service or DSCP class for
+	// connections.  Accepted values are af11, af12, af13, af21,
+	// af22, af23, af31, af32, af33, af41, af42, af43, cs0, cs1,
+	// cs2, cs3, cs4, cs5, cs6, cs7, ef, le, lowdelay,
+	// throughput, reliability, a numeric value, or none to use
+	// the operating system default.  This option may take one
+	// or two arguments, separated by whitespace.  If one
+	// argument is specified, it is used as the packet class
+	// unconditionally.  If two values are specified, the first
+	// is automatically selected for interactive sessions and
+	// the second for non-interactive sessions.  The default is
+	// af21 (Low-Latency Data) for interactive sessions and cs1
+	// (Lower Effort) for non-interactive sessions.
+	IPQoS []string // one or two values
+
+	// Specifies whether to use keyboard-interactive
+	// authentication.  The argument to this keyword must be yes
+	// (the default) or no.  ChallengeResponseAuthentication is
+	// a deprecated alias for this.
+	KbdInteractiveAuthentication options.BooleanOption
+
+	// Specifies the list of methods to use in keyboard-
+	// interactive authentication.  Multiple method names must
+	// be comma-separated.  The default is to use the server
+	// specified list.  The methods available vary depending on
+	// what the server supports.  For an OpenSSH server, it may
+	// be zero or more of: bsdauth and pam.
+	KbdInteractiveDevices []string // csv
+
+	// Specifies the available KEX (Key Exchange) algorithms.
+	// Multiple algorithms must be comma-separated.  If the
+	// specified list begins with a `+' character, then the
+	// specified algorithms will be appended to the default set
+	// instead of replacing them.  If the specified list begins
+	// with a `-' character, then the specified algorithms
+	// (including wildcards) will be removed from the default
+	// set instead of replacing them.  If the specified list
+	// begins with a `^' character, then the specified
+	// algorithms will be placed at the head of the default set.
+	// The default is:
+	//
+	// sntrup761x25519-sha512@openssh.com,
+	// curve25519-sha256,curve25519-sha256@libssh.org,
+	// ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,
+	// diffie-hellman-group-exchange-sha256,
+	// diffie-hellman-group16-sha512,
+	// diffie-hellman-group18-sha512,
+	// diffie-hellman-group14-sha256
+	//
+	// The list of available key exchange algorithms may also be
+	// obtained using "ssh -Q kex".
+	KexAlgorithms []string // modifier prefixes, defaults need to be set first, no none
+
+	// Specifies a command to use to obtain a list of host keys,
+	// in addition to those listed in UserKnownHostsFile and
+	// GlobalKnownHostsFile.  This command is executed after the
+	// files have been read.  It may write host key lines to
+	// standard output in identical format to the usual files
+	// (described in the "VERIFYING HOST KEYS" section in
+	// ssh(1)).  Arguments to KnownHostsCommand accept the
+	// tokens described in the "TOKENS" section.  The command
+	// may be invoked multiple times per connection: once when
+	// preparing the preference list of host key algorithms to
+	// use, again to obtain the host key for the requested host
+	// name and, if CheckHostIP is enabled, one more time to
+	// obtain the host key matching the server's address.  If
+	// the command exits abnormally or returns a non-zero exit
+	// status then the connection is terminated.
+	KnownHostsCommand string
+
+	// Specifies a command to execute on the local machine after
+	// successfully connecting to the server.  The command
+	// string extends to the end of the line, and is executed
+	// with the user's shell.  Arguments to LocalCommand accept
+	// the tokens described in the "TOKENS" section.
+	//
+	// The command is run synchronously and does not have access
+	// to the session of the ssh(1) that spawned it.  It should
+	// not be used for interactive commands.
+	//
+	// This directive is ignored unless PermitLocalCommand has
+	// been enabled.
+	LocalCommand string // comment is part of value (oh no.)
+
+	// Specifies that a TCP port on the local machine be
+	// forwarded over the secure channel to the specified host
+	// and port from the remote machine.  The first argument
+	// specifies the listener and may be [bind_address:]port or
+	// a Unix domain socket path.  The second argument is the
+	// destination and may be host:hostport or a Unix domain
+	// socket path if the remote host supports it.
+	//
+	// IPv6 addresses can be specified by enclosing addresses in
+	// square brackets.  Multiple forwardings may be specified,
+	// and additional forwardings can be given on the command
+	// line.  Only the superuser can forward privileged ports.
+	// By default, the local port is bound in accordance with
+	// the GatewayPorts setting.  However, an explicit
+	// bind_address may be used to bind the connection to a
+	// specific address.  The bind_address of localhost
+	// indicates that the listening port be bound for local use
+	// only, while an empty address or `*' indicates that the
+	// port should be available from all interfaces.  Unix
+	// domain socket paths may use the tokens described in the
+	// "TOKENS" section and environment variables as described
+	// in the "ENVIRONMENT VARIABLES" section.
+	LocalForward map[string]string // always appends, one pair per line like 8080 remote:80
+
+	// Gives the verbosity level that is used when logging
+	// messages from ssh(1).  The possible values are: QUIET,
+	// FATAL, ERROR, INFO, VERBOSE, DEBUG, DEBUG1, DEBUG2, and
+	// DEBUG3.  The default is INFO.  DEBUG and DEBUG1 are
+	// equivalent.  DEBUG2 and DEBUG3 each specify higher levels
+	// of verbose output.
+	LogLevel string // use enum setter
+
+	// Specify one or more overrides to LogLevel.  An override
+	// consists of a pattern lists that matches the source file,
+	// function and line number to force detailed logging for.
+	// For example, an override pattern of:
+	//
+	// kex.c:*:1000,*:kex_exchange_identification():*,packet.c:*
+	//
+	// would enable detailed logging for line 1000 of kex.c,
+	// everything in the kex_exchange_identification() function,
+	// and all code in the packet.c file.  This option is
+	// intended for debugging and no overrides are enabled by
+	// default.
+	LogVerbose []string // patterns, openssh client specific
+
+	// Specifies the MAC (message authentication code)
+	// algorithms in order of preference.  The MAC algorithm is
+	// used for data integrity protection.  Multiple algorithms
+	// must be comma-separated.  If the specified list begins
+	// with a `+' character, then the specified algorithms will
+	// be appended to the default set instead of replacing them.
+	// If the specified list begins with a `-' character, then
+	// the specified algorithms (including wildcards) will be
+	// removed from the default set instead of replacing them.
+	// If the specified list begins with a `^' character, then
+	// the specified algorithms will be placed at the head of
+	// the default set.
+	//
+	// The algorithms that contain "-etm" calculate the MAC
+	// after encryption (encrypt-then-mac).  These are
+	// considered safer and their use recommended.
+	//
+	// The default is:
+	//
+	// umac-64-etm@openssh.com,umac-128-etm@openssh.com,
+	// hmac-sha2-256-etm@openssh.com,
+	// hmac-sha2-512-etm@openssh.com,
+	// hmac-sha1-etm@openssh.com,
+	// umac-64@openssh.com,umac-128@openssh.com,
+	// hmac-sha2-256,hmac-sha2-512,hmac-sha1
+	//
+	// The list of available MAC algorithms may also be obtained
+	// using "ssh -Q mac".
+	MACs []string // modifier prefixes, defaults need to be set first, no none
+
+	// Disable host authentication for localhost (loopback
+	// addresses).  The argument to this keyword must be yes or
+	// no (the default).
+	NoHostAuthenticationForLocalhost options.BooleanOption
+
+	// Specifies the number of password prompts before giving
+	// up.  The argument to this keyword must be an integer.
+	// The default is 3.
+	NumberOfPasswordPrompts *int
+
+	// Specifies whether ssh(1) should try to obscure inter-
+	// keystroke timings from passive observers of network
+	// traffic.  If enabled, then for interactive sessions,
+	// ssh(1) will send keystrokes at fixed intervals of a few
+	// tens of milliseconds and will send fake keystroke packets
+	// for some time after typing ceases.  The argument to this
+	// keyword must be yes, no or an interval specifier of the
+	// form interval:milliseconds (e.g. interval:80 for 80
+	// milliseconds).  The default is to obscure keystrokes
+	// using a 20ms packet interval.  Note that smaller
+	// intervals will result in higher fake keystroke packet
+	// rates.
+	ObscureKeystrokeTiming options.ObscureKeystrokeTimingOption
+
+	// Specifies whether to use password authentication.  The
+	// argument to this keyword must be yes (the default) or no.
+	PasswordAuthentication options.BooleanOption
+
+	// Allow local command execution via the LocalCommand option
+	// or using the !command escape sequence in ssh(1).  The
+	// argument must be yes or no (the default).
+	PermitLocalCommand options.BooleanOption
+
+	// Specifies the destinations to which remote TCP port
+	// forwarding is permitted when RemoteForward is used as a
+	// SOCKS proxy.  The forwarding specification must be one of
+	// the following forms:
+	//
+	// PermitRemoteOpen host:port
+	// PermitRemoteOpen IPv4_addr:port
+	// PermitRemoteOpen [IPv6_addr]:port
+	//
+	// Multiple forwards may be specified by separating them
+	// with whitespace.  An argument of any can be used to
+	// remove all restrictions and permit any forwarding
+	// requests.  An argument of none can be used to prohibit
+	// all forwarding requests.  The wildcard `*' can be used
+	// for host or port to allow all hosts or ports
+	// respectively.  Otherwise, no pattern matching or address
+	// lookups are performed on supplied names.
+	PermitRemoteOpen []string
+
+	// Specifies which PKCS#11 provider to use or none to
+	// indicate that no provider should be used (the default).
+	// The argument to this keyword is a path to the PKCS#11
+	// shared library ssh(1) should use to communicate with a
+	// PKCS#11 token providing keys for user authentication.
+	PKCS11Provider string // none or path
+
+	// Specifies the port number to connect on the remote host.
+	// The default is 22.
+	Port int
+
+	// Specifies the order in which the client should try
+	// authentication methods.  This allows a client to prefer
+	// one method (e.g. keyboard-interactive) over another
+	// method (e.g. password).  The default is:
+	//
+	// gssapi-with-mic,hostbased,publickey,
+	// keyboard-interactive,password
+	PreferredAuthentications []string // csv
+
+	// Specifies the command to use to connect to the server.
+	// The command string extends to the end of the line, and is
+	// executed using the user's shell `exec' directive to avoid
+	// a lingering shell process.
+	//
+	// Arguments to ProxyCommand accept the tokens described in
+	// the "TOKENS" section.  The command can be basically
+	// anything, and should read from its standard input and
+	// write to its standard output.  It should eventually
+	// connect an sshd(8) server running on some machine, or
+	// execute sshd -i somewhere.  Host key management will be
+	// done using the Hostname of the host being connected
+	// (defaulting to the name typed by the user).  Setting the
+	// command to none disables this option entirely.  Note that
+	// CheckHostIP is not available for connects with a proxy
+	// command.
+	//
+	// This directive is useful in conjunction with nc(1) and
+	// its proxy support.  For example, the following directive
+	// would connect via an HTTP proxy at 192.0.2.0:
+	//
+	// ProxyCommand /usr/bin/nc -X connect -x 192.0.2.0:8080 %h %p
+	ProxyCommand string // none is a special value, comment is part of value
+
+	// Specifies one or more jump proxies as either
+	// [user@]host[:port] or an ssh URI.  Multiple proxies may
+	// be separated by comma characters and will be visited
+	// sequentially.  Setting this option will cause ssh(1) to
+	// connect to the target host by first making a ssh(1)
+	// connection to the specified ProxyJump host and then
+	// establishing a TCP forwarding to the ultimate target from
+	// there.  Setting the host to none disables this option
+	// entirely.
+	//
+	// Note that this option will compete with the ProxyCommand
+	// option - whichever is specified first will prevent later
+	// instances of the other from taking effect.
+	//
+	// Note also that the configuration for the destination host
+	// (either supplied via the command-line or the
+	// configuration file) is not generally applied to jump
+	// hosts.  ~/.ssh/config should be used if specific
+	// configuration is required for jump hosts.
+	ProxyJump []string // csv
+
+	// Specifies that ProxyCommand will pass a connected file
+	// descriptor back to ssh(1) instead of continuing to
+	// execute and pass data.  The default is no.
+	ProxyUseFdpass options.BooleanOption
+
+	// Specifies the signature algorithms that will be used for
+	// public key authentication as a comma-separated list of
+	// patterns.  If the specified list begins with a `+'
+	// character, then the algorithms after it will be appended
+	// to the default instead of replacing it.  If the specified
+	// list begins with a `-' character, then the specified
+	// algorithms (including wildcards) will be removed from the
+	// default set instead of replacing them.  If the specified
+	// list begins with a `^' character, then the specified
+	// algorithms will be placed at the head of the default set.
+	// The default for this option is:
+	//
+	// ssh-ed25519-cert-v01@openssh.com,
+	// ecdsa-sha2-nistp256-cert-v01@openssh.com,
+	// ecdsa-sha2-nistp384-cert-v01@openssh.com,
+	// ecdsa-sha2-nistp521-cert-v01@openssh.com,
+	// sk-ssh-ed25519-cert-v01@openssh.com,
+	// sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,
+	// rsa-sha2-512-cert-v01@openssh.com,
+	// rsa-sha2-256-cert-v01@openssh.com,
+	// ssh-ed25519,
+	// ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,
+	// sk-ssh-ed25519@openssh.com,
+	// sk-ecdsa-sha2-nistp256@openssh.com,
+	// rsa-sha2-512,rsa-sha2-256
+	//
+	// The list of available signature algorithms may also be
+	// obtained using "ssh -Q PubkeyAcceptedAlgorithms".
+	PubkeyAcceptedAlgorithms []string // preload defaults
+
+	// Specifies whether to try public key authentication.  The
+	// argument to this keyword must be yes (the default), no,
+	// unbound or host-bound.  The final two options enable
+	// public key authentication while respectively disabling or
+	// enabling the OpenSSH host-bound authentication protocol
+	// extension required for restricted ssh-agent(1)
+	// forwarding.
+	PubkeyAuthentication options.PubkeyAuthenticationOption
+
+	// Specifies the maximum amount of data that may be
+	// transmitted or received before the session key is
+	// renegotiated, optionally followed by a maximum amount of
+	// time that may pass before the session key is
+	// renegotiated.  The first argument is specified in bytes
+	// and may have a suffix of `K', `M', or `G' to indicate
+	// Kilobytes, Megabytes, or Gigabytes, respectively.  The
+	// default is between `1G' and `4G', depending on the
+	// cipher.  The optional second value is specified in
+	// seconds and may use any of the units documented in the
+	// TIME FORMATS section of sshd_config(5).  The default
+	// value for RekeyLimit is default none, which means that
+	// rekeying is performed after the cipher's default amount
+	// of data has been sent or received and no time based
+	// rekeying is done.
+	RekeyLimit options.RekeyLimitOption
+
+	// Specifies a command to execute on the remote machine
+	// after successfully connecting to the server.  The command
+	// string extends to the end of the line, and is executed
+	// with the user's shell.  Arguments to RemoteCommand accept
+	// the tokens described in the "TOKENS" section.
+	RemoteCommand string // comment is part of value
+
+	// Specifies that a TCP port on the remote machine be
+	// forwarded over the secure channel.  The remote port may
+	// either be forwarded to a specified host and port from the
+	// local machine, or may act as a SOCKS 4/5 proxy that
+	// allows a remote client to connect to arbitrary
+	// destinations from the local machine.  The first argument
+	// is the listening specification and may be
+	// [bind_address:]port or, if the remote host supports it, a
+	// Unix domain socket path.  If forwarding to a specific
+	// destination then the second argument must be
+	// host:hostport or a Unix domain socket path, otherwise if
+	// no destination argument is specified then the remote
+	// forwarding will be established as a SOCKS proxy.  When
+	// acting as a SOCKS proxy, the destination of the
+	// connection can be restricted by PermitRemoteOpen.
+	//
+	// IPv6 addresses can be specified by enclosing addresses in
+	// square brackets.  Multiple forwardings may be specified,
+	// and additional forwardings can be given on the command
+	// line.  Privileged ports can be forwarded only when
+	// logging in as root on the remote machine.  Unix domain
+	// socket paths may use the tokens described in the "TOKENS"
+	// section and environment variables as described in the
+	// "ENVIRONMENT VARIABLES" section.
+	//
+	// If the port argument is 0, the listen port will be
+	// dynamically allocated on the server and reported to the
+	// client at run time.
+	//
+	// If the bind_address is not specified, the default is to
+	// only bind to loopback addresses.  If the bind_address is
+	// `*' or an empty string, then the forwarding is requested
+	// to listen on all interfaces.  Specifying a remote
+	// bind_address will only succeed if the server's
+	// GatewayPorts option is enabled (see sshd_config(5)).
+	RemoteForward map[string]string // always append
+
+	// Specifies whether to request a pseudo-tty for the
+	// session.  The argument may be one of: no (never request a
+	// TTY), yes (always request a TTY when standard input is a
+	// TTY), force (always request a TTY) or auto (request a TTY
+	// when opening a login session).  This option mirrors the
+	// -t and -T flags for ssh(1).
+	RequestTTY options.RequestTTYOption
+
+	// Specifies the minimum RSA key size (in bits) that ssh(1)
+	// will accept.  User authentication keys smaller than this
+	// limit will be ignored.  Servers that present host keys
+	// smaller than this limit will cause the connection to be
+	// terminated.  The default is 1024 bits.  Note that this
+	// limit may only be raised from the default.
+	RequiredRSASize *int
+
+	// Specifies revoked host public keys.  Keys listed in this
+	// file will be refused for host authentication.  Note that
+	// if this file does not exist or is not readable, then host
+	// authentication will be refused for all hosts.  Keys may
+	// be specified as a text file, listing one public key per
+	// line, or as an OpenSSH Key Revocation List (KRL) as
+	// generated by ssh-keygen(1).  For more information on
+	// KRLs, see the KEY REVOCATION LISTS section in
+	// ssh-keygen(1).  Arguments to RevokedHostKeys may use the
+	// tilde syntax to refer to a user's home directory, the
+	// tokens described in the "TOKENS" section and environment
+	// variables as described in the "ENVIRONMENT VARIABLES"
+	// section.
+	RevokedHostKeys string // path
+
+	// Specifies a path to a library that will be used when
+	// loading any FIDO authenticator-hosted keys, overriding
+	// the default of using the built-in USB HID support.
+	//
+	// If the specified value begins with a `$' character, then
+	// it will be treated as an environment variable containing
+	// the path to the library.
+	SecurityKeyProvider string // path or env
+
+	// Specifies what variables from the local environ(7) should
+	// be sent to the server.  The server must also support it,
+	// and the server must be configured to accept these
+	// environment variables.  Note that the TERM environment
+	// variable is always sent whenever a pseudo-terminal is
+	// requested as it is required by the protocol.  Refer to
+	// AcceptEnv in sshd_config(5) for how to configure the
+	// server.  Variables are specified by name, which may
+	// contain wildcard characters.  Multiple environment
+	// variables may be separated by whitespace or spread across
+	// multiple SendEnv directives.
+	//
+	// See "PATTERNS" for more information on patterns.
+	//
+	// It is possible to clear previously set SendEnv variable
+	// names by prefixing patterns with -.  The default is not
+	// to send any environment variables.
+	//
+	// NOTE: It is quite usual to have LANG and LC_* variables
+	// in /etc/ssh/ssh_config, and since that file is read
+	// last, using something like "SendEnv -*" in user config
+	// or ssh options will not remove those.
+	SendEnv []string // always append or use - prefix to remove.
+
+	// Sets the number of server alive messages (see below)
+	// which may be sent without ssh(1) receiving any messages
+	// back from the server.  If this threshold is reached while
+	// server alive messages are being sent, ssh will disconnect
+	// from the server, terminating the session.  It is
+	// important to note that the use of server alive messages
+	// is very different from TCPKeepAlive (below).  The server
+	// alive messages are sent through the encrypted channel and
+	// therefore will not be spoofable.  The TCP keepalive
+	// option enabled by TCPKeepAlive is spoofable.  The server
+	// alive mechanism is valuable when the client or server
+	// depend on knowing when a connection has become
+	// unresponsive.
+	//
+	// The default value is 3.  If, for example,
+	// ServerAliveInterval (see below) is set to 15 and
+	// ServerAliveCountMax is left at the default, if the server
+	// becomes unresponsive, ssh will disconnect after
+	// approximately 45 seconds.
+	ServerAliveCountMax *int
+
+	// Sets a timeout interval in seconds after which if no data
+	// has been received from the server, ssh(1) will send a
+	// message through the encrypted channel to request a
+	// response from the server.  The default is 0, indicating
+	// that these messages will not be sent to the server.
+	ServerAliveInterval time.Duration
+
+	// May be used to either request invocation of a subsystem
+	// on the remote system, or to prevent the execution of a
+	// remote command at all.  The latter is useful for just
+	// forwarding ports.  The argument to this keyword must be
+	// none (same as the -N option), subsystem (same as the -s
+	// option) or default (shell or command execution).
+	SessionType string // enum
+
+	// Directly specify one or more environment variables and
+	// their contents to be sent to the server.  Similarly to
+	// SendEnv, with the exception of the TERM variable, the
+	// server must be prepared to accept the environment
+	// variable.
+	SetEnv map[string]string // always append
+
+	// The SmartcardDevice parameter controls which smartcard device to use.
+	SmartcardDevice string
+
+	// Redirects stdin from /dev/null (actually, prevents
+	// reading from stdin).  Either this or the equivalent -n
+	// option must be used when ssh is run in the background.
+	// The argument to this keyword must be yes (same as the -n
+	// option) or no (the default).
+	StdinNull options.BooleanOption
+
+	// Sets the octal file creation mode mask (umask) used when
+	// creating a Unix-domain socket file for local or remote
+	// port forwarding.  This option is only used for port
+	// forwarding to a Unix-domain socket file.
+	//
+	// The default value is 0177, which creates a Unix-domain
+	// socket file that is readable and writable only by the
+	// owner.  Note that not all operating systems honor the
+	// file mode on Unix-domain socket files.
+	StreamLocalBindMask *uint // should parse and output as octal
+
+	// Specifies whether to remove an existing Unix-domain
+	// socket file for local or remote port forwarding before
+	// creating a new one.  If the socket file already exists
+	// and StreamLocalBindUnlink is not enabled, ssh will be
+	// unable to forward the port to the Unix-domain socket
+	// file.  This option is only used for port forwarding to a
+	// Unix-domain socket file.
+	//
+	// The argument must be yes or no (the default).
+	StreamLocalBindUnlink options.BooleanOption
+
+	// If this flag is set to yes, ssh(1) will never
+	// automatically add host keys to the ~/.ssh/known_hosts
+	// file, and refuses to connect to hosts whose host key has
+	// changed.  This provides maximum protection against man-
+	// in-the-middle (MITM) attacks, though it can be annoying
+	// when the /etc/ssh/ssh_known_hosts file is poorly
+	// maintained or when connections to new hosts are
+	// frequently made.  This option forces the user to manually
+	// add all new hosts.
+	//
+	// If this flag is set to accept-new then ssh will
+	// automatically add new host keys to the user's known_hosts
+	// file, but will not permit connections to hosts with
+	// changed host keys.  If this flag is set to no or off, ssh
+	// will automatically add new host keys to the user known
+	// hosts files and allow connections to hosts with changed
+	// hostkeys to proceed, subject to some restrictions.  If
+	// this flag is set to ask (the default), new host keys will
+	// be added to the user known host files only after the user
+	// has confirmed that is what they really want to do, and
+	// ssh will refuse to connect to hosts whose host key has
+	// changed.  The host keys of known hosts will be verified
+	// automatically in all cases.
+	StrictHostKeyChecking options.StrictHostKeyCheckingOption
+
+	// Gives the facility code that is used when logging
+	// messages from ssh(1).  The possible values are: DAEMON,
+	// USER, AUTH, LOCAL0, LOCAL1, LOCAL2, LOCAL3, LOCAL4,
+	// LOCAL5, LOCAL6, LOCAL7.  The default is USER.
+	SyslogFacility string // use EnumSetter
+
+	// Specifies whether the system should send TCP keepalive
+	// messages to the other side.  If they are sent, death of
+	// the connection or crash of one of the machines will be
+	// properly noticed.  However, this means that connections
+	// will die if the route is down temporarily, and some
+	// people find it annoying.
+	//
+	// The default is yes (to send TCP keepalive messages), and
+	// the client will notice if the network goes down or the
+	// remote host dies.  This is important in scripts, and many
+	// users want it too.
+	//
+	// To disable TCP keepalive messages, the value should be
+	// set to no.  See also ServerAliveInterval for protocol-
+	// level keepalives.
+	TCPKeepAlive options.BooleanOption
+
+	// Specify a configuration tag name that may be later used
+	// by a Match directive to select a block of configuration.
+	Tag string
+
+	// Request tun(4) device forwarding between the client and
+	// the server.  The argument must be yes, point-to-point
+	// (layer 3), ethernet (layer 2), or no (the default).
+	// Specifying yes requests the default tunnel mode, which is
+	// point-to-point.
+	Tunnel options.TunnelOption
+
+	// Specifies the tun(4) devices to open on the client
+	// (local_tun) and the server (remote_tun).
+	//
+	// The argument must be local_tun[:remote_tun].  The devices
+	// may be specified by numerical ID or the keyword any,
+	// which uses the next available tunnel device.  If
+	// remote_tun is not specified, it defaults to any.  The
+	// default is any:any.
+	TunnelDevice string
+
+	// Specifies whether ssh(1) should accept notifications of
+	// additional hostkeys from the server sent after
+	// authentication has completed and add them to
+	// UserKnownHostsFile.  The argument must be yes, no or ask.
+	// This option allows learning alternate hostkeys for a
+	// server and supports graceful key rotation by allowing a
+	// server to send replacement public keys before old ones
+	// are removed.
+	//
+	// Additional hostkeys are only accepted if the key used to
+	// authenticate the host was already trusted or explicitly
+	// accepted by the user, the host was authenticated via
+	// UserKnownHostsFile (i.e. not GlobalKnownHostsFile) and
+	// the host was authenticated using a plain key and not a
+	// certificate.
+	//
+	// UpdateHostKeys is enabled by default if the user has not
+	// overridden the default UserKnownHostsFile setting and has
+	// not enabled VerifyHostKeyDNS, otherwise UpdateHostKeys
+	// will be set to no.
+	//
+	// If UpdateHostKeys is set to ask, then the user is asked
+	// to confirm the modifications to the known_hosts file.
+	// Confirmation is currently incompatible with
+	// ControlPersist, and will be disabled if it is enabled.
+	//
+	// Presently, only sshd(8) from OpenSSH 6.8 and greater
+	// support the "hostkeys@openssh.com" protocol extension
+	// used to inform the client of all the server's hostkeys.
+	UpdateHostKeys options.UpdateHostKeysOption
+
+	// Specifies one or more files to use for the user host key
+	// database, separated by whitespace.  Each filename may use
+	// tilde notation to refer to the user's home directory, the
+	// tokens described in the "TOKENS" section and environment
+	// variables as described in the "ENVIRONMENT VARIABLES"
+	// section.  A value of none causes ssh(1) to ignore any
+	// user-specific known hosts files.  The default is
+	// ~/.ssh/known_hosts, ~/.ssh/known_hosts2.
+	UserKnownHostsFile []string // none is special
+
+	// Specifies whether to verify the remote key using DNS and
+	// SSHFP resource records.  If this option is set to yes,
+	// the client will implicitly trust keys that match a secure
+	// fingerprint from DNS.  Insecure fingerprints will be
+	// handled as if this option was set to ask.  If this option
+	// is set to ask, information on fingerprint match will be
+	// displayed, but the user will still need to confirm new
+	// host keys according to the StrictHostKeyChecking option.
+	// The default is no.
+	//
+	// See also "VERIFYING HOST KEYS" in ssh(1).
+	VerifyHostKeyDNS options.VerifyHostKeyDNSOption
+
+	// If this flag is set to yes, an ASCII art representation
+	// of the remote host key fingerprint is printed in addition
+	// to the fingerprint string at login and for unknown host
+	// keys.  If this flag is set to no (the default), no
+	// fingerprint strings are printed at login and only the
+	// fingerprint string will be printed for unknown host keys.
+	VisualHostKey options.BooleanOption
+
+	// Specifies the full pathname of the xauth(1) program.  The
+	// default is /usr/X11R6/bin/xauth.
+	XAuthLocation string // path
+}

--- a/sshconfig/defaultconfig_darwin.go
+++ b/sshconfig/defaultconfig_darwin.go
@@ -1,0 +1,88 @@
+package sshconfig
+
+var defaultGlobalConfigPath = func() string {
+	return "/etc/ssh/ssh_config"
+}
+
+// sshDefaultConfig is the default configuration for an SSH client.
+// this is obtained via "ssh -G" on a mac without any ssh config
+// files. the output is sorted and the fields with key
+// "identityfile" are joined into a single line.
+//
+// note that some of the boolean values are displayed as "true"/"false"
+// instead of "yes"/"no".
+const sshDefaultConfig = `
+addkeystoagent false
+addressfamily any
+applemultipath no
+batchmode no
+canonicaldomains none
+canonicalizePermittedcnames none
+canonicalizefallbacklocal yes
+canonicalizehostname false
+canonicalizemaxdots 1
+casignaturealgorithms ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,rsa-sha2-512,rsa-sha2-256
+checkhostip no
+ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
+clearallforwardings no
+compression no
+connectionattempts 1
+connecttimeout none
+controlmaster false
+controlpersist no
+enableescapecommandline no
+enablesshkeysign no
+escapechar ~
+exitonforwardfailure no
+fingerprinthash SHA256
+forkafterauthentication no
+forwardagent no
+forwardx11 no
+forwardx11timeout 1200
+forwardx11trusted no
+gatewayports no
+globalknownhostsfile /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
+gssapiauthentication no
+gssapidelegatecredentials no
+hashknownhosts no
+hostbasedacceptedalgorithms ssh-ed25519-cert-v01@openssh.com,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,rsa-sha2-512,rsa-sha2-256
+hostbasedauthentication no
+hostkeyalgorithms ssh-ed25519-cert-v01@openssh.com,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,rsa-sha2-512,rsa-sha2-256
+identitiesonly no
+identityfile ~/.ssh/id_dsa ~/.ssh/id_ecdsa ~/.ssh/id_ecdsa_sk ~/.ssh/id_ed25519 ~/.ssh/id_ed25519_sk ~/.ssh/id_rsa ~/.ssh/id_xmss
+ipqos af21 cs1
+kbdinteractiveauthentication yes
+kexalgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+loglevel INFO
+logverbose none
+macs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
+nohostauthenticationforlocalhost no
+numberofpasswordprompts 3
+passwordauthentication yes
+permitlocalcommand no
+permitremoteopen any
+port 22
+proxyusefdpass no
+pubkeyacceptedalgorithms ssh-ed25519-cert-v01@openssh.com,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,rsa-sha2-512,rsa-sha2-256
+pubkeyauthentication true
+rekeylimit 0 0
+requesttty auto
+requiredrsasize 1024
+securitykeyprovider $SSH_SK_PROVIDER
+serveralivecountmax 3
+serveraliveinterval 30
+sessiontype default
+stdinnull no
+streamlocalbindmask 0177
+streamlocalbindunlink no
+stricthostkeychecking ask
+syslogfacility USER
+tcpkeepalive yes
+tunnel false
+tunneldevice any:any
+updatehostkeys true
+userknownhostsfile ~/.ssh/known_hosts ~/.ssh/known_hosts2
+verifyhostkeydns false
+visualhostkey no
+xauthlocation /usr/X11R6/bin/xauth
+`

--- a/sshconfig/defaultconfig_unix.go
+++ b/sshconfig/defaultconfig_unix.go
@@ -1,0 +1,87 @@
+//go:build !windows && !darwin
+
+package sshconfig
+
+var defaultGlobalConfigPath = func() string {
+	return "/etc/ssh/ssh_config"
+}
+
+// sshDefaultConfig is the default configuration for an SSH client.
+// this is obtained via "ssh -G" on a fresh linux machine without
+// any ssh config files. the output is sorted and the fields with key
+// "identityfile" are joined into a single line.
+//
+// note that some of the boolean values are displayed as "true"/"false"
+// instead of "yes"/"no".
+const sshDefaultConfig = `
+addkeystoagent false
+addressfamily any
+batchmode no
+canonicaldomains none
+canonicalizePermittedcnames none
+canonicalizefallbacklocal yes
+canonicalizehostname false
+canonicalizemaxdots 1
+casignaturealgorithms ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,rsa-sha2-512,rsa-sha2-256
+checkhostip no
+ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
+clearallforwardings no
+compression no
+connectionattempts 1
+connecttimeout none
+controlmaster false
+controlpersist no
+enableescapecommandline no
+enablesshkeysign no
+escapechar ~
+exitonforwardfailure no
+fingerprinthash SHA256
+forkafterauthentication no
+forwardagent no
+forwardx11 no
+forwardx11timeout 1200
+forwardx11trusted no
+gatewayports no
+globalknownhostsfile /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
+hashknownhosts no
+hostbasedacceptedalgorithms ssh-ed25519-cert-v01@openssh.com,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,rsa-sha2-512,rsa-sha2-256
+hostbasedauthentication no
+hostkeyalgorithms ssh-ed25519-cert-v01@openssh.com,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,rsa-sha2-512,rsa-sha2-256
+identitiesonly no
+identityfile ~/.ssh/id_dsa ~/.ssh/id_ecdsa ~/.ssh/id_ecdsa_sk ~/.ssh/id_ed25519 ~/.ssh/id_ed25519_sk ~/.ssh/id_rsa ~/.ssh/id_xmss
+ipqos af21 cs1
+kbdinteractiveauthentication yes
+kexalgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+loglevel INFO
+logverbose none
+macs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
+nohostauthenticationforlocalhost no
+numberofpasswordprompts 3
+passwordauthentication yes
+permitlocalcommand no
+permitremoteopen any
+port 22
+proxyusefdpass no
+pubkeyacceptedalgorithms ssh-ed25519-cert-v01@openssh.com,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,rsa-sha2-512,rsa-sha2-256
+pubkeyauthentication true
+rekeylimit 0 0
+requesttty auto
+requiredrsasize 1024
+securitykeyprovider internal
+serveralivecountmax 3
+serveraliveinterval 0
+sessiontype default
+stdinnull no
+streamlocalbindmask 0177
+streamlocalbindunlink no
+stricthostkeychecking ask
+syslogfacility USER
+tcpkeepalive yes
+tunnel false
+tunneldevice any:any
+updatehostkeys true
+userknownhostsfile ~/.ssh/known_hosts ~/.ssh/known_hosts2
+verifyhostkeydns false
+visualhostkey no
+xauthlocation /usr/bin/xauth
+`

--- a/sshconfig/defaultconfig_windows.go
+++ b/sshconfig/defaultconfig_windows.go
@@ -1,0 +1,88 @@
+package sshconfig
+
+import (
+	"os"
+	"path"
+)
+
+var defaultGlobalConfigPath = func() string {
+	pd := os.Getenv("PROGRAMDATA")
+	if pd == "" {
+		pd = "C:/ProgramData"
+	}
+	return path.Join(pd, "ssh", "ssh_config")
+}
+
+// sshDefaultConfig is the default configuration for an SSH client.
+// this is obtained via "ssh -G" on a fresh windows machine without
+// any ssh config files.
+//
+// note that some of the boolean values are displayed as "true"/"false"
+// instead of "yes"/"no" and the __PROGRAMDATA__ in some of the paths
+// in addition to mixed path separators.
+const sshDefaultConfig = `
+addkeystoagent false
+addressfamily any
+batchmode no
+canonicaldomains
+canonicalizefallbacklocal yes
+canonicalizehostname false
+canonicalizemaxdots 1
+casignaturealgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+challengeresponseauthentication yes
+checkhostip yes
+ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
+clearallforwardings no
+compression no
+connectionattempts 1
+connecttimeout none
+controlmaster false
+controlpersist no
+enablesshkeysign no
+escapechar ~
+exitonforwardfailure no
+fingerprinthash SHA256
+forwardagent no
+forwardx11 no
+forwardx11timeout 1200
+forwardx11trusted no
+gatewayports no
+globalknownhostsfile __PROGRAMDATA__/ssh/ssh_known_hosts __PROGRAMDATA__/ssh/ssh_known_hosts2
+gssapiauthentication no
+gssapidelegatecredentials no
+hashknownhosts no
+hostbasedauthentication no
+hostbasedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+hostkeyalgorithms ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+identitiesonly no
+identityfile ~/.ssh/id_dsa ~/.ssh/id_ecdsa ~/.ssh/id_ed25519 ~/.ssh/id_rsa ~/.ssh/id_xmss
+ipqos af21 cs1
+kbdinteractiveauthentication yes
+kexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1
+loglevel INFO
+macs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
+nohostauthenticationforlocalhost no
+numberofpasswordprompts 3
+passwordauthentication yes
+permitlocalcommand no
+port 22
+proxyusefdpass no
+pubkeyacceptedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+pubkeyauthentication yes
+rekeylimit 0 0
+requesttty auto
+serveralivecountmax 3
+serveraliveinterval 0
+streamlocalbindmask 0177
+streamlocalbindunlink no
+stricthostkeychecking ask
+syslogfacility USER
+tcpkeepalive yes
+tunnel false
+tunneldevice any:any
+updatehostkeys false
+userknownhostsfile ~/.ssh/known_hosts ~/.ssh/known_hosts2
+verifyhostkeydns false
+visualhostkey no
+xauthlocation __PROGRAMDATA__/ssh/bin/xauth
+`

--- a/sshconfig/defaults.go
+++ b/sshconfig/defaults.go
@@ -1,0 +1,74 @@
+package sshconfig
+
+import (
+	"bufio"
+	"bytes"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+var haveOpenSSH = sync.OnceValue(func() bool {
+	cmd := exec.Command("ssh", "-V")
+	return cmd.Run() == nil
+})
+
+func getFromOpenSSH(key string) string {
+	if !haveOpenSSH() {
+		return ""
+	}
+	cmd := exec.Command("ssh", "-Q", key)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	var items []string
+	for scanner.Scan() {
+		row := strings.TrimSpace(scanner.Text())
+		if row == "" {
+			continue
+		}
+		if strings.Contains(row, " ") {
+			continue
+		}
+		items = append(items, row)
+	}
+	if scanner.Err() != nil {
+		return ""
+	}
+	return strings.Join(items, ",")
+}
+
+// from openssh 9.4p1, libreSSL 3.3.6.
+const (
+	defaultCASig        = "ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,rsa-sha2-512,rsa-sha2-256"
+	defaultCiphers      = "chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com"
+	defaultHostkeyAlgos = "ssh-ed25519-cert-v01@openssh.com,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,rsa-sha2-512,rsa-sha2-256"
+	defaultKexAlgos     = "sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256"
+	defaultMACs         = "umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1"
+)
+
+// defaultList returns the default list of algos for the given key. it tries to get them from the local openssh installation when available.
+func defaultList(key string) string {
+	if fromSSH := getFromOpenSSH(key); fromSSH != "" {
+		return fromSSH
+	}
+	switch key {
+	case "casignaturealgorithms":
+		return defaultCASig
+	case "ciphers":
+		return defaultCiphers
+	case "hostbasedacceptedalgorithms":
+		return defaultHostkeyAlgos
+	case "hostkeyalgorithms":
+		return defaultHostkeyAlgos
+	case "kexalgorithms":
+		return defaultKexAlgos
+	case "macs":
+		return defaultMACs
+	case "pubkeyacceptedalgorithms":
+		return defaultHostkeyAlgos
+	}
+	return ""
+}

--- a/sshconfig/keys.go
+++ b/sshconfig/keys.go
@@ -1,0 +1,174 @@
+package sshconfig
+
+import "github.com/k0sproject/rig/v2/sshconfig/options"
+
+type setterFunc func(setter *Setter, key string, values ...string) error
+
+type printerFunc func(printer *printer, key string) (string, bool)
+
+type keyInfo struct {
+	key       string      // the canonical key as it appears in the spec, such as CanonicalizePermittedCNAMEs
+	setFunc   setterFunc  // which function to use to set the value for this key
+	printFunc printerFunc // which function to use to print the value for this key
+	tokens    []string    // the list of allowed tokens for the value of this key
+	tilde     bool        // whether tilde expansion is allowed in the value of this key
+	env       bool        // whether environment variable expansion is allowed in the value of this key
+}
+
+// These tokens are used to replace values in the config file, like %h for the hostname.
+// the tokens are not allowed in all fields, and some fields only allow a subset of tokens.
+var (
+	alltokens = []string{
+		"%%", "%C", "%d", "%f", "%H", "%h", "%I", "%i", "%j", "%K", "%k", "%L", "%l", "%n",
+		"%p", "%r", "%T", "%t", "%u",
+	}
+	tokenset1 = []string{"%%", "%C", "%d", "%h", "%i", "%j", "%k", "%L", "%l", "%n", "%p", "%r", "%u"}
+	tokenset2 = append(tokenset1, "%f", "%H", "%I", "%K", "%t")
+	tokenset3 = []string{"%%", "%h", "%n", "%p", "%r"}
+)
+
+var ( //nolint:gofumpt
+	// this is here for making the list below easier to read.
+	noTokens []string
+)
+
+const (
+	// these are here for making the list below easier to read.
+	noTilde = false
+	noEnv   = false
+)
+
+var knownKeys = map[string]keyInfo{
+	// deprecated keys (from readconf.c)
+	"cipher":                 {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"fallbacktorsh":          {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"globalknownhostsfile2":  {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"identityfile2":          {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"protocol":               {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"pubkeyacceptedkeytypes": {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"rhostsauthentication":   {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"useprivilegedport":      {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"userknownhostsfile2":    {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"useroaming":             {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"usersh":                 {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+
+	// unsupported options (from readconf.c)
+	"afstokenpassing":         {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"compressionlevel":        {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"kerberosauthentication":  {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"kerberostgtpassing":      {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"rhostsrsaauthentication": {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+	"rsaauthentication":       {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
+
+	// config structuring keys
+	fkHost:    {"Host", (*Setter).setHost, (*printer).stringer, noTokens, noTilde, noEnv},
+	"match":   {"Match", nil, nil, noTokens, noTilde, noEnv},
+	"include": {"Include", nil, nil, noTokens, noTilde, noEnv},
+
+	"addkeystoagent":                   {"AddKeysToAgent", (*Setter).setAddKeysToAgentOption, (*printer).stringer, noTokens, noTilde, noEnv},
+	"addressfamily":                    {"AddressFamily", enum("any", "inet", "inet6"), (*printer).stringer, noTokens, noTilde, noEnv},
+	"applemultipath":                   {"AppleMultiPath", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"batchmode":                        {"BatchMode", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"bindaddress":                      {"BindAddress", (*Setter).setString, (*printer).stringer, noTokens, noTilde, noEnv},
+	"bindinterface":                    {"BindInterface", (*Setter).setString, (*printer).stringer, noTokens, noTilde, noEnv},
+	"canonicaldomains":                 {"CanonicalDomains", (*Setter).setStringSlice, (*printer).stringerslice, noTokens, noTilde, noEnv},
+	"canonicalizefallbacklocal":        {"CanonicalizeFallbackLocal", (*Setter).setBool, (*printer).stringer, noTokens, noTilde, noEnv},
+	"canonicalizehostname":             {"CanonicalizeHostname", extendedBoolSetter[options.CanonicalizeHostnameOption](), (*printer).stringer, noTokens, noTilde, noEnv},
+	"canonicalizemaxdots":              {"CanonicalizeMaxDots", (*Setter).setInt, (*printer).number, noTokens, noTilde, noEnv},
+	"canonicalizepermittedcnames":      {"CanonicalizePermittedCNAMEs", (*Setter).setColonSeparatedValues, (*printer).stringerslice, noTokens, noTilde, noEnv},
+	"casignaturealgorithms":            {"CASignatureAlgorithms", preloadedDefaultsSetter(defaultList("CASignatureAlgorithms")), (*printer).stringercsv, noTokens, noTilde, noEnv},
+	"certificatefile":                  {"CertificateFile", (*Setter).appendPathList, (*printer).stringer, tokenset1, true, true},
+	"channeltimeout":                   {"ChannelTimeout", (*Setter).setChannelTimeoutOption, (*printer).channeltimeout, noTokens, noTilde, noEnv},
+	"checkhostip":                      {"CheckHostIP", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"ciphers":                          {"Ciphers", preloadedDefaultsSetter(defaultList("Ciphers")), (*printer).stringercsv, noTokens, noTilde, noEnv},
+	"clearallforwardings":              {"ClearAllForwardings", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"compression":                      {"Compression", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"connectionattempts":               {"ConnectionAttempts", (*Setter).setInt, (*printer).number, noTokens, noTilde, noEnv},
+	"connecttimeout":                   {"ConnectTimeout", (*Setter).setDuration, (*printer).duration, noTokens, noTilde, noEnv},
+	"controlmaster":                    {"ControlMaster", extendedBoolSetter[options.ControlMasterOption](), (*printer).stringer, noTokens, noTilde, noEnv},
+	"controlpath":                      {"ControlPath", (*Setter).setPath, (*printer).stringer, tokenset1, true, true},
+	"controlpersist":                   {"ControlPersist", extendedBoolSetter[options.ControlPersistOption](), (*printer).stringer, noTokens, noTilde, noEnv},
+	"dynamicforward":                   {"DynamicForward", (*Setter).appendStringList, (*printer).stringerslice, noTokens, noTilde, noEnv},
+	"enableescapecommandline":          {"EnableEscapeCommandline", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"enablesshkeysign":                 {"EnableSSHKeysign", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"escapechar":                       {"EscapeChar", (*Setter).setEscapeCharOption, (*printer).stringer, noTokens, noTilde, noEnv},
+	"exitonforwardfailure":             {"ExitOnForwardFailure", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"fingerprinthash":                  {"FingerprintHash", extendedBoolSetter[options.FingerprintHashOption](), (*printer).stringer, noTokens, noTilde, noEnv},
+	"forkafterauthentication":          {"ForkAfterAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"forwardagent":                     {"ForwardAgent", extendedBoolSetter[options.ForwardAgentOption](), (*printer).stringer, noTokens, noTilde, noEnv}, // envs handled in Option
+	"forwardx11":                       {"ForwardX11", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"forwardx11timeout":                {"ForwardX11Timeout", (*Setter).setDuration, (*printer).duration, noTokens, noTilde, noEnv},
+	"forwardx11trusted":                {"ForwardX11Trusted", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"gatewayports":                     {"GatewayPorts", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"globalknownhostsfile":             {"GlobalKnownHostsFile", (*Setter).setPathList, (*printer).stringerslice, noTokens, noTilde, noEnv},
+	"gssapiauthentication":             {"GSSAPIAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"gssapidelegatecredentials":        {"GSSAPIDelegateCredentials", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"hashknownhosts":                   {"HashKnownHosts", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"hostbasedkeytypes":                {"HostbasedAcceptedAlgorithms", preloadedDefaultsSetter(defaultList("HostbasedAcceptedAlgorithms")), (*printer).stringercsv, noTokens, noTilde, noEnv}, // (deprecated) alias
+	"hostbasedacceptedalgorithms":      {"HostbasedAcceptedAlgorithms", preloadedDefaultsSetter(defaultList("HostbasedAcceptedAlgorithms")), (*printer).stringercsv, noTokens, noTilde, noEnv},
+	"hostbasedauthentication":          {"HostbasedAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"hostkeyalgorithms":                {"HostKeyAlgorithms", preloadedDefaultsSetter(defaultList("HostKeyAlgorithms")), (*printer).stringercsv, noTokens, noTilde, noEnv},
+	"hostkeyalias":                     {"HostKeyAlias", (*Setter).setString, (*printer).stringer, noTokens, noTilde, noEnv},
+	"hostname":                         {"Hostname", (*Setter).setString, (*printer).stringer, []string{"%%", "%h"}, noTilde, noEnv},
+	"identitiesonly":                   {"IdentitiesOnly", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"identityagent":                    {"IdentityAgent", extendedBoolSetter[options.IdentityAgentOption](), (*printer).stringer, tokenset1, noTilde, noEnv},
+	"identityfile":                     {"IdentityFile", (*Setter).appendPathList, (*printer).stringerslice, tokenset1, true, noEnv},
+	"ignoreunknown":                    {"IgnoreUnknown", (*Setter).setStringSlice, (*printer).stringerslice, noTokens, noTilde, noEnv},
+	"ipqos":                            {"IPQoS", (*Setter).setIPQoSOption, (*printer).stringerslice, noTokens, noTilde, noEnv},
+	"challengeresponseauthentication":  {"KbdInteractiveAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv}, // alias
+	"skeyauthentication":               {"KbdInteractiveAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv}, // alias
+	"tisauthentication":                {"KbdInteractiveAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv}, // alias
+	"kbdinteractiveauthentication":     {"KbdInteractiveAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"kbdinteractivedevices":            {"KbdInteractiveDevices", (*Setter).setStringSliceCSV, (*printer).stringercsv, noTokens, noTilde, noEnv},
+	"kexalgorithms":                    {"KexAlgorithms", preloadedDefaultsSetter(defaultList("KexAlgorithms")), (*printer).stringercsv, noTokens, noTilde, noEnv},
+	"knownhostscommand":                {"KnownHostsCommand", (*Setter).setString, (*printer).stringer, tokenset2, noTilde, noEnv},
+	"localcommand":                     {"LocalCommand", (*Setter).setString, (*printer).stringer, alltokens, noTilde, noEnv},
+	"localforward":                     {"LocalForward", (*Setter).setForwardOption, (*printer).forward, tokenset1, noTilde, noEnv},
+	"loglevel":                         {"LogLevel", enum("QUIET", "FATAL", "ERROR", "INFO", "VERBOSE", "DEBUG", "DEBUG1", "DEBUG2", "DEBUG3"), (*printer).stringer, noTokens, noTilde, noEnv},
+	"logverbose":                       {"LogVerbose", (*Setter).setStringSlice, (*printer).stringerslice, noTokens, noTilde, noEnv},
+	"macs":                             {"MACs", preloadedDefaultsSetter(defaultList("MACs")), (*printer).stringercsv, noTokens, noTilde, noEnv},
+	"nohostauthenticationforlocalhost": {"NoHostAuthenticationForLocalhost", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"numberofpasswordprompts":          {"NumberOfPasswordPrompts", (*Setter).setInt, (*printer).number, noTokens, noTilde, noEnv},
+	"obscurekeystroketiming":           {"ObscureKeystrokeTiming", extendedBoolSetter[options.ObscureKeystrokeTimingOption](), (*printer).stringer, noTokens, noTilde, noEnv},
+	"passwordauthentication":           {"PasswordAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"permitlocalcommand":               {"PermitLocalCommand", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"permitremoteopen":                 {"PermitRemoteOpen", (*Setter).setColonSeparatedValues, (*printer).stringerslice, noTokens, noTilde, noEnv},
+	"pkcs11provider":                   {"PKCS11Provider", (*Setter).setString, (*printer).stringer, noTokens, noTilde, noEnv}, // env?
+	"port":                             {"Port", (*Setter).setPort, (*printer).number, noTokens, noTilde, noEnv},
+	"preferredauthentications":         {"PreferredAuthentications", (*Setter).setStringSliceCSV, (*printer).stringercsv, noTokens, noTilde, noEnv},
+	"proxycommand":                     {"ProxyCommand", (*Setter).setString, (*printer).stringer, tokenset3, noTilde, noEnv},
+	"proxyjump":                        {"ProxyJump", (*Setter).setStringSliceCSV, (*printer).stringercsv, tokenset3, noTilde, noEnv},
+	"proxyusefdpass":                   {"ProxyUseFdpass", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"pubkeyacceptedalgorithms":         {"PubkeyAcceptedAlgorithms", preloadedDefaultsSetter(defaultList("PubkeyAcceptedAlgorithms")), (*printer).stringercsv, noTokens, noTilde, noEnv},
+	"dsaauthentication":                {"PubkeyAuthentication", extendedBoolSetter[options.PubkeyAuthenticationOption](), (*printer).stringer, noTokens, noTilde, noEnv}, // alias
+	"pubkeyauthentication":             {"PubkeyAuthentication", extendedBoolSetter[options.PubkeyAuthenticationOption](), (*printer).stringer, noTokens, noTilde, noEnv},
+	"rekeylimit":                       {"RekeyLimit", (*Setter).setRekeyLimitOption, (*printer).stringer, noTokens, noTilde, noEnv},
+	"remotecommand":                    {"RemoteCommand", (*Setter).setString, (*printer).stringer, tokenset1, noTilde, noEnv},
+	"remoteforward":                    {"RemoteForward", (*Setter).setForwardOption, (*printer).forward, tokenset1, noTilde, noEnv},
+	"requesttty":                       {"RequestTTY", extendedBoolSetter[options.RequestTTYOption](), (*printer).stringer, noTokens, noTilde, noEnv},
+	"requiredrsasize":                  {"RequiredRSASize", (*Setter).setInt, (*printer).number, noTokens, noTilde, noEnv},
+	"revokedhostkeys":                  {"RevokedHostKeys", (*Setter).setPath, (*printer).stringer, tokenset1, true, true},
+	"securitykeyprovider":              {"SecurityKeyProvider", (*Setter).setString, (*printer).stringer, noTokens, noTilde, true}, // env should support $var syntax?
+	"sendenv":                          {"SendEnv", (*Setter).setSendEnvOption, (*printer).stringerslice, noTokens, noTilde, noEnv},
+	"serveralivecountmax":              {"ServerAliveCountMax", (*Setter).setInt, (*printer).number, noTokens, noTilde, noEnv},
+	"serveraliveinterval":              {"ServerAliveInterval", (*Setter).setDuration, (*printer).number, noTokens, noTilde, noEnv},
+	"sessiontype":                      {"SessionType", enum("none", "subsystem", "default"), (*printer).stringer, noTokens, noTilde, noEnv},
+	"setenv":                           {"SetEnv", (*Setter).setSetEnvOption, (*printer).stringerslice, noTokens, noTilde, noEnv},
+	"smartcarddevice":                  {"SmartcardDevice", (*Setter).setString, (*printer).stringer, noTokens, noTilde, noEnv},
+	"stdinnull":                        {"StdinNull", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"streamlocalbindmask":              {"StreamLocalBindMask", (*Setter).setUint, (*printer).number, noTokens, noTilde, noEnv},
+	"streamlocalbindunlink":            {"StreamLocalBindUnlink", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"stricthostkeychecking":            {"StrictHostKeyChecking", extendedBoolSetter[options.StrictHostKeyCheckingOption](), (*printer).stringer, noTokens, noTilde, noEnv},
+	"syslogfacility":                   {"SyslogFacility", enum("DAEMON", "USER", "AUTH", "AUTHPRIV", "LOCAL0", "LOCAL1", "LOCAL2", "LOCAL3", "LOCAL4", "LOCAL5", "LOCAL6", "LOCAL7"), (*printer).stringer, noTokens, noTilde, noEnv},
+	"tag":                              {"Tag", (*Setter).setString, (*printer).stringer, noTokens, noTilde, noEnv},
+	"tcpkeepalive":                     {"TCPKeepAlive", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"tunnel":                           {"Tunnel", extendedBoolSetter[options.TunnelOption](), (*printer).stringer, noTokens, noTilde, noEnv},
+	"tunneldevice":                     {"TunnelDevice", (*Setter).setString, (*printer).stringer, noTokens, noTilde, noEnv},
+	"updatehostkeys":                   {"UpdateHostKeys", extendedBoolSetter[options.UpdateHostKeysOption](), (*printer).stringer, noTokens, noTilde, noEnv},
+	"usekeychain":                      {"UseKeychain", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"user":                             {"User", (*Setter).setString, (*printer).stringer, noTokens, noTilde, noEnv},
+	"userknownhostsfile":               {"UserKnownHostsFile", (*Setter).setPathList, (*printer).stringerslice, tokenset1, true, true},
+	"verifyhostkeydns":                 {"VerifyHostKeyDNS", extendedBoolSetter[options.VerifyHostKeyDNSOption](), (*printer).stringer, noTokens, noTilde, noEnv},
+	"visualhostkey":                    {"VisualHostKey", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"xauthlocation":                    {"XAuthLocation", (*Setter).setPath, (*printer).stringer, noTokens, noTilde, noEnv},
+}

--- a/sshconfig/options/options.go
+++ b/sshconfig/options/options.go
@@ -1,0 +1,931 @@
+// Package options defines a number of types that represent options that can be set in the SSH configuration file.
+package options
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	boolTrue   = "true"
+	boolFalse  = "false"
+	boolYes    = "yes"
+	boolNo     = "no"
+	optAsk     = "ask"
+	optConfirm = "confirm"
+	optAlways  = "always"
+	optAuto    = "auto"
+	optAutoAsk = "autoask"
+	optNone    = "none"
+)
+
+var (
+	errInvalidValue = errors.New("invalid value")
+
+	userhome = sync.OnceValue(
+		func() string {
+			if home, err := os.UserHomeDir(); err == nil {
+				return home
+			}
+			return ""
+		},
+	)
+)
+
+// BooleanOption is an option that can be set to yes or no.
+type BooleanOption string
+
+const (
+	BooleanOptionNo  = BooleanOption(boolNo)
+	BooleanOptionYes = BooleanOption(boolYes)
+)
+
+// IsTrue returns true if the option is set to yes.
+func (b BooleanOption) IsTrue() bool {
+	return b == boolYes
+}
+
+// IsFalse returns true if the option is set to no.
+func (b BooleanOption) IsFalse() bool {
+	return b == boolNo
+}
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (b BooleanOption) Normalize() (BooleanOption, error) {
+	switch string(b) {
+	case boolNo, boolFalse:
+		return BooleanOptionNo, nil
+	case boolYes, boolTrue:
+		return BooleanOptionYes, nil
+	}
+	return "", fmt.Errorf("%w: invalid value %q for a boolean option", errInvalidValue, b)
+}
+
+// String returns the string representation of the option.
+func (b BooleanOption) String() string {
+	return string(b)
+}
+
+// CanonicalizeHostnameOption is an option that can be set to no, yes or always.
+type CanonicalizeHostnameOption string
+
+const (
+	CanonicalizeHostnameNo     = CanonicalizeHostnameOption(boolNo)
+	CanonicalizeHostnameYes    = CanonicalizeHostnameOption(boolYes)
+	CanonicalizeHostnameAlways = CanonicalizeHostnameOption(optAlways)
+)
+
+var CanonicalizeHostnameOptions = map[string]CanonicalizeHostnameOption{
+	boolNo:    CanonicalizeHostnameNo,
+	boolFalse: CanonicalizeHostnameNo,
+	boolYes:   CanonicalizeHostnameYes,
+	boolTrue:  CanonicalizeHostnameYes,
+	optAlways: CanonicalizeHostnameAlways,
+}
+
+// IsTrue returns true if the option is set to yes or always.
+func (c CanonicalizeHostnameOption) IsTrue() bool {
+	return c == boolYes || c == optAlways
+}
+
+// IsFalse returns true if the option is set to no.
+func (c CanonicalizeHostnameOption) IsFalse() bool {
+	return c == boolNo
+}
+
+// IsAlways returns true if the option is set to always.
+func (c CanonicalizeHostnameOption) IsAlways() bool {
+	return c == optAlways
+}
+
+// String returns the string representation of the option.
+func (c CanonicalizeHostnameOption) String() string {
+	return string(c)
+}
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (c CanonicalizeHostnameOption) Normalize() (CanonicalizeHostnameOption, error) {
+	if nv, ok := CanonicalizeHostnameOptions[string(c)]; ok {
+		return nv, nil
+	}
+
+	return "", fmt.Errorf("%w: invalid value %q for CanonicalizeHostname", errInvalidValue, c)
+}
+
+// AddKeysToAgentOption is an extended boolean option that can be set to yes, no, ask, confirm,
+// confirm with a time interval or a time interval.
+type AddKeysToAgentOption string
+
+var errNoInterval = errors.New("no interval")
+
+const (
+	AddKeysToAgentNo      = AddKeysToAgentOption(boolNo)
+	AddKeysToAgentYes     = AddKeysToAgentOption(boolYes)
+	AddKeysToAgentAsk     = AddKeysToAgentOption(optAsk)
+	AddKeysToAgentConfirm = AddKeysToAgentOption(optConfirm)
+)
+
+// IsTrue returns true if the option is set to yes.
+func (a AddKeysToAgentOption) IsTrue() bool {
+	return a == boolYes
+}
+
+// IsFalse returns true if the option is set to no.
+func (a AddKeysToAgentOption) IsFalse() bool {
+	return a == boolNo
+}
+
+// HasInterval returns true if the option has an interval set.
+func (a AddKeysToAgentOption) HasInterval() bool {
+	return (a.IsConfirm() && a[len(a)-1] >= '0' && a[len(a)-1] <= '0') || (a[0] >= '0' && a[0] <= '9')
+}
+
+// IsAsk returns true if the option is set to ask.
+func (a AddKeysToAgentOption) IsAsk() bool {
+	return a == optAsk
+}
+
+// IsConfirm returns true if the option is set to confirm.
+func (a AddKeysToAgentOption) IsConfirm() bool {
+	return strings.HasPrefix(string(a), "confirm ")
+}
+
+// Interval returns the time interval set in the option. If the option does not have an interval an error is returned.
+func (a AddKeysToAgentOption) Interval() (time.Duration, error) {
+	if !a.HasInterval() {
+		return 0, errNoInterval
+	}
+	str := strings.TrimPrefix(string(a), "confirm ")
+
+	d, err := time.ParseDuration(AddIntervalSuffix(str))
+	if err != nil {
+		return 0, fmt.Errorf("invalid interval: %w", err)
+	}
+	return d, nil
+}
+
+// String returns the string representation of the option.
+func (a AddKeysToAgentOption) String() string {
+	return string(a)
+}
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (a AddKeysToAgentOption) Normalize() (AddKeysToAgentOption, error) {
+	switch string(a) {
+	case boolNo, boolFalse:
+		return AddKeysToAgentNo, nil
+	case boolYes, boolTrue:
+		return AddKeysToAgentYes, nil
+	case optAsk:
+		return AddKeysToAgentAsk, nil
+	case optConfirm:
+		return AddKeysToAgentConfirm, nil
+	}
+
+	if a.HasInterval() {
+		return a, nil
+	}
+
+	return "", fmt.Errorf("%w: invalid value %q for AddKeysToAgent", errInvalidValue, a)
+}
+
+// ControlMasterOption is an extended boolean option that can be set to yes, no, ask, auto or autoask.
+type ControlMasterOption string
+
+const (
+	ControlMasterNo      = ControlMasterOption(boolNo)
+	ControlMasterYes     = ControlMasterOption(boolYes)
+	ControlMasterAsk     = ControlMasterOption(optAsk)
+	ControlMasterAuto    = ControlMasterOption(optAuto)
+	ControlMasterAutoAsk = ControlMasterOption(optAutoAsk)
+)
+
+var ControlMasterOptions = map[string]ControlMasterOption{
+	boolNo:     ControlMasterNo,
+	boolFalse:  ControlMasterNo,
+	boolYes:    ControlMasterYes,
+	boolTrue:   ControlMasterYes,
+	optAsk:     ControlMasterAsk,
+	optAuto:    ControlMasterAuto,
+	optAutoAsk: ControlMasterAutoAsk,
+}
+
+// IsTrue returns true if the option is set to yes.
+func (c ControlMasterOption) IsTrue() bool {
+	return c == ControlMasterYes
+}
+
+// IsFalse returns true if the option is set to no.
+func (c ControlMasterOption) IsFalse() bool {
+	return c == ControlMasterNo
+}
+
+// IsAsk returns true if the option is set to ask.
+func (c ControlMasterOption) IsAsk() bool {
+	return c == ControlMasterAsk
+}
+
+// IsAuto returns true if the option is set to auto.
+func (c ControlMasterOption) IsAuto() bool {
+	return c == ControlMasterAuto
+}
+
+// IsAutoAsk returns true if the option is set to autoask.
+func (c ControlMasterOption) IsAutoAsk() bool {
+	return c == ControlMasterAutoAsk
+}
+
+// String returns the string representation of the option.
+func (c ControlMasterOption) String() string {
+	return string(c)
+}
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (c ControlMasterOption) Normalize() (ControlMasterOption, error) {
+	if nv, ok := ControlMasterOptions[string(c)]; ok {
+		return nv, nil
+	}
+
+	return "", fmt.Errorf("%w: invalid value %q for ControlMaster", errInvalidValue, c)
+}
+
+// ControlPersistOption is an extended boolean option that can be set to yes, no or a time interval.
+type ControlPersistOption string
+
+const (
+	ControlPersistOptionNo  = ControlPersistOption(boolNo)
+	ControlPersistOptionYes = ControlPersistOption(boolYes)
+)
+
+// IsTrue returns true if the option is set to yes or 0.
+func (c ControlPersistOption) IsTrue() bool {
+	return c == ControlPersistOptionYes || c == "0"
+}
+
+// IsFalse returns true if the option is set to no.
+func (c ControlPersistOption) IsFalse() bool {
+	return c == ControlPersistOptionNo
+}
+
+// HasInterval returns true if the option has an interval set.
+func (c ControlPersistOption) HasInterval() bool {
+	return c[0] >= '0' && c[0] <= '9'
+}
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (c ControlPersistOption) Normalize() (ControlPersistOption, error) {
+	switch string(c) {
+	case boolNo, boolFalse:
+		return ControlPersistOptionNo, nil
+	case boolYes, boolTrue:
+		return ControlPersistOptionYes, nil
+	}
+
+	if c.HasInterval() {
+		return c, nil
+	}
+
+	return "", fmt.Errorf("%w: invalid value %q for ControlPersist", errInvalidValue, c)
+}
+
+// Interval returns the time interval set in the option. If the option does not have an interval an error is returned.
+func (c ControlPersistOption) Interval() (time.Duration, error) {
+	if !c.HasInterval() {
+		return 0, errNoInterval
+	}
+	d, err := time.ParseDuration(AddIntervalSuffix(string(c)))
+	if err != nil {
+		return 0, fmt.Errorf("invalid interval: %w", err)
+	}
+	return d, nil
+}
+
+// String returns the string representation of the option.
+func (c ControlPersistOption) String() string {
+	return string(c)
+}
+
+// FingerprintHashOption is an option that can be set to md5 or sha256.
+type FingerprintHashOption string
+
+const (
+	FingerprintHashMD5    = FingerprintHashOption("MD5")
+	FingerprintHashSHA256 = FingerprintHashOption("SHA256")
+)
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (f FingerprintHashOption) Normalize() (FingerprintHashOption, error) {
+	switch strings.ToLower(string(f)) {
+	case "md5":
+		return FingerprintHashMD5, nil
+	case "sha256":
+		return FingerprintHashSHA256, nil
+	default:
+		return "", fmt.Errorf("%w: invalid value %q for FingerprintHash", errInvalidValue, f)
+	}
+}
+
+// String returns the string representation of the option.
+func (f FingerprintHashOption) String() string {
+	return string(f)
+}
+
+// ForwardAgentOption is an extended boolean option that can be set to yes, no or a path to an agent socket
+// or the name of an environment variable prefixed with a dollar sign.
+type ForwardAgentOption string
+
+const (
+	ForwardAgentNo  = ForwardAgentOption(boolNo)
+	ForwardAgentYes = ForwardAgentOption(boolYes)
+)
+
+// IsTrue returns true if the option is set to yes.
+func (f ForwardAgentOption) IsTrue() bool {
+	return f == ForwardAgentYes
+}
+
+// IsFalse returns true if the option is set to no.
+func (f ForwardAgentOption) IsFalse() bool {
+	return f == ForwardAgentNo
+}
+
+// IsSocket returns true if the option is non-empty and not a boolean value.
+func (f ForwardAgentOption) IsSocket() bool {
+	return !f.IsTrue() && !f.IsFalse() && f != ""
+}
+
+// Socket returns the path to the agent socket or the value of the environment variable.
+func (f ForwardAgentOption) Socket() string {
+	if f.IsTrue() || f.IsFalse() {
+		return ""
+	}
+	str := string(f)
+	if strings.HasPrefix(str, "$") {
+		return os.ExpandEnv(str)
+	}
+	if strings.HasPrefix(str, "~/") {
+		return userhome() + str[1:]
+	}
+	return str
+}
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (f ForwardAgentOption) Normalize() (ForwardAgentOption, error) {
+	switch string(f) {
+	case boolNo, boolFalse:
+		return ForwardAgentNo, nil
+	case boolYes, boolTrue:
+		return ForwardAgentYes, nil
+	}
+
+	if f != "" {
+		return f, nil
+	}
+
+	return "", fmt.Errorf("%w: invalid value %q for ForwardAgent", errInvalidValue, f)
+}
+
+// String returns the string representation of the option.
+func (f ForwardAgentOption) String() string {
+	return string(f)
+}
+
+// IdentityAgentOption is an option that can be set to a path to an agent socket or the name of an environment variable prefixed with a dollar sign.
+type IdentityAgentOption string
+
+// String returns the string representation of the option.
+func (i IdentityAgentOption) String() string {
+	return string(i)
+}
+
+// Socket returns the path to the agent socket or the value of the environment variable.
+func (i IdentityAgentOption) Socket() string {
+	str := string(i)
+	if str == "" {
+		return ""
+	}
+	if str == "SSH_AUTH_SOCK" {
+		return os.Getenv("SSH_AUTH_SOCK")
+	}
+	if strings.HasPrefix(str, "$") {
+		return os.ExpandEnv(str)
+	}
+	if strings.HasPrefix(str, "~/") {
+		return userhome() + str[1:]
+	}
+	return str
+}
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+// The value is always valid but the function is provided for consistency.
+func (i IdentityAgentOption) Normalize() (IdentityAgentOption, error) {
+	return i, nil
+}
+
+// ObscureKeystrokeTimingOption is an extended boolean option that can be set to yes, no or interval:ms.
+type ObscureKeystrokeTimingOption string
+
+const (
+	ObscureKeystrokeTimingOptionNo  = ObscureKeystrokeTimingOption(boolNo)
+	ObscureKeystrokeTimingOptionYes = ObscureKeystrokeTimingOption(boolYes)
+)
+
+// IsTrue returns true if the option is set to yes.
+func (o ObscureKeystrokeTimingOption) IsTrue() bool {
+	return o == ObscureKeystrokeTimingOptionYes
+}
+
+// IsFalse returns true if the option is set to no.
+func (o ObscureKeystrokeTimingOption) IsFalse() bool {
+	return o == ObscureKeystrokeTimingOptionNo
+}
+
+// String returns the string representation of the option.
+func (o ObscureKeystrokeTimingOption) String() string {
+	return string(o)
+}
+
+// HasInterval returns true if the option has an interval set.
+func (o ObscureKeystrokeTimingOption) HasInterval() bool {
+	_, err := o.Interval()
+	return err == nil
+}
+
+// Interval returns the time interval set in the option. If the option does not have an interval an error is returned.
+func (o ObscureKeystrokeTimingOption) Interval() (time.Duration, error) {
+	if !strings.HasPrefix(string(o), "interval:") {
+		return 0, errNoInterval
+	}
+	i, err := strconv.Atoi(string(o)[9:])
+	if err != nil {
+		return 0, fmt.Errorf("invalid interval: %w", err)
+	}
+	return time.Duration(i) * time.Millisecond, nil
+}
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (o ObscureKeystrokeTimingOption) Normalize() (ObscureKeystrokeTimingOption, error) {
+	switch string(o) {
+	case boolNo, boolFalse:
+		return ObscureKeystrokeTimingOptionNo, nil
+	case boolYes, boolTrue:
+		return ObscureKeystrokeTimingOptionYes, nil
+	}
+
+	if o.HasInterval() {
+		return o, nil
+	}
+	return "", fmt.Errorf("%w: invalid value %q for ObscureKeystrokeTiming", errInvalidValue, o)
+}
+
+// Adds an "s" suffix to a duration string if it ends with a number.
+func AddIntervalSuffix(s string) string {
+	if s[len(s)-1] >= '0' && s[len(s)-1] <= '9' {
+		return s + "s"
+	}
+	return s
+}
+
+// IPQoSOption is the type for the IPQoS option.
+type IPQoSOption string
+
+const (
+	IPQoSOptionAf11        = IPQoSOption("af11")
+	IPQoSOptionAf12        = IPQoSOption("af12")
+	IPQoSOptionAf13        = IPQoSOption("af13")
+	IPQoSOptionAf21        = IPQoSOption("af21")
+	IPQoSOptionAf22        = IPQoSOption("af22")
+	IPQoSOptionAf23        = IPQoSOption("af23")
+	IPQoSOptionAf31        = IPQoSOption("af31")
+	IPQoSOptionAf32        = IPQoSOption("af32")
+	IPQoSOptionAf33        = IPQoSOption("af33")
+	IPQoSOptionAf41        = IPQoSOption("af41")
+	IPQoSOptionAf42        = IPQoSOption("af42")
+	IPQoSOptionAf43        = IPQoSOption("af43")
+	IPQoSOptionCs0         = IPQoSOption("cs0")
+	IPQoSOptionCs1         = IPQoSOption("cs1")
+	IPQoSOptionCs2         = IPQoSOption("cs2")
+	IPQoSOptionCs3         = IPQoSOption("cs3")
+	IPQoSOptionCs4         = IPQoSOption("cs4")
+	IPQoSOptionCs5         = IPQoSOption("cs5")
+	IPQoSOptionCs6         = IPQoSOption("cs6")
+	IPQoSOptionCs7         = IPQoSOption("cs7")
+	IPQoSOptionEf          = IPQoSOption("ef")
+	IPQoSOptionLe          = IPQoSOption("le")
+	IPQoSOptionLowDelay    = IPQoSOption("lowdelay")
+	IPQoSOptionThroughput  = IPQoSOption("throughput")
+	IPQoSOptionReliability = IPQoSOption("reliability")
+	IPQoSOptionNone        = IPQoSOption(optNone)
+)
+
+var IPQoSOptions = map[string]IPQoSOption{
+	"af11":        IPQoSOptionAf11,
+	"af12":        IPQoSOptionAf12,
+	"af13":        IPQoSOptionAf13,
+	"af21":        IPQoSOptionAf21,
+	"af22":        IPQoSOptionAf22,
+	"af23":        IPQoSOptionAf23,
+	"af31":        IPQoSOptionAf31,
+	"af32":        IPQoSOptionAf32,
+	"af33":        IPQoSOptionAf33,
+	"af41":        IPQoSOptionAf41,
+	"af42":        IPQoSOptionAf42,
+	"af43":        IPQoSOptionAf43,
+	"cs0":         IPQoSOptionCs0,
+	"cs1":         IPQoSOptionCs1,
+	"cs2":         IPQoSOptionCs2,
+	"cs3":         IPQoSOptionCs3,
+	"cs4":         IPQoSOptionCs4,
+	"cs5":         IPQoSOptionCs5,
+	"cs6":         IPQoSOptionCs6,
+	"cs7":         IPQoSOptionCs7,
+	"ef":          IPQoSOptionEf,
+	"le":          IPQoSOptionLe,
+	"lowdelay":    IPQoSOptionLowDelay,
+	"throughput":  IPQoSOptionThroughput,
+	"reliability": IPQoSOptionReliability,
+	optNone:       IPQoSOptionNone,
+}
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (o IPQoSOption) Normalize() (IPQoSOption, error) {
+	if _, ok := IPQoSOptions[string(o)]; ok {
+		return o, nil
+	}
+	return "", fmt.Errorf("%w: invalid value %q for IPQoS", errInvalidValue, o)
+}
+
+// String returns the string representation of the option.
+func (o IPQoSOption) String() string {
+	if o == "" {
+		return optNone
+	}
+	return string(o)
+}
+
+// PubkeyAuthenticationOption is the type for the PubkeyAuthentication option.
+type PubkeyAuthenticationOption string
+
+const (
+	PubkeyAuthenticationOptionYes       = PubkeyAuthenticationOption(boolYes)
+	PubkeyAuthenticationOptionNo        = PubkeyAuthenticationOption(boolNo)
+	PubkeyAuthenticationOptionUnbound   = PubkeyAuthenticationOption("unbound")
+	PubkeyAuthenticationOptionHostbound = PubkeyAuthenticationOption("host-bound")
+)
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (o PubkeyAuthenticationOption) Normalize() (PubkeyAuthenticationOption, error) {
+	switch string(o) {
+	case boolYes, boolTrue:
+		return PubkeyAuthenticationOptionYes, nil
+	case boolNo, boolFalse:
+		return PubkeyAuthenticationOptionNo, nil
+	case "unbound":
+		return PubkeyAuthenticationOptionUnbound, nil
+	case "host-bound":
+		return PubkeyAuthenticationOptionHostbound, nil
+	}
+	return "", fmt.Errorf("%w: invalid value %q for PubkeyAuthentication", errInvalidValue, o)
+}
+
+// String returns the string representation of the option.
+func (o PubkeyAuthenticationOption) String() string {
+	return string(o)
+}
+
+// IsTrue returns true if the option is true.
+func (o PubkeyAuthenticationOption) IsTrue() bool {
+	return o == PubkeyAuthenticationOptionYes
+}
+
+// IsFalse returns true if the option is false.
+func (o PubkeyAuthenticationOption) IsFalse() bool {
+	return o == PubkeyAuthenticationOptionNo
+}
+
+// RekeyLimitOption is the type for the RekeyLimit option.
+type RekeyLimitOption struct {
+	MaxData int64
+	MaxTime time.Duration
+}
+
+// String returns the string representation of the option.
+// If MaxData lines up with a K, M, or G suffix, it will be printed as such.
+// If MaxTime is under a minute, it will be printed as a number of seconds.
+func (o RekeyLimitOption) String() string {
+	if o.MaxData == 0 && o.MaxTime == 0 {
+		return ""
+	}
+	sb := &strings.Builder{}
+	switch {
+	case o.MaxData >= 1024*1024*1024 && o.MaxData%(1024*1024*1024) == 0:
+		fmt.Fprintf(sb, "%dG", o.MaxData/(1024*1024*1024))
+	case o.MaxData >= 1024*1024 && o.MaxData%(1024*1024) == 0:
+		fmt.Fprintf(sb, "%dM", o.MaxData/(1024*1024))
+	case o.MaxData >= 1024 && o.MaxData%1024 == 0:
+		fmt.Fprintf(sb, "%dK", o.MaxData/1024)
+	default:
+		sb.WriteString(strconv.FormatInt(o.MaxData, 10))
+	}
+	if o.MaxTime > 0 {
+		sb.WriteByte(' ')
+		if o.MaxTime < time.Minute {
+			// write seconds as just numbers
+			sb.WriteString(strconv.Itoa(int(time.Duration(o.MaxTime.Seconds()))))
+		} else {
+			sb.WriteString(formatDuration(o.MaxTime))
+		}
+	}
+	return sb.String()
+}
+
+func formatDuration(duration time.Duration) string {
+	var parts []string
+
+	hours := int(duration.Hours())
+	if hours > 0 {
+		parts = append(parts, fmt.Sprintf("%dh", hours))
+		duration -= time.Duration(hours) * time.Hour
+	}
+
+	minutes := int(duration.Minutes())
+	if minutes > 0 {
+		parts = append(parts, fmt.Sprintf("%dm", minutes))
+		duration -= time.Duration(minutes) * time.Minute
+	}
+
+	seconds := int(duration.Seconds())
+	if seconds > 0 {
+		parts = append(parts, fmt.Sprintf("%ds", seconds))
+	}
+
+	return strings.Join(parts, "")
+}
+
+// RequestTTYOption is the type for the RequestTTY option.
+type RequestTTYOption string
+
+const (
+	RequestTTYOptionYes   = RequestTTYOption(boolYes)
+	RequestTTYOptionNo    = RequestTTYOption(boolNo)
+	RequestTTYOptionForce = RequestTTYOption("force")
+	RequestTTYOptionAuto  = RequestTTYOption(optAuto)
+)
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (r RequestTTYOption) Normalize() (RequestTTYOption, error) {
+	switch string(r) {
+	case boolYes, boolTrue:
+		return RequestTTYOptionYes, nil
+	case boolNo, boolFalse:
+		return RequestTTYOptionNo, nil
+	case "force":
+		return RequestTTYOptionForce, nil
+	case optAuto:
+		return RequestTTYOptionAuto, nil
+	}
+	return "", fmt.Errorf("%w: invalid value %q for RequestTTY", errInvalidValue, r)
+}
+
+// IsTrue returns true if the option is true.
+func (r RequestTTYOption) IsTrue() bool {
+	return r == RequestTTYOptionYes
+}
+
+// IsFalse returns true if the option is false.
+func (r RequestTTYOption) IsFalse() bool {
+	return r == RequestTTYOptionNo
+}
+
+// String returns the string representation of the option.
+func (r RequestTTYOption) String() string {
+	return string(r)
+}
+
+// StrictHostKeyCheckingOption is the type for the StrictHostKeyChecking option.
+type StrictHostKeyCheckingOption string
+
+const (
+	StrictHostKeyCheckingOptionYes       = StrictHostKeyCheckingOption(boolYes)
+	StrictHostKeyCheckingOptionNo        = StrictHostKeyCheckingOption(boolNo)
+	StrictHostKeyCheckingOptionAcceptNew = StrictHostKeyCheckingOption("accept-new")
+	StrictHostKeyCheckingOptionAsk       = StrictHostKeyCheckingOption(optAsk)
+)
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (s StrictHostKeyCheckingOption) Normalize() (StrictHostKeyCheckingOption, error) {
+	switch string(s) {
+	case boolYes, boolTrue:
+		return StrictHostKeyCheckingOptionYes, nil
+	case boolNo, boolFalse, "off":
+		return StrictHostKeyCheckingOptionNo, nil
+	case "accept-new":
+		return StrictHostKeyCheckingOptionAcceptNew, nil
+	case optAsk:
+		return StrictHostKeyCheckingOptionAsk, nil
+	}
+	return "", fmt.Errorf("%w: invalid value %q for StrictHostKeyChecking", errInvalidValue, s)
+}
+
+// IsTrue returns true if the option is true.
+func (s StrictHostKeyCheckingOption) IsTrue() bool {
+	return s == StrictHostKeyCheckingOptionYes
+}
+
+// IsFalse returns true if the option is false.
+func (s StrictHostKeyCheckingOption) IsFalse() bool {
+	return s == StrictHostKeyCheckingOptionNo
+}
+
+// IsAsk returns true if the option is "ask".
+func (s StrictHostKeyCheckingOption) IsAsk() bool {
+	return s == StrictHostKeyCheckingOptionAsk
+}
+
+// IsAcceptNew returns true if the option is "accept-new".
+func (s StrictHostKeyCheckingOption) IsAcceptNew() bool {
+	return s == StrictHostKeyCheckingOptionAcceptNew
+}
+
+// String returns the string representation of the option.
+func (s StrictHostKeyCheckingOption) String() string {
+	return string(s)
+}
+
+// TunnelOption is the type for the Tunnel option.
+type TunnelOption string
+
+const (
+	TunnelOptionYes          = TunnelOption(boolYes)
+	TunnelOptionNo           = TunnelOption(boolNo)
+	TunnelOptionPointToPoint = TunnelOption("point-to-point")
+	TunnelOptionEthernet     = TunnelOption("ethernet")
+)
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (t TunnelOption) Normalize() (TunnelOption, error) {
+	switch string(t) {
+	case boolYes, boolTrue:
+		return TunnelOptionYes, nil
+	case boolNo, boolFalse:
+		return TunnelOptionNo, nil
+	case "point-to-point":
+		return TunnelOptionPointToPoint, nil
+	case "ethernet":
+		return TunnelOptionEthernet, nil
+	}
+	return "", fmt.Errorf("%w: invalid value %q for Tunnel", errInvalidValue, t)
+}
+
+// IsTrue returns true if the option is true.
+func (t TunnelOption) IsTrue() bool {
+	return t == TunnelOptionYes
+}
+
+// IsFalse returns true if the option is false.
+func (t TunnelOption) IsFalse() bool {
+	return t == TunnelOptionNo
+}
+
+// String returns the string representation of the option.
+func (t TunnelOption) String() string {
+	return string(t)
+}
+
+// UpdateHostKeysOption is the type for the UpdateHostKeys option.
+type UpdateHostKeysOption string
+
+const (
+	UpdateHostKeysOptionYes = UpdateHostKeysOption(boolYes)
+	UpdateHostKeysOptionNo  = UpdateHostKeysOption(boolNo)
+	UpdateHostKeysOptionAsk = UpdateHostKeysOption(optAsk)
+)
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (u UpdateHostKeysOption) Normalize() (UpdateHostKeysOption, error) {
+	switch string(u) {
+	case boolYes, boolTrue:
+		return UpdateHostKeysOptionYes, nil
+	case boolNo, boolFalse:
+		return UpdateHostKeysOptionNo, nil
+	case optAsk:
+		return UpdateHostKeysOptionAsk, nil
+	}
+	return "", fmt.Errorf("%w: invalid value %q for UpdateHostKeys", errInvalidValue, u)
+}
+
+// IsTrue returns true if the option is true.
+func (u UpdateHostKeysOption) IsTrue() bool {
+	return u == UpdateHostKeysOptionYes
+}
+
+// IsFalse returns true if the option is false.
+func (u UpdateHostKeysOption) IsFalse() bool {
+	return u == UpdateHostKeysOptionNo
+}
+
+// IsAsk returns true if the option is "ask".
+func (u UpdateHostKeysOption) IsAsk() bool {
+	return u == UpdateHostKeysOptionAsk
+}
+
+// String returns the string representation of the option.
+func (u UpdateHostKeysOption) String() string {
+	return string(u)
+}
+
+// VerifyHostKeyDNSOption is the type for the UpdateHostKeys option.
+type VerifyHostKeyDNSOption string
+
+const (
+	VerifyHostKeyDNSOptionYes = VerifyHostKeyDNSOption(boolYes)
+	VerifyHostKeyDNSOptionNo  = VerifyHostKeyDNSOption(boolNo)
+	VerifyHostKeyDNSOptionAsk = VerifyHostKeyDNSOption(optAsk)
+)
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (u VerifyHostKeyDNSOption) Normalize() (VerifyHostKeyDNSOption, error) {
+	switch string(u) {
+	case boolYes, boolTrue:
+		return VerifyHostKeyDNSOptionYes, nil
+	case boolNo, boolFalse:
+		return VerifyHostKeyDNSOptionNo, nil
+	case optAsk:
+		return VerifyHostKeyDNSOptionAsk, nil
+	}
+	return "", fmt.Errorf("%w: invalid value %q for UpdateHostKeys", errInvalidValue, u)
+}
+
+// IsTrue returns true if the option is true.
+func (u VerifyHostKeyDNSOption) IsTrue() bool {
+	return u == VerifyHostKeyDNSOptionYes
+}
+
+// IsFalse returns true if the option is false.
+func (u VerifyHostKeyDNSOption) IsFalse() bool {
+	return u == VerifyHostKeyDNSOptionNo
+}
+
+// IsAsk returns true if the option is "ask".
+func (u VerifyHostKeyDNSOption) IsAsk() bool {
+	return u == VerifyHostKeyDNSOptionAsk
+}
+
+// String returns the string representation of the option.
+func (u VerifyHostKeyDNSOption) String() string {
+	return string(u)
+}
+
+// EscapeCharOption is the type for the EscapeChar option.
+type EscapeCharOption string
+
+const (
+	EscapeCharOptionNone    = EscapeCharOption("none")
+	EscapeCharOptionDefault = EscapeCharOption("~")
+)
+
+// Normalize returns the normalized value of the option or an error if the value is invalid.
+func (e EscapeCharOption) Normalize() (EscapeCharOption, error) {
+	if e == "" || e == "none" {
+		return EscapeCharOptionNone, nil
+	}
+	if e == "~" {
+		return EscapeCharOptionDefault, nil
+	}
+	if len(e) == 1 || (e[0] == '^' && len(e) == 2) {
+		return e, nil
+	}
+	return "", fmt.Errorf("%w: invalid value %q for EscapeChar", errInvalidValue, e)
+}
+
+// String returns the string representation of the option.
+func (e EscapeCharOption) String() string {
+	return string(e)
+}
+
+// IsNone returns true if the option is "none".
+func (e EscapeCharOption) IsNone() bool {
+	return e == EscapeCharOptionNone
+}
+
+// Byte returns the byte representation of the option.
+func (e EscapeCharOption) Byte() byte {
+	if e == EscapeCharOptionNone {
+		return 0
+	}
+
+	if len(e) == 1 {
+		return e[0]
+	}
+
+	if e[0] == '^' && len(e) == 2 {
+		return e[1] & 31
+	}
+
+	return 0
+}

--- a/sshconfig/parser.go
+++ b/sshconfig/parser.go
@@ -1,0 +1,387 @@
+// Package sshconfig provides a parser for OpenSSH ssh_config files as
+// documented in the [man page].
+//
+// # Implemented features:
+//
+//   - Go mappings for all of the keys known to OpenSSH client (and two
+//     additional Apple specific fields from the Mac port).
+//   - Partial Match directive support. Address, LocalAddress, LocalPort and
+//     RDomain are not implemented because they require passing
+//     in a connection, which is not (yet?) implemented.
+//   - Partial token expansion support. Like above, expanding some of the
+//     tokens would require an established connection.
+//   - Include directive support, the parser will follow the Include directives
+//     in lexical order as specified in the spec.
+//   - Expansion of ~ and environment variables in the values where applicable
+//     (the enabled fields are listed in the [man page]).
+//   - Support for list modifier prefixes for fields like HostKeyAlgorithms or
+//     KexAlgorithms where you can use "+" prefix to append to default list,
+//     "-" to remove from the default list and ^ to prepend to the default
+//     list.
+//   - Support for boolean fields which can also have string values (yes, no,
+//     ask, always, none, etc.). These are not enforced or validated like in
+//     the OpenSSH implementation, if the field is a MultiStateBooleanValue,
+//     it will accept any string value, but Bool() will return the boolean
+//     value and an ok flag indicating if the value is one of the known boolean
+//     values.
+//   - "Strict" mode for supporting the IgnoreUnknown directive. When enabled,
+//     the parser will throw an error when it encounters an unknown directive.
+//     By default this is not enabled. To enable, use the
+//     [WithErrorOnUnknown] option when creating the parser.
+//   - The origin of each value can be determined.
+//   - The order based value precedence is correctly implemented as described
+//     in the specification.
+//   - Hostname canonicalization.
+//   - Original-like unquoting and splitting of values based on `argv_split`
+//     from the OpenSSH source converted to go.
+//
+// # Usage:
+//
+// What you create a new [Parser], what you get is not a key-value store that
+// you can use to query values for keys. Upon initialization, the Parser
+// reads in the ssh configuration files and creates an internal tree structure
+// that will be iterated over for each host configuration object to be
+// populated with values from the configuration.
+//
+// The SSH configuration files do not define a list of hosts, it's not a
+// phone-book. The configuration is a set of rules that match hostnames or
+// other attributes like the username or the current local address and
+// the settings are applied only when they match the current connection.
+//
+// You can either use the full [Config] which includes all the known keys
+// or you can define a struct with a subset of the keys that you are
+// interested in.
+//
+// [man page]: https://man7.org/linux/man-pages/man5/ssh_config.5.html
+package sshconfig
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/user"
+	"sync"
+
+	"github.com/k0sproject/rig/v2/log"
+)
+
+/*
+SSH Configuration files parsing rules:
+
+Config value load order:
+
+When a configuration file is not supplied (ssh -F path or NewParser(nil)):
+1. Configuration defaults - any values set here can be overridden at any stage.
+2. Command-line options - any values set here have the highest precedence.
+3. User configuration file (~/.ssh/config)
+4. Global configuration file (/etc/ssh/ssh_config))
+5. Canonicalization if enabled
+6. Final match blocks
+
+If a configuration file path is provided (or NewParser(reader) is used)
+the stages 3 and 4 are replaced by parsing the supplied configuration file.
+
+Each stage can contain Include directives, which are processed as they
+are encountered.
+
+For each parameter, the first obtained value will be used except
+for some fields that can be used multiple times or can modify
+existing values (remove items from lists of ciphers, append to lists,
+etc)
+*/
+
+// Exported errors.
+var (
+	// ErrSyntax is returned when the config file has a syntax error.
+	ErrSyntax = errors.New("syntax error")
+
+	// ErrInvalidObject is returned when the object passed to Apply is not compatible.
+	ErrInvalidObject = errors.New("invalid object")
+
+	// ErrNotImplemented is returned when encountering a ssh_config feature that has not been
+	// implemented.
+	ErrNotImplemented = errors.New("not implemented")
+
+	username = sync.OnceValue(
+		func() string {
+			if user, err := user.Current(); err == nil {
+				return user.Username
+			}
+			return ""
+		},
+	)
+
+	userhome = sync.OnceValue(
+		func() string {
+			if home, err := os.UserHomeDir(); err == nil {
+				return home
+			}
+			return ""
+		},
+	)
+)
+
+// the word "host" is used so many times it's worth making a constant for it.
+const fkHost = "host"
+
+// Parser for OpenSSH ssh_config files.
+type Parser struct {
+	mu sync.Mutex
+
+	iter *treeIterator
+
+	options parserOptions
+}
+
+// parserOptions for the ssh config parser.
+type parserOptions struct {
+	errorOnUnknown     bool
+	globalConfigPath   string
+	userConfigPath     string
+	globalConfigReader io.Reader
+	userConfigReader   io.Reader
+	executor           executor
+	nofinalize         bool
+	home               string
+}
+
+type executor interface {
+	Run(cmd string, args ...string) error
+}
+
+type defaultExecutor struct{}
+
+func (d defaultExecutor) Run(cmd string, args ...string) error {
+	if err := exec.Command(cmd, args...).Run(); err != nil {
+		return fmt.Errorf("run command %q: %w", cmd, err)
+	}
+	return nil
+}
+
+// ParserOption is a function that sets a parser option.
+type ParserOption func(*parserOptions)
+
+// newParserOptions returns a new ParserOptions with the given options applied.
+func newParserOptions(opts ...ParserOption) parserOptions {
+	options := parserOptions{executor: defaultExecutor{}}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return options
+}
+
+// WithStrict is a functional option that makes the parser respect the 'IgnoreUnknown'
+// directive, thus making it error out on any encountered key that is not found and is not listed
+// in the "IgnoreUnknown" config field.
+func WithStrict() ParserOption {
+	return func(o *parserOptions) {
+		o.errorOnUnknown = true
+	}
+}
+
+// WithNoFinalize is a functional option that disables the finalization of the object.
+func WithNoFinalize() ParserOption {
+	return func(o *parserOptions) {
+		o.nofinalize = true
+	}
+}
+
+// WithGlobalConfigPath is a functional option that overrides the default global config path
+// (/etc/ssh/ssh_config or %PROGRAMDATA%/ssh/ssh_config on Windows).
+func WithGlobalConfigPath(path string) ParserOption {
+	return func(o *parserOptions) {
+		o.globalConfigPath = path
+	}
+}
+
+// WithUserConfigPath is a functional option that overrides the default user config path (~/.ssh/config).
+func WithUserConfigPath(path string) ParserOption {
+	return func(o *parserOptions) {
+		o.userConfigPath = path
+	}
+}
+
+// WithGlobalConfigReader is a functional option that overrides the default global config reader.
+func WithGlobalConfigReader(r io.Reader) ParserOption {
+	return func(o *parserOptions) {
+		o.globalConfigReader = r
+	}
+}
+
+// WithUserConfigReader is a functional option that overrides the default user config reader.
+func WithUserConfigReader(r io.Reader) ParserOption {
+	return func(o *parserOptions) {
+		o.userConfigReader = r
+	}
+}
+
+// WithExecutor is a functional option that overrides the default executor for testing (or disabling?) purposes.
+func WithExecutor(e executor) ParserOption {
+	return func(o *parserOptions) {
+		o.executor = e
+	}
+}
+
+// WithUserHome is a functional option that sets the home directory for the current user.
+func WithUserHome(home string) ParserOption {
+	return func(o *parserOptions) {
+		o.home = home
+	}
+}
+
+// NewParser returns a new Parser. If r is nil, the default ssh config files will be read
+// from ~/.ssh/config and /etc/ssh/ssh_config (or %PROGRAMDATA%/ssh/ssh_config on Windows).
+//
+// Calling NewParser will perform the initial parsing of the configuration files and returns
+// an error if it fails.
+//
+// If your use-case is to parse the configuration for multiple hosts, you only need to
+// create one parser and use it to apply settings to multiple host objects by calling
+// Apply multiple times with different objects..
+func NewParser(r io.Reader, opts ...ParserOption) (*Parser, error) {
+	options := newParserOptions(opts...)
+	treeParser := newTreeParser(r)
+	if options.globalConfigPath != "" {
+		treeParser.GlobalConfigPath = options.globalConfigPath
+	}
+	if options.userConfigPath != "" {
+		treeParser.UserConfigPath = options.userConfigPath
+	}
+	if options.globalConfigReader != nil {
+		treeParser.GlobalConfigReader = options.globalConfigReader
+	}
+	if options.userConfigReader != nil {
+		treeParser.UserConfigReader = options.userConfigReader
+	}
+
+	iter, err := treeParser.Parse()
+	if err != nil {
+		return nil, fmt.Errorf("failed to tokenize ssh config: %w", err)
+	}
+	return &Parser{iter: iter, options: options}, nil
+}
+
+// ConfigFor returns a new Config for the given host.
+//
+// This is a shorthand for creating a [Parser], and using it to populate a [Config] object.
+//
+// Do not use this if you need to get configurations for multiple hosts.
+func ConfigFor(host string, opts ...ParserOption) (*Config, error) {
+	parser, err := NewParser(nil, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("create parser: %w", err)
+	}
+	config := &Config{}
+	if err := parser.Apply(config, host); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	return config, nil
+}
+
+func (p *Parser) apply(setter *Setter) error {
+	for p.iter.Next() {
+		key := p.iter.Key()
+		values := p.iter.Values()
+		path := p.iter.Path()
+		row := p.iter.Row()
+
+		setter.applyingDefaults(path == "__default__")
+
+		switch key {
+		case "include":
+			// just keep on iterating, the tree parser has already included the file as just another beanch
+			continue
+		case fkHost:
+			match, err := setter.matchesHost(values...)
+			if err != nil {
+				return err
+			}
+			if !match {
+				// Not for this host, skip the block.
+				p.iter.Skip()
+			}
+		case "match":
+			match, err := setter.matchesMatch(values...)
+			if err != nil {
+				return fmt.Errorf("can't process Match directive %q in %s:%d: %w", values, path, row, err)
+			}
+			log.Trace(context.Background(), "match directive result", "match", match, "values", values, "path", path, "row", row)
+			if !match {
+				// Not for this host, skip the block.
+				p.iter.Skip()
+			}
+		default:
+			if err := setter.Set(key, values...); err != nil {
+				return fmt.Errorf("set %q: %w", key, err)
+			}
+		}
+	}
+	return nil
+}
+
+// Apply the ssh config into the passed in object, such as an instance
+// of [Config]. The object needs at least a Host (string) field.
+func (p *Parser) Apply(obj any, host string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.reset()
+
+	setter, err := NewSetter(obj)
+	if err != nil {
+		return fmt.Errorf("create setter: %w", err)
+	}
+
+	if p.options.errorOnUnknown {
+		setter.ErrorOnUnknownFields = true
+	}
+
+	if p.options.home != "" {
+		setter.home = p.options.home
+	}
+
+	setter.executor = p.options.executor
+
+	if err := setter.Set(fkHost, host); err != nil {
+		return fmt.Errorf("set host %q: %w", host, err)
+	}
+
+	p.iter.Reset()
+	if err := p.apply(setter); err != nil {
+		return fmt.Errorf("failed to apply ssh config: %w", err)
+	}
+
+	if err := setter.CanonicalizeHostname(); err != nil {
+		return fmt.Errorf("canonicalize hostname: %w", err)
+	}
+
+	if setter.wantFinal || setter.HostChanged() {
+		setter.doingFinal()
+		p.iter.Reset()
+		if err := p.apply(setter); err != nil {
+			return fmt.Errorf("second pass of ssh config application failed: %w", err)
+		}
+	}
+
+	if !p.options.nofinalize {
+		if err := setter.Finalize(); err != nil {
+			return fmt.Errorf("finalize: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (p *Parser) reset() {
+	p.iter.Reset()
+}
+
+// Reset resets the parser to its initial state.
+func (p *Parser) Reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.reset()
+}

--- a/sshconfig/parser_test.go
+++ b/sshconfig/parser_test.go
@@ -1,0 +1,430 @@
+package sshconfig_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/sshconfig"
+	"github.com/stretchr/testify/require"
+)
+
+func Example_simple() {
+	hostconfig, err := sshconfig.ConfigFor("example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(hostconfig.Port)
+	// Output: 22
+}
+
+func Example() {
+	// this will read the configurations from the default locations.
+	parser, err := sshconfig.NewParser(nil)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	host := &sshconfig.Config{}
+	if err := parser.Apply(host, "example.com"); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// To read from a specific file or a string instead of the default files, pass in an io.Reader:
+func Example_configFromReader() {
+	parser, err := sshconfig.NewParser(strings.NewReader("Host example.com\nIdentityFile id_example\n"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	host := &sshconfig.Config{}
+	if err := parser.Apply(host, "example.com"); err != nil {
+		log.Fatal(err)
+	}
+	for _, identityFile := range host.IdentityFile {
+		fmt.Println(identityFile)
+	}
+	// Output: id_example
+}
+
+// You can also use the parser to apply configuration values into your own custom Config object.
+func Example_withCustomConfigObject() {
+	type customConfig struct {
+		Host         string
+		IdentityFile []string
+	}
+
+	// To read from a specific file or a string instead of the default files, pass in an io.Reader:
+	parser, err := sshconfig.NewParser(strings.NewReader("Host example.com\nIdentityFile id_example\n"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	host := &customConfig{}
+	if err := parser.Apply(host, "example.com"); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(host.IdentityFile[0])
+	// Output: id_example
+}
+
+func TestParse(t *testing.T) {
+	config := sshconfig.Config{}
+	parser, err := sshconfig.NewParser(nil)
+	require.NoError(t, err)
+	err = parser.Apply(&config, "example.com")
+	require.NoError(t, err)
+}
+
+func TestParseIgnoreUnknown(t *testing.T) {
+	content := "Host example.com\n  IdentityFile ~/.ssh/id_rsa\n  UnknownOption yes\n"
+	parser, err := sshconfig.NewParser(strings.NewReader(content))
+	obj := &sshconfig.Config{}
+	t.Run("ErrorOnUnknown false", func(t *testing.T) {
+		t.Run("IgnoreUnknown not set", func(t *testing.T) {
+			obj.IgnoreUnknown = nil
+			require.NoError(t, err)
+			require.NoError(t, parser.Apply(obj, "example.com"))
+		})
+		t.Run("IgnoreUnknown set", func(t *testing.T) {
+			obj := &sshconfig.Config{}
+			obj.IgnoreUnknown = []string{"unknown*"}
+			parser, err := sshconfig.NewParser(strings.NewReader(content))
+			require.NoError(t, err)
+			require.NoError(t, parser.Apply(obj, "example.com"))
+		})
+	})
+	t.Run("ErrorOnUnknown true", func(t *testing.T) {
+		t.Run("IgnoreUnknown not set", func(t *testing.T) {
+			obj := &sshconfig.Config{}
+			obj.IgnoreUnknown = nil
+			parser, err := sshconfig.NewParser(strings.NewReader(content), sshconfig.WithStrict())
+			require.NoError(t, err)
+			require.ErrorContains(t, parser.Apply(obj, "example.com"), "unknown key")
+		})
+		t.Run("IgnoreUnknown set", func(t *testing.T) {
+			obj := &sshconfig.Config{}
+			obj.IgnoreUnknown = []string{"unknown*"}
+			parser, err := sshconfig.NewParser(strings.NewReader(content), sshconfig.WithStrict())
+			require.NoError(t, err)
+			require.NoError(t, parser.Apply(obj, "example.com"))
+		})
+	})
+}
+
+func TestParsePrecedence(t *testing.T) {
+	ucReader := strings.NewReader("GlobalKnownHostsFile /dev/null\nStrictHostKeyChecking no\nHost example.com\nSendEnv TERM\nStrictHostKeyChecking ask\n")
+	gcReader := strings.NewReader("GlobalKnownHostsFile /foo/ssh/ssh_known_hosts\nSendEnv LANG\nStrictHostKeyChecking yes\n")
+	obj := &sshconfig.Config{}
+	parser, err := sshconfig.NewParser(nil, sshconfig.WithGlobalConfigReader(gcReader), sshconfig.WithUserConfigReader(ucReader))
+	require.NoError(t, err)
+	err = parser.Apply(obj, "example.com")
+	require.NoError(t, err)
+	require.Equal(t, []string{"/dev/null"}, obj.GlobalKnownHostsFile, "User config should be loaded first and the value should stick")
+	require.Equal(t, []string{"TERM", "LANG"}, obj.SendEnv, "SendEnv is always appending")
+	require.Equal(t, "no", obj.StrictHostKeyChecking.String(), "The first occurence was in user config and it should stick")
+}
+
+func TestHostAndMatchBlocks(t *testing.T) {
+	content := `
+        Host example.com
+            IdentityFile ~/.ssh/id_example
+            Port 23
+
+        Host *.example.net
+            IdentityFile ~/.ssh/id_example_net
+            Port 2222
+
+        Match host="some.random.example,specific.example.net"
+            IdentityFile ~/.ssh/id_specific
+            Port 2200
+
+        Host *
+            IdentityFile ~/.ssh/id_default
+            Port 22
+    `
+
+	parser, err := sshconfig.NewParser(strings.NewReader(content), sshconfig.WithUserHome("/tmp"))
+	require.NoError(t, err)
+
+	exampleCom := &sshconfig.Config{}
+	require.NoError(t, parser.Apply(exampleCom, "example.com"))
+	require.Equal(t, []string{"/tmp/.ssh/id_example", "/tmp/.ssh/id_default"}, exampleCom.IdentityFile)
+	require.Equal(t, 23, exampleCom.Port)
+
+	randomExampleNet := &sshconfig.Config{}
+	require.NoError(t, parser.Apply(randomExampleNet, "random.example.net"))
+	require.Equal(t, []string{"/tmp/.ssh/id_example_net", "/tmp/.ssh/id_default"}, randomExampleNet.IdentityFile)
+	require.Equal(t, 2222, randomExampleNet.Port)
+
+	specificExampleNet := &sshconfig.Config{}
+	require.NoError(t, parser.Apply(specificExampleNet, "specific.example.net"))
+	require.Equal(t, []string{"/tmp/.ssh/id_example_net", "/tmp/.ssh/id_specific", "/tmp/.ssh/id_default"}, specificExampleNet.IdentityFile)
+	require.Equal(t, 2222, specificExampleNet.Port)
+
+	fooExampleCom := &sshconfig.Config{}
+	require.NoError(t, parser.Apply(fooExampleCom, "foo.example.com"))
+	require.Equal(t, []string{"/tmp/.ssh/id_default"}, fooExampleCom.IdentityFile)
+	require.Equal(t, 22, fooExampleCom.Port)
+}
+
+func TestParserCircularInclude(t *testing.T) {
+	// Setup temporary directory for mock config files
+	tmpDir := t.TempDir()
+
+	userConfigDir := filepath.Join(tmpDir, "home", "user", ".ssh")
+	err := os.MkdirAll(userConfigDir, 0755)
+	require.NoError(t, err)
+
+	// Circular import setup
+	err = os.WriteFile(filepath.Join(userConfigDir, "circular"), []byte(`Include circular`), 0644)
+	require.NoError(t, err)
+
+	// Test with global and user config paths
+	_, err = sshconfig.NewParser(nil, sshconfig.WithUserConfigPath(filepath.Join(userConfigDir, "circular")))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "circular include")
+}
+
+func TestParserIncludeRelativePaths(t *testing.T) {
+	// Setup temporary directory for mock config files
+	tmpDir := t.TempDir()
+
+	// Mock global and user config directories
+	globalConfigDir := filepath.Join(tmpDir, "etc", "ssh")
+	userConfigDir := filepath.Join(tmpDir, "home", "user", ".ssh")
+	err := os.MkdirAll(globalConfigDir, 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(userConfigDir, 0755)
+	require.NoError(t, err)
+
+	// Mock include files with relative paths
+	err = os.WriteFile(filepath.Join(globalConfigDir, "ssh_config"), []byte(`Include ssh_config.d/*`), 0644)
+	require.NoError(t, err)
+	err = os.Mkdir(filepath.Join(globalConfigDir, "ssh_config.d"), 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(globalConfigDir, "ssh_config.d", "config1"), []byte("Host global\n  UserKnownHostsFile /global/known"), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(userConfigDir, "ssh_config"), []byte(`Include user_config.d/*`), 0644)
+	require.NoError(t, err)
+	err = os.Mkdir(filepath.Join(userConfigDir, "user_config.d"), 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(userConfigDir, "user_config.d", "config1"), []byte("Host user\n  UserKnownHostsFile /user/known"), 0644)
+	require.NoError(t, err)
+
+	// Test with global and user config paths
+	parser, err := sshconfig.NewParser(nil, sshconfig.WithGlobalConfigPath(filepath.Join(globalConfigDir, "ssh_config")), sshconfig.WithUserConfigPath(filepath.Join(userConfigDir, "ssh_config")))
+	require.NoError(t, err)
+
+	testCases := []struct {
+		hostName   string
+		knownhosts string
+	}{
+		{"global", "/global/known"},
+		{"user", "/user/known"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.hostName, func(t *testing.T) {
+			obj := &sshconfig.Config{}
+			err = parser.Apply(obj, tc.hostName)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.knownhosts, strings.Join(obj.UserKnownHostsFile, ","))
+		})
+	}
+}
+
+func TestIncludeDirectives(t *testing.T) {
+	// Setup temporary directory for mock config files
+	tmpDir := t.TempDir()
+
+	// Mock include files with distinct settings
+	include1Path := filepath.Join(tmpDir, "include1")
+	include2Path := filepath.Join(tmpDir, "include2")
+	err := os.WriteFile(include1Path, []byte("Host included1\n  UserKnownHostsFile /included1/known"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(include2Path, []byte("Host included2\n  UserKnownHostsFile /included2/known"), 0644)
+	require.NoError(t, err)
+
+	// Main config content with include directives
+	content := fmt.Sprintf(`
+        Include %s
+        Include %s
+
+        Host default
+            UserKnownHostsFile /.ssh/known_default
+    `, include1Path, include2Path)
+
+	parser, err := sshconfig.NewParser(strings.NewReader(content))
+	require.NoError(t, err)
+
+	testCases := []struct {
+		hostName   string
+		knownhosts string
+	}{
+		{"included1", "/included1/known"},
+		{"included2", "/included2/known"},
+		{"default", "/.ssh/known_default"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.hostName, func(t *testing.T) {
+			obj := &sshconfig.Config{}
+			err = parser.Apply(obj, tc.hostName)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.knownhosts, strings.Join(obj.UserKnownHostsFile, ","))
+		})
+	}
+}
+
+func TestPatternMatchingAndNegation(t *testing.T) {
+	content := `
+        Host *.example.com
+            UserKnownHostsFile ~/.ssh/wildcard
+
+        Host ??.example.net
+            UserKnownHostsFile ~/.ssh/question
+
+        Host !forbidden.example.com
+            UserKnownHostsFile ~/.ssh/negation
+
+        Host example.*
+            UserKnownHostsFile ~/.ssh/domain
+
+        Host *
+            UserKnownHostsFile ~/.ssh/known_default
+    `
+
+	for _, win := range []bool{true, false} {
+		t.Run(fmt.Sprintf("windows_lf=%v", win), func(t *testing.T) {
+			if win {
+				content = strings.ReplaceAll(content, "\n", "\r\n")
+			}
+			parser, err := sshconfig.NewParser(strings.NewReader(content))
+			require.NoError(t, err)
+
+			testCases := []struct {
+				hostName   string
+				knownhosts string
+			}{
+				{"test.example.com", "/.ssh/wildcard"},
+				{"aa.example.net", "/.ssh/question"},
+				{"acceptable.example.com", "/.ssh/wildcard"},
+				{"example.org", "/.ssh/domain"},
+				{"forbidden.example.com", "/.ssh/wildcard"},
+				{"randomhost", "/.ssh/known_default"},
+			}
+
+			for _, tc := range testCases {
+				t.Run(tc.hostName, func(t *testing.T) {
+					obj := &sshconfig.Config{}
+					err = parser.Apply(obj, tc.hostName)
+					require.NoError(t, err)
+					require.True(t, strings.HasSuffix(strings.Join(obj.UserKnownHostsFile, ","), tc.knownhosts), "UserKnownHostsFile should end with %s but is %s", tc.knownhosts, obj.UserKnownHostsFile)
+					require.False(t, strings.HasPrefix(strings.Join(obj.UserKnownHostsFile, ","), "~"), "tilde paths should be expanded, but got %s", obj.UserKnownHostsFile)
+				})
+			}
+		})
+	}
+}
+
+func TestMatchHostHostname(t *testing.T) {
+	content := `
+    Host example.com
+      Hostname foo.example.com
+    Match host=example.com
+      Port 2021
+    Match host=foo.example.com
+      Port 2022
+	`
+
+	parser, err := sshconfig.NewParser(strings.NewReader(content))
+	require.NoError(t, err)
+
+	obj := &sshconfig.Config{}
+	require.NoError(t, parser.Apply(obj, "example.com"))
+	require.Equal(t, 2022, obj.Port, "host rule in Match should match 'hostname' value once defined")
+}
+
+func TestMatchConditions(t *testing.T) {
+	content := `
+        Match host="example.com" user="user1"
+            UserKnownHostsFile ${TEST_SSH_KNOWN}/example_com
+            Port 2222
+
+        Match host="example.net" exec="test -f /some/file"
+            UserKnownHostsFile ${TEST_SSH_KNOWN}/example_net
+            Port 23
+
+        Host *
+            UserKnownHostsFile ${TEST_SSH_KNOWN}/default
+            Port 22
+    `
+
+	// Mocking an environment variable for the UserKnownHostsFile paths
+	t.Setenv("TEST_SSH_KNOWN", "/mock/ssh")
+
+	me := &mockExecutor{}
+	parser, err := sshconfig.NewParser(strings.NewReader(content), sshconfig.WithExecutor(me))
+	require.NoError(t, err)
+
+	testCases := []struct {
+		hostName string
+		user     string
+		execCmd  string
+		known    string
+		port     int
+	}{
+		{"example.com", "user1", "", "/mock/ssh/example_com", 2222},
+		{"example.net", "", "test -f /some/file", "/mock/ssh/example_net", 23},
+		{"otherhost", "", "", "/mock/ssh/default", 22},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.hostName, func(t *testing.T) {
+			obj := &sshconfig.Config{}
+			obj.User = tc.user
+			if tc.execCmd != "" {
+				me.expect = map[string]bool{tc.execCmd: true}
+			}
+			me.received = []string{}
+
+			err = parser.Apply(obj, tc.hostName)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.known, strings.Join(obj.UserKnownHostsFile, ","))
+			require.Equal(t, tc.port, obj.Port)
+			if tc.execCmd != "" {
+				require.Contains(t, me.received, tc.execCmd)
+			}
+		})
+	}
+}
+
+type mockExecutor struct {
+	expect   map[string]bool
+	received []string
+}
+
+func (m *mockExecutor) Run(cmd string, args ...string) error {
+	stringified := fmt.Sprintf("%s %s", cmd, strings.Join(args, " "))
+	m.received = append(m.received, stringified)
+	if res, ok := m.expect[stringified]; ok {
+		if res {
+			return nil
+		}
+		return fmt.Errorf("command failed")
+	}
+	return fmt.Errorf("unexpected command")
+}
+
+func TestSyntaxError(t *testing.T) {
+	_, err := sshconfig.NewParser(strings.NewReader("Host example.com\n  UserKnownHostsFile ~/.ssh/id_known\n  UnknownOption\n"))
+	require.Error(t, err)
+	require.ErrorIs(t, err, sshconfig.ErrSyntax)
+}

--- a/sshconfig/patternmatch.go
+++ b/sshconfig/patternmatch.go
@@ -1,0 +1,87 @@
+package sshconfig
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// patternMatch compares a single pattern against a string.
+func patternMatch(value, pattern string) (bool, error) {
+	if pattern == "*" {
+		return true, nil
+	}
+
+	if pattern == value {
+		return true, nil
+	}
+
+	if !strings.ContainsAny(pattern, "*?") {
+		return pattern == value, nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("^")
+	for _, ch := range pattern {
+		switch ch {
+		case '*':
+			sb.WriteString(".*")
+		case '?':
+			sb.WriteString(".")
+		default:
+			if !unicode.IsLetter(ch) && !unicode.IsNumber(ch) {
+				sb.WriteRune('\\')
+			}
+			sb.WriteRune(ch)
+		}
+	}
+	sb.WriteString("$")
+
+	regex, err := regexp.Compile(sb.String())
+	if err != nil {
+		return false, fmt.Errorf("invalid pattern: %w", err)
+	}
+
+	return regex.MatchString(value), nil
+}
+
+// patternMatchAll returns true if the value matches the combination of
+// multiple patterns.
+//
+// A !negated patterns alone will never yield a match unless there is also a positive
+// match in the combination.
+func patternMatchAll(value string, patterns ...string) (bool, error) {
+	var hasPositiveMatch bool
+
+	for _, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
+		subPatterns := strings.Split(pattern, ",")
+		for _, subPattern := range subPatterns {
+			subPattern = strings.TrimSpace(subPattern)
+			if subPattern == "" {
+				continue
+			}
+			negate := strings.HasPrefix(subPattern, "!")
+			if negate {
+				subPattern = subPattern[1:]
+			}
+
+			match, err := patternMatch(value, subPattern)
+			if err != nil {
+				return false, err
+			}
+
+			if match {
+				if negate {
+					return false, nil
+				}
+				hasPositiveMatch = true
+			}
+		}
+	}
+
+	return hasPositiveMatch, nil
+}

--- a/sshconfig/printer.go
+++ b/sshconfig/printer.go
@@ -1,0 +1,301 @@
+package sshconfig
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Dump an SSH configuration to a string.
+//
+// Example:
+//
+//	config, _ := sshconfig.ConfigFor("example.com")
+//	dump, _ := sshconfig.Dump(config)
+//	fmt.Println(dump)
+//	// Output:
+//	// Host example.com
+//	// 	Hostname example.com
+//	// 	User user
+//	// 	..and so on
+func Dump(obj any) (string, error) {
+	p, err := newprinter(obj)
+	if err != nil {
+		return "", fmt.Errorf("can't create printer: %w", err)
+	}
+	return p.dump(), nil
+}
+
+type printer struct {
+	setter *Setter
+}
+
+func newprinter(obj any) (*printer, error) {
+	setter, err := NewSetter(obj)
+	if err != nil {
+		return nil, fmt.Errorf("can't create a setter for importing field info: %w", err)
+	}
+	p := &printer{
+		setter: setter,
+	}
+	return p, nil
+}
+
+func (p *printer) fieldByName(key string) (reflect.Value, bool) {
+	return p.setter.fieldByName(key)
+}
+
+func (p *printer) get(key string, expectedKinds ...reflect.Kind) (reflect.Value, error) {
+	return p.setter.get(key, expectedKinds...)
+}
+
+func quote(s string) string {
+	if s == "" {
+		return ""
+	}
+	if strings.Contains(s, " ") {
+		return strconv.Quote(s)
+	}
+	return s
+}
+
+func (p *printer) stringify(field reflect.Value) (string, bool) {
+	if field.Kind() == reflect.String {
+		return quote(field.String()), true
+	}
+	if field.Kind() == reflect.Ptr && field.Elem().Kind() == reflect.String {
+		return quote(field.Elem().String()), true
+	}
+	if field.CanInterface() {
+		if s, ok := field.Interface().(fmt.Stringer); ok {
+			return quote(s.String()), true
+		}
+	}
+	if field.CanAddr() {
+		if s, ok := field.Addr().Interface().(fmt.Stringer); ok {
+			return quote(s.String()), true
+		}
+	}
+	return "", false
+}
+
+func (p *printer) stringer(key string) (string, bool) {
+	field, ok := p.fieldByName(key)
+	if !ok {
+		return "", false
+	}
+	return p.stringify(field)
+}
+
+func (p *printer) stringerslicejoin(key string, separator rune) (string, bool) {
+	field, err := p.get(key, reflect.Slice)
+	if err != nil {
+		return "", false
+	}
+	if field.Len() == 0 {
+		return "", false
+	}
+	sb := &strings.Builder{}
+	for i := 0; i < field.Len(); i++ {
+		if i > 0 {
+			sb.WriteRune(separator)
+		}
+		if s, ok := p.stringify(field.Index(i)); ok {
+			if strings.HasSuffix(key, "File") && s[1] == ':' {
+				// Windows path with a drive letter
+				s = strings.ReplaceAll(s, "/", "\\")
+			}
+			sb.WriteString(s)
+		}
+	}
+	return sb.String(), true
+}
+
+func (p *printer) stringerslice(key string) (string, bool) {
+	return p.stringerslicejoin(key, ' ')
+}
+
+func (p *printer) stringercsv(key string) (string, bool) {
+	return p.stringerslicejoin(key, ',')
+}
+
+func (p *printer) number(key string) (string, bool) {
+	if field, err := p.get(key, reflect.Int); err == nil {
+		return strconv.FormatInt(field.Int(), 10), true
+	}
+	if field, err := p.get(key, reflect.Uint); err == nil {
+		if key == "StreamLocalBindMask" {
+			return "0" + strconv.FormatInt(int64(field.Uint()), 8), true
+		}
+		return strconv.FormatInt(int64(field.Uint()), 10), true
+	}
+	return "", false
+}
+
+func (p *printer) boolean(key string) (string, bool) {
+	if field, err := p.get(key, reflect.Bool); err == nil {
+		if field.Bool() {
+			return yes, true
+		}
+		return no, true
+	}
+
+	if field, err := p.get(key, reflect.String); err == nil {
+		return field.String(), true
+	}
+
+	return "", false
+}
+
+func (p *printer) duration(key string) (string, bool) {
+	kind := reflect.TypeOf(time.Duration(0)).Kind()
+	if field, err := p.get(key, kind); err == nil {
+		if field.CanInterface() {
+			if d, ok := field.Interface().(time.Duration); ok {
+				return strconv.Itoa(int(d.Seconds())), true
+			}
+		}
+	}
+
+	if field, err := p.get(key, reflect.String); err == nil {
+		return field.String(), true
+	}
+
+	return "", false
+}
+
+func (p *printer) channeltimeout(key string) (string, bool) {
+	kind := reflect.TypeOf(map[string]time.Duration{}).Kind()
+	if field, err := p.get(key, kind); err == nil { //nolint:nestif
+		if field.CanInterface() {
+			if d, ok := field.Interface().(map[string]time.Duration); ok {
+				sb := &strings.Builder{}
+				for k, v := range d {
+					if sb.Len() > 0 {
+						sb.WriteRune(' ')
+					}
+					sb.WriteString(k)
+					sb.WriteRune('=')
+					sb.WriteString(strconv.Itoa(int(v.Seconds())))
+				}
+				return sb.String(), true
+			}
+		}
+	}
+	if field, err := p.get(key, reflect.Slice); err == nil {
+		sb := &strings.Builder{}
+		for i := 0; i < field.Len(); i++ {
+			if s, ok := p.stringify(field.Index(i)); ok {
+				if sb.Len() > 0 {
+					sb.WriteRune(' ')
+				}
+				sb.WriteString(s)
+			}
+		}
+		return sb.String(), true
+	}
+	if field, err := p.get(key, reflect.String); err == nil {
+		return field.String(), true
+	}
+	return "", false
+}
+
+func (p *printer) forward(key string) (string, bool) {
+	kind := reflect.TypeOf(map[string]string{}).Kind()
+	if field, err := p.get(key, kind); err == nil { //nolint:nestif
+		if field.CanInterface() {
+			if d, ok := field.Interface().(map[string]string); ok {
+				sb := &strings.Builder{}
+				for k, v := range d {
+					if sb.Len() > 0 {
+						sb.WriteRune(' ')
+					}
+					sb.WriteString(k)
+					sb.WriteRune(' ')
+					sb.WriteString(v)
+				}
+				return sb.String(), true
+			}
+		}
+	}
+	if field, err := p.get(key, reflect.Slice); err == nil {
+		sb := &strings.Builder{}
+		for i := 0; i < field.Len(); i++ {
+			if s, ok := p.stringify(field.Index(i)); ok {
+				if sb.Len() > 0 {
+					sb.WriteRune(' ')
+				}
+				sb.WriteString(s)
+			}
+		}
+	}
+	return "", false
+}
+
+func (p *printer) dump() string { //nolint:cyclop
+	sb := &strings.Builder{}
+	keys := make([]string, len(knownKeys))
+	i := 0
+	for key := range knownKeys {
+		keys[i] = key
+		i++
+	}
+	sort.Strings(keys)
+	host := p.setter.getHost()
+	if host != "" {
+		sb.WriteString("Host ")
+		sb.WriteString(host)
+		sb.WriteRune('\n')
+	}
+	for _, key := range keys {
+		if key == "Host" {
+			continue
+		}
+		keyinfo, ok := knownKeys[key]
+		if !ok {
+			continue
+		}
+		if keyinfo.printFunc == nil {
+			continue
+		}
+		if key == "localforward" || key == "remoteforward" { //nolint:nestif
+			slice, ok := p.stringerslice(key)
+			if !ok {
+				continue
+			}
+			if slice == "" {
+				continue
+			}
+			for i, s := range strings.Split(slice, " ") {
+				if i%2 == 0 {
+					sb.WriteRune('\t')
+					sb.WriteString(key)
+					sb.WriteRune(' ')
+				}
+				sb.WriteString(s)
+				if i%2 != 0 {
+					sb.WriteRune(' ')
+				} else {
+					sb.WriteRune('\n')
+				}
+			}
+			continue
+		}
+		strval, ok := keyinfo.printFunc(p, keyinfo.key)
+		if !ok {
+			continue
+		}
+		if strval == "" {
+			continue
+		}
+		sb.WriteRune('\t')
+		sb.WriteString(keyinfo.key)
+		sb.WriteRune(' ')
+		sb.WriteString(strval)
+		sb.WriteRune('\n')
+	}
+	return sb.String()
+}

--- a/sshconfig/printer_test.go
+++ b/sshconfig/printer_test.go
@@ -1,0 +1,23 @@
+package sshconfig_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/sshconfig"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrinter(t *testing.T) {
+	config, err := sshconfig.ConfigFor("example.com")
+	require.NoError(t, err)
+	configStr, err := sshconfig.Dump(config)
+	require.NoError(t, err)
+	parser, err := sshconfig.NewParser(strings.NewReader(configStr))
+	require.NoError(t, err)
+	configNew := &sshconfig.Config{}
+	require.NoError(t, parser.Apply(configNew, "example.com"))
+	configStr2, err := sshconfig.Dump(configNew)
+	require.Equal(t, configStr, configStr2)
+	require.Equal(t, config, configNew)
+}

--- a/sshconfig/set.go
+++ b/sshconfig/set.go
@@ -1,0 +1,1765 @@
+package sshconfig
+
+import (
+	"context"
+	"crypto/sha1" //nolint:gosec // sha1 is used for hasging certain filenames in ssh_config
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/k0sproject/rig/v2/log"
+	"github.com/k0sproject/rig/v2/sh/shellescape"
+	"github.com/k0sproject/rig/v2/sshconfig/options"
+)
+
+var (
+	errFieldNotFound = errors.New("field not found")
+	errInvalidField  = errors.New("invalid field")
+	errInvalidValue  = errors.New("invalid value")
+	errInvalidObject = errors.New("invalid object")
+
+	errCanonicalizationFailed = errors.New("hostname canonicalization failed")
+
+	// There's no need to rediscover the struct fields every time for the same type,
+	// so they're cached. When the pre-parsed struct fields are found, scanning
+	// for reflect.Value's for an instance's fields is faster too because the
+	// struct field's Index can be used to call FieldByIndex.
+	//
+	// The expected use-case is that there will be one or many instances of the
+	// single type, not many instances of different types.
+	sfCache map[reflect.Type]map[string]reflect.StructField
+	sfcMu   sync.Mutex
+)
+
+type parserPhase int
+
+const (
+	none = "none" // the string "none" is used in some fields to indicate no value
+	yes  = "yes"  // the string "yes" is used as the boolean true value
+	no   = "no"   // the string "no" is used as the boolean false value
+
+	phaseRegular  parserPhase = iota // when setting regular values
+	phaseDefaults                    // when setting values from defaults
+	phaseFinal                       // when performing a finall pass
+)
+
+// Setter is a reflect based Setter for ssh configuration struct fields.
+type Setter struct {
+	wantFinal bool
+
+	// The original host alias before any hostname canonicalization has been applied.
+	OriginalHost string
+	// When true, unknown fields will cause an error unless they match patterns defined in the IgnoreUnknown field.
+	ErrorOnUnknownFields bool
+
+	executor executor
+
+	elem       reflect.Value
+	elemFields map[string]reflect.Value
+
+	home string
+
+	phase parserPhase
+}
+
+// NewSetter creates a ssh config value setter for the given object. It can be used to set
+// values on the object's fields using the same rules as the openssh client configuration
+// parser via the Set(key, values...) function.
+//
+// It is used internally by the [Parser] but it can be used to set values manually.
+func NewSetter(obj any) (*Setter, error) {
+	elem, err := getElem(obj)
+	if err != nil {
+		return nil, err
+	}
+	setter := &Setter{elem: elem, executor: defaultExecutor{}, home: userhome()}
+	setter.discoverFields()
+	setter.initHost()
+	return setter, nil
+}
+
+// sets the phase of the setter to "phaseDefaults" which is used when setting values from defaults.
+// there are some fields that behave differently when setting defaults, so this is used to track that.
+func (s *Setter) applyingDefaults(state bool) {
+	if state {
+		s.phase = phaseDefaults
+	} else {
+		s.phase = phaseFinal
+	}
+}
+
+// sets the phase of the setter to "phaseFinal" which is used when performing a final pass.
+// blocks like "Match final" are only applied in the final pass.
+func (s *Setter) doingFinal() {
+	s.phase = phaseFinal
+}
+
+func (s *Setter) initHost() {
+	if s.OriginalHost != "" {
+		return
+	}
+	s.OriginalHost = s.getHost()
+}
+
+func getElem(obj any) (reflect.Value, error) {
+	objVal := reflect.ValueOf(obj)
+
+	if objVal.Kind() != reflect.Ptr {
+		return reflect.Value{}, fmt.Errorf("%w: object is not a pointer", errInvalidObject)
+	}
+
+	if objVal.IsNil() {
+		return reflect.Value{}, fmt.Errorf("%w: object is nil", errInvalidObject)
+	}
+
+	structVal := objVal.Elem()
+	if structVal.Kind() != reflect.Struct {
+		return reflect.Value{}, fmt.Errorf("%w: object is not a struct", errInvalidObject)
+	}
+	return structVal, nil
+}
+
+func expectOne(v []string) error {
+	if len(v) != 1 {
+		return fmt.Errorf("%w: expected one value, got %d", errInvalidValue, len(v))
+	}
+	if v[0] == "" {
+		return fmt.Errorf("%w: expected one value, got none", errInvalidValue)
+	}
+	return nil
+}
+
+func expectAtLeastOne(v []string) error {
+	if len(v) == 0 || v[0] == "" {
+		return fmt.Errorf("%w: expected at least one value, got none", errInvalidValue)
+	}
+	return nil
+}
+
+func (s *Setter) discoverFields() {
+	sfcMu.Lock()
+	defer sfcMu.Unlock()
+
+	var sfields map[string]reflect.StructField
+	if sfCache == nil {
+		sfCache = make(map[reflect.Type]map[string]reflect.StructField)
+	}
+
+	sf, cached := sfCache[s.elem.Type()]
+	if cached {
+		sfields = sf
+		s.elemFields = make(map[string]reflect.Value)
+		for k, v := range sfields {
+			s.elemFields[k] = s.elem.FieldByIndex(v.Index)
+		}
+		return
+	}
+
+	sfields = make(map[string]reflect.StructField)
+	sfCache[s.elem.Type()] = sfields
+
+	s.elemFields = make(map[string]reflect.Value)
+
+	for i := 0; i < s.elem.NumField(); i++ {
+		field := s.elem.Field(i)
+		structField := s.elem.Type().Field(i)
+		s.elemFields[structField.Name] = field
+		sfields[structField.Name] = structField
+	}
+}
+
+func (s *Setter) fieldByName(key string) (reflect.Value, bool) {
+	if f, ok := s.elemFields[key]; ok {
+		return f, ok
+	}
+	return reflect.Value{}, false
+}
+
+func (s *Setter) get(key string, expectedKinds ...reflect.Kind) (reflect.Value, error) { //nolint:cyclop
+	field, ok := s.fieldByName(key)
+	if !ok {
+		return reflect.Value{}, fmt.Errorf("%w: field %q is not found", errFieldNotFound, key)
+	}
+	if !field.CanSet() {
+		return reflect.Value{}, fmt.Errorf("%w: field %q is not settable", errInvalidObject, key)
+	}
+
+	isPtr := field.Kind() == reflect.Ptr
+	expectsPtr := len(expectedKinds) > 0 && expectedKinds[0] == reflect.Ptr
+
+	if isPtr && !expectsPtr {
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		field = field.Elem()
+	} else if !isPtr && expectsPtr {
+		return reflect.Value{}, fmt.Errorf("%w: expected a pointer for field %q", errInvalidField, key)
+	}
+
+	if !expectsPtr && len(expectedKinds) == 1 && field.Kind() != expectedKinds[0] {
+		return reflect.Value{}, fmt.Errorf("%w: field %q is not of the expected type %s", errInvalidField, key, expectedKinds[0])
+	} else if len(expectedKinds) == 2 {
+		if expectedKinds[0] == reflect.Slice && (field.Kind() != reflect.Slice || field.Type().Elem().Kind() != expectedKinds[1]) {
+			return reflect.Value{}, fmt.Errorf("%w: field %q is not a slice of the expected type", errInvalidField, key)
+		}
+	}
+
+	return field, nil
+}
+
+func (s *Setter) setString(key string, values ...string) error {
+	if err := expectOne(values); err != nil {
+		return err
+	}
+	field, err := s.get(key, reflect.String)
+	if err != nil {
+		return err
+	}
+	if field.String() == "" {
+		field.SetString(values[0])
+	}
+	return nil
+}
+
+func (s *Setter) setStringSlice(key string, values ...string) error {
+	if err := expectAtLeastOne(values); err != nil {
+		return err
+	}
+	field, err := s.get(key, reflect.Slice, reflect.String)
+	if err != nil {
+		return err
+	}
+	if field.Len() > 0 {
+		return nil
+	}
+	field.Set(reflect.ValueOf(values))
+	return nil
+}
+
+func (s *Setter) setStringSliceCSV(key string, values ...string) error {
+	if err := expectOne(values); err != nil {
+		return err
+	}
+	field, err := s.get(key, reflect.Slice, reflect.String)
+	if err != nil {
+		if f, err := s.get(key, reflect.String); err == nil {
+			if f.String() == "" {
+				f.SetString(values[0])
+			}
+			return nil
+		}
+		return err
+	}
+	if field.Len() > 0 {
+		return nil
+	}
+	field.Set(reflect.ValueOf(strings.Split(values[0], ",")))
+	return nil
+}
+
+func (s *Setter) setBool(key string, values ...string) error {
+	if err := expectOne(values); err != nil {
+		return err
+	}
+	bval, err := options.BooleanOption(values[0]).Normalize()
+	if err != nil {
+		return fmt.Errorf("%w: field %q: %w", errInvalidValue, key, err)
+	}
+	value := reflect.ValueOf(bval)
+	field, err := s.get(key, value.Kind())
+	if err != nil {
+		if field, err := s.get(key, reflect.Ptr, reflect.Bool); err == nil {
+			if !field.IsNil() {
+				return nil
+			}
+			boolPtr := reflect.New(reflect.TypeOf(bval.IsTrue()))
+			boolPtr.Elem().SetBool(bval.IsTrue())
+			field.Set(boolPtr)
+			return nil
+		}
+		return fmt.Errorf("%w: field %q is not a BooleanOption or a pointer to a bool", errInvalidField, key)
+	}
+	if field.String() != "" {
+		return nil
+	}
+	field.Set(value)
+	return nil
+}
+
+func (s *Setter) setInt(key string, values ...string) error {
+	if err := expectOne(values); err != nil {
+		return err
+	}
+	var ival int64
+	if strings.HasPrefix(values[0], "0") && len(values[0]) > 1 {
+		v, err := strconv.ParseInt(values[0], 8, 64)
+		if err != nil {
+			return fmt.Errorf("%w: invalid octal int value %q", errInvalidValue, values[0])
+		}
+		ival = v
+	} else {
+		v, err := strconv.ParseInt(values[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("%w: invalid int value %q", errInvalidValue, values[0])
+		}
+		ival = v
+	}
+	field, err := s.get(key, reflect.Int)
+	if err != nil {
+		return err
+	}
+	if field.Kind() == reflect.Ptr {
+		if !field.IsNil() {
+			return nil
+		}
+		intPtr := reflect.New(reflect.TypeOf(ival))
+		intPtr.Elem().SetInt(ival)
+		field.Set(intPtr)
+	} else {
+		if field.Int() != 0 {
+			return nil
+		}
+		field.SetInt(ival)
+	}
+	return nil
+}
+
+func (s *Setter) setUint(key string, values ...string) error {
+	if err := expectOne(values); err != nil {
+		return err
+	}
+	var uval uint64
+	if strings.HasPrefix(values[0], "0") && len(values[0]) > 1 { //nolint:nestif
+		v, err := strconv.ParseUint(values[0], 8, 64)
+		if err != nil {
+			return fmt.Errorf("%w: invalid octal uint value %q", errInvalidValue, values[0])
+		}
+		if v > uint64(math.MaxUint) {
+			return fmt.Errorf("%w: invalid uint value %q", errInvalidValue, values[0])
+		}
+		uval = v
+	} else {
+		v, err := strconv.ParseUint(values[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("%w: invalid uint value %q", errInvalidValue, values[0])
+		}
+		if v > uint64(math.MaxUint) {
+			return fmt.Errorf("%w: invalid uint value %q", errInvalidValue, values[0])
+		}
+		uval = v
+	}
+	field, err := s.get(key, reflect.Uint)
+	if err != nil {
+		return err
+	}
+	if field.Kind() == reflect.Ptr {
+		if !field.IsNil() {
+			return nil
+		}
+		uintPtr := reflect.New(reflect.TypeOf(uval))
+		uintPtr.Elem().SetUint(uval)
+		field.Set(uintPtr)
+		return nil
+	}
+	if field.Uint() != 0 {
+		return nil
+	}
+	field.SetUint(uval)
+	return nil
+}
+
+// setDuration sets a duration field value. If the value is none, the duration is set to 0. If a unit is not
+// specified, "s" is assumed. The field can be a duration or a pointer to a duration. Note that if the field is not
+// a pointer, a zero value is considered unset.
+func (s *Setter) setDuration(key string, values ...string) error { //nolint:cyclop
+	if err := expectOne(values); err != nil {
+		return err
+	}
+
+	value := values[0]
+
+	var dur time.Duration
+
+	if value != none {
+		if value[len(value)-1] >= '0' && value[len(value)-1] <= '9' {
+			value += "s"
+		}
+		var err error
+		dur, err = time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("%w: invalid duration value %q: %w", errInvalidValue, value, err)
+		}
+	}
+
+	field, err := s.get(key, reflect.Ptr, reflect.Int64)
+	if err != nil {
+		if f, err := s.get(key, reflect.Int64); err == nil {
+			field = f
+		} else {
+			return fmt.Errorf("%w: field must be a duration or a pointer to a duration", err)
+		}
+	} else if !field.IsNil() {
+		return nil
+	}
+
+	durationType := reflect.TypeOf(time.Duration(0))
+	switch {
+	case field.Kind() == reflect.Ptr:
+		if field.Type().Elem() != durationType {
+			return fmt.Errorf("%w: field must be a pointer to a duration", errInvalidField)
+		}
+		if !field.IsNil() {
+			return nil
+		}
+	case field.Type() != durationType:
+		return fmt.Errorf("%w: field must be a duration", errInvalidField)
+	case field.Int() != 0:
+		return nil
+	}
+
+	if field.Kind() == reflect.Ptr {
+		durPtr := reflect.New(durationType)
+		durPtr.Elem().Set(reflect.ValueOf(dur))
+		field.Set(durPtr)
+	} else {
+		field.Set(reflect.ValueOf(dur))
+	}
+
+	return nil
+}
+
+func normalizePath(value string) string {
+	if runtime.GOOS == "windows" {
+		// this is a hack to support the __PROGRAMDATA__ in the ssh config dumps on windows.
+		value = strings.ReplaceAll(value, "__PROGRAMDATA__", os.Getenv("PROGRAMDATA"))
+	}
+
+	return strings.ReplaceAll(filepath.Clean(value), "\\", "/")
+}
+
+func (s *Setter) setPath(key string, values ...string) error {
+	if err := expectOne(values); err != nil {
+		return err
+	}
+	return s.setString(key, normalizePath(values[0]))
+}
+
+func (s *Setter) setPathList(key string, values ...string) error {
+	if err := expectAtLeastOne(values); err != nil {
+		return err
+	}
+
+	newValues := make([]string, len(values))
+	var j int
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		newValues[j] = normalizePath(value)
+		j++
+	}
+	return s.setStringSlice(key, newValues[:j]...)
+}
+
+// appendPathList appends a path list field value. The value is expected to be a path or a list of paths.
+// Unlike setPathList, this function appends the values to the existing list except when performing
+// parsing of the defaults.
+func (s *Setter) appendPathList(key string, values ...string) error {
+	if err := expectAtLeastOne(values); err != nil {
+		return err
+	}
+
+	field, err := s.get(key, reflect.Slice, reflect.String)
+	if err != nil {
+		return err
+	}
+	if slices.Contains(values, none) {
+		if len(values) > 1 {
+			return fmt.Errorf("%w: none cannot be used with other values", errInvalidValue)
+		}
+		field.Set(reflect.ValueOf(values))
+	}
+
+	oldValues, ok := field.Interface().([]string)
+	if !ok {
+		return fmt.Errorf("%w: field %q is not a slice of strings", errInvalidField, key)
+	}
+	if len(oldValues) == 1 && oldValues[0] == none {
+		return nil
+	}
+	if len(oldValues) > 0 && s.phase == phaseDefaults {
+		// defaults should not be appended to a populated list
+		return nil
+	}
+	for _, value := range values {
+		value = normalizePath(value)
+		if !slices.Contains(oldValues, value) {
+			oldValues = append(oldValues, value)
+		}
+	}
+	field.Set(reflect.ValueOf(oldValues))
+	return nil
+}
+
+// appendStringList appends strings to a string list field value. If the list is already populated, values
+// from defaults will not be appended.
+func (s *Setter) appendStringList(key string, values ...string) error {
+	if err := expectAtLeastOne(values); err != nil {
+		return err
+	}
+	field, err := s.get(key, reflect.Slice, reflect.String)
+	if err != nil {
+		return err
+	}
+	if slices.Contains(values, none) {
+		if len(values) > 1 {
+			return fmt.Errorf("%w: none cannot be used with other values", errInvalidValue)
+		}
+		field.Set(reflect.ValueOf(values))
+		return nil
+	}
+	oldValues, ok := field.Interface().([]string)
+	if !ok {
+		return fmt.Errorf("%w: field %q is not a slice of strings", errInvalidField, key)
+	}
+	if len(oldValues) == 1 && oldValues[0] == none {
+		return nil
+	}
+	if len(oldValues) > 0 && s.phase == phaseDefaults {
+		// defaults should not be appended to a populated list
+		return nil
+	}
+	for _, value := range values {
+		if !slices.Contains(oldValues, value) {
+			oldValues = append(oldValues, value)
+		}
+	}
+	field.Set(reflect.ValueOf(oldValues))
+	return nil
+}
+
+func (s *Setter) setRekeyLimitOption(key string, values ...string) error { //nolint:cyclop
+	if len(values) < 1 || len(values) > 2 {
+		return fmt.Errorf("%w: expected 1 or 2 values, got %d", errInvalidValue, len(values))
+	}
+	byteVal := values[0]
+	var suffix byte
+	if byteVal[len(byteVal)-1] < '0' || byteVal[len(byteVal)-1] > '9' {
+		suffix = byteVal[len(byteVal)-1]
+		byteVal = byteVal[:len(byteVal)-1]
+	}
+	byteInt64, err := strconv.ParseInt(byteVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("%w: failed to parse byte value: %w", errInvalidValue, err)
+	}
+	switch suffix {
+	case 'k', 'K':
+		byteInt64 *= 1024
+	case 'm', 'M':
+		byteInt64 *= 1024 * 1024
+	case 'g', 'G':
+		byteInt64 *= 1024 * 1024 * 1024
+	}
+
+	var maxTime time.Duration
+	if len(values) == 2 {
+		timeVal := options.AddIntervalSuffix(values[1])
+		d, err := time.ParseDuration(timeVal)
+		if err != nil {
+			return fmt.Errorf("%w: failed to parse time value: %w", errInvalidValue, err)
+		}
+		maxTime = d
+	}
+	opt := options.RekeyLimitOption{MaxData: byteInt64, MaxTime: maxTime}
+	value := reflect.ValueOf(opt)
+	field, err := s.get(key, value.Kind())
+	if err != nil {
+		if f, err := s.get(key, reflect.Slice, reflect.String); err == nil {
+			if f.Len() > 0 {
+				return nil
+			}
+			f.Set(reflect.ValueOf(values))
+			return nil
+		}
+		return fmt.Errorf("%w: field %q is not a RekeyLimitOption or a string slice", errInvalidField, key)
+	}
+	rk, ok := field.Interface().(options.RekeyLimitOption)
+	if !ok {
+		return fmt.Errorf("%w: field %q is not a RekeyLimitOption", errInvalidField, key)
+	}
+	if rk.String() != "" {
+		return nil
+	}
+	field.Set(value)
+	return nil
+}
+
+func (s *Setter) setChannelTimeoutOption(key string, values ...string) error {
+	if err := expectAtLeastOne(values); err != nil {
+		return err
+	}
+	res := make(map[string]time.Duration)
+	for _, value := range values {
+		parts := strings.Split(value, "=")
+		if len(parts) != 2 {
+			return fmt.Errorf("%w: invalid channel timeout value %q", errInvalidValue, value)
+		}
+
+		switch parts[0] {
+		case "agent-connection", "direct-tcpip", "direct-streamlocal@openssh.com", "forwarded-tcpip", "forwarded-streamlocal@openssh.com", "session", "tun-connection", "x11-connection":
+		// valid
+		default:
+			return fmt.Errorf("%w: invalid channel timeout type %q", errInvalidValue, parts[0])
+		}
+		timeVal := options.AddIntervalSuffix(parts[1])
+		d, err := time.ParseDuration(timeVal)
+		if err != nil {
+			return fmt.Errorf("%w: failed to parse time value %q: %w", errInvalidValue, parts[1], err)
+		}
+		res[parts[0]] = d
+	}
+	value := reflect.ValueOf(res)
+	field, err := s.get(key, value.Kind())
+	if err != nil {
+		return err
+	}
+	if field.Len() > 0 {
+		return nil
+	}
+	field.Set(value)
+	return nil
+}
+
+func (s *Setter) setAddKeysToAgentOption(key string, values ...string) error {
+	if len(values) < 1 || len(values) > 2 {
+		return fmt.Errorf("%w: expected 1 or 2 values, got %d", errInvalidValue, len(values))
+	}
+
+	normalized, err := options.AddKeysToAgentOption(strings.Join(values, " ")).Normalize()
+	if err != nil {
+		return fmt.Errorf("not a valid %q value %q: %w", key, values, err)
+	}
+
+	value := reflect.ValueOf(normalized)
+	field, err := s.get(key, value.Kind())
+	if err != nil {
+		if f, err := s.get(key, reflect.String); err == nil {
+			if f.String() != "" {
+				return nil
+			}
+			f.SetString(normalized.String())
+			return nil
+		}
+		return fmt.Errorf("%w: field %q is not a %s or a string", errInvalidField, key, reflect.TypeOf(normalized))
+	}
+	if field.String() != "" {
+		return nil
+	}
+	field.Set(value)
+	return nil
+}
+
+func (s *Setter) setIPQoSOption(key string, values ...string) error {
+	if len(values) < 1 || len(values) > 2 {
+		return fmt.Errorf("%w: expected 1 or 2 values, got %d", errInvalidValue, len(values))
+	}
+	res := make([]string, len(values))
+	for i, v := range values {
+		nv, err := options.IPQoSOption(v).Normalize()
+		if err != nil {
+			return fmt.Errorf("not a valid %q value: %w", key, err)
+		}
+		res[i] = nv.String()
+	}
+	value := reflect.ValueOf(res)
+	field, err := s.get(key, value.Kind())
+	if err != nil {
+		if f, err := s.get(key, reflect.Slice, reflect.String); err == nil {
+			if f.Len() > 0 {
+				return nil
+			}
+			f.Set(reflect.ValueOf(values))
+			return nil
+		}
+		return fmt.Errorf("%w: field %q is not a string slice or a []IPQoSOption", errInvalidField, key)
+	}
+	if field.Len() > 0 {
+		return nil
+	}
+	field.Set(value)
+	return nil
+}
+
+func (s *Setter) setForwardOption(key string, values ...string) error {
+	if len(values) != 2 {
+		return fmt.Errorf("%w: expected 2 values, got %d", errInvalidValue, len(values))
+	}
+	var res map[string]string
+	value := reflect.ValueOf(res)
+	field, err := s.get(key, value.Kind())
+	if err != nil {
+		return err
+	}
+	if field.IsNil() {
+		res = make(map[string]string)
+	} else {
+		var ok bool
+		res, ok = field.Interface().(map[string]string)
+		if !ok {
+			return fmt.Errorf("%w: field %q is not a map[string]string", errInvalidField, key)
+		}
+	}
+	res[values[0]] = values[1]
+	field.Set(reflect.ValueOf(res))
+	return nil
+}
+
+func (s *Setter) setPort(key string, values ...string) error {
+	if err := expectOne(values); err != nil {
+		return err
+	}
+	port, err := strconv.Atoi(values[0])
+	if err != nil {
+		return fmt.Errorf("%w: invalid port value %q", errInvalidValue, values[0])
+	}
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("%w: invalid port value %q", errInvalidValue, values[0])
+	}
+	return s.setInt(key, values[0])
+}
+
+// setSendEnvOption sets the sendenv field value. The field is "always appending" but you can also
+// use the - prefix to remove a value.
+func (s *Setter) setSendEnvOption(key string, values ...string) error {
+	if err := expectAtLeastOne(values); err != nil {
+		return err
+	}
+	field, err := s.get(key, reflect.Slice, reflect.String)
+	if err != nil {
+		return err
+	}
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if value[0] == '-' {
+			value = value[1:]
+			oldVals, ok := field.Interface().([]string)
+			if !ok {
+				return fmt.Errorf("%w: field %q is not a slice of strings", errInvalidField, key)
+			}
+			var newVals []string
+			for _, v := range oldVals {
+				match, err := patternMatch(v, value)
+				if err != nil {
+					return fmt.Errorf("%w: failed to match %q with %q: %w", errInvalidValue, value, v, err)
+				}
+				if match {
+					continue
+				}
+				newVals = append(newVals, v)
+			}
+			field.Set(reflect.ValueOf(newVals))
+		} else {
+			field.Set(reflect.Append(field, reflect.ValueOf(value)))
+		}
+	}
+	return nil
+}
+
+// setSetEnvOption sets the setenv field value. The field is "always appending".
+func (s *Setter) setSetEnvOption(key string, values ...string) error {
+	if err := expectAtLeastOne(values); err != nil {
+		return err
+	}
+	var res map[string]string
+	value := reflect.ValueOf(res)
+	field, err := s.get(key, value.Kind())
+	if err != nil {
+		return err
+	}
+	if field.IsNil() {
+		res = make(map[string]string)
+	} else {
+		r, ok := field.Interface().(map[string]string)
+		if !ok {
+			return fmt.Errorf("%w: field %q is not a map of strings", errInvalidField, key)
+		}
+		if len(r) > 0 {
+			return nil
+		}
+		res = r
+	}
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		parts := strings.SplitN(value, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("%w: invalid setenv value %q", errInvalidValue, value)
+		}
+		if parts[0] == "" {
+			return fmt.Errorf("%w: invalid setenv value %q", errInvalidValue, value)
+		}
+		res[parts[0]] = parts[1]
+	}
+	field.Set(reflect.ValueOf(res))
+	return nil
+}
+
+// setColonSeparatedValues sets a string map field value from a list of key:value pairs.
+// It supports the none keyword.
+func (s *Setter) setColonSeparatedValues(key string, values ...string) error {
+	if err := expectAtLeastOne(values); err != nil {
+		return err
+	}
+	field, err := s.get(key, reflect.Slice, reflect.String)
+	if err != nil {
+		return err
+	}
+	if field.Len() > 0 {
+		return nil
+	}
+	if slices.Contains(values, none) {
+		if len(values) > 1 {
+			return fmt.Errorf("%w: 'none' must be the only value", errInvalidValue)
+		}
+		field.Set(reflect.ValueOf(values))
+		return nil
+	}
+	if strings.ToLower(key) == "permitremoteopen" && slices.Contains(values, "any") {
+		if len(values) > 1 {
+			return fmt.Errorf("%w: 'any' must be the only value", errInvalidValue)
+		}
+		field.Set(reflect.ValueOf(values))
+		return nil
+	}
+
+	for _, value := range values {
+		if strings.Count(value, ":") != 1 {
+			return fmt.Errorf("%w: invalid %q value %q", errInvalidValue, key, value)
+		}
+	}
+	field.Set(reflect.ValueOf(values))
+	return nil
+}
+
+func (s *Setter) getHost() string {
+	field, err := s.get("Host", reflect.String)
+	if err != nil {
+		return ""
+	}
+	return field.String()
+}
+
+func (s *Setter) setHost(_ string, values ...string) error {
+	if err := expectOne(values); err != nil {
+		return err
+	}
+	field, err := s.get("Host", reflect.String)
+	if err != nil {
+		return err
+	}
+	if s.OriginalHost == values[0] {
+		return nil
+	}
+	if s.OriginalHost == "" {
+		s.OriginalHost = values[0]
+	}
+	field.SetString(values[0])
+	return nil
+}
+
+// HostChanged returns true if the value of "Host" (the host alias initially used to connect) has been changed.
+// This happens if hostname canonicalization is performed. When connecting to the target, you should first
+// check if Hostname is defined, if not, use the Host value.
+func (s *Setter) HostChanged() bool {
+	field, err := s.get("Host", reflect.String)
+	if err != nil {
+		return false
+	}
+	return field.String() != s.OriginalHost
+}
+
+func (s *Setter) setEscapeCharOption(key string, values ...string) error {
+	if err := expectOne(values); err != nil {
+		return err
+	}
+	escOpt, err := options.EscapeCharOption(values[0]).Normalize()
+	if err != nil {
+		return fmt.Errorf("not a valid %q value: %w", key, err)
+	}
+	value := reflect.ValueOf(escOpt)
+	field, err := s.get(key, value.Kind())
+	if err != nil { //nolint:nestif
+		if f, err := s.get(key, reflect.String); err == nil {
+			if f.String() != "" {
+				f.SetString(escOpt.String())
+			}
+			return nil
+		}
+		if f, err := s.get(key, reflect.Int); err == nil {
+			if f.Int() != 0 {
+				f.SetInt(int64(escOpt.Byte()))
+			}
+			return nil
+		}
+		if f, err := s.get(key, reflect.Uint8); err == nil {
+			if f.Uint() != 0 {
+				f.SetUint(uint64(escOpt.Byte()))
+			}
+			return nil
+		}
+		return err
+	}
+	if field.String() != "" {
+		return nil
+	}
+	field.Set(value)
+	return nil
+}
+
+// Ignore a key.
+func (s *Setter) ignore(key string, _ ...string) error {
+	log.Trace(context.Background(), "ignoring key", "key", key)
+	return nil
+}
+
+// Set a value for a field by key name using the precedence rules of the SSH configuration file syntax.
+//
+// Note that some of the fields take their values as separate strings and some as a comma-separated list, most
+// only accept a single value.
+func (s *Setter) Set(key string, values ...string) error {
+	key = strings.ToLower(key)
+	info, ok := knownKeys[key]
+
+	var err error
+	switch {
+	case !ok:
+		err = fmt.Errorf("%w: unknown key %q", errFieldNotFound, key)
+	case info.setFunc == nil:
+		return fmt.Errorf("%w: field %q is not settable", errInvalidObject, key)
+	default:
+		err = info.setFunc(s, info.key, values...)
+	}
+
+	if errors.Is(err, errFieldNotFound) || errors.Is(err, errInvalidField) {
+		if !s.ErrorOnUnknownFields {
+			return nil
+		}
+		if !s.isInIgnoreUnknown(key) {
+			return err
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to set %q: %w", info.key, err)
+	}
+	return nil
+}
+
+// Reset sets a field to its zero value. This is useful in testing.
+func (s *Setter) Reset(key string) error {
+	info, ok := knownKeys[strings.ToLower(key)]
+	if !ok {
+		return fmt.Errorf("%w: unknown key %q", errFieldNotFound, key)
+	}
+	field, ok := s.fieldByName(info.key)
+	if !ok {
+		return fmt.Errorf("%w: field %q is not found", errFieldNotFound, key)
+	}
+	// Set a pointer to nil and a non-pointer to zero value.
+	if field.Kind() == reflect.Ptr {
+		field.Set(reflect.New(field.Type().Elem()))
+	} else {
+		field.Set(reflect.Zero(field.Type()))
+	}
+	return nil
+}
+
+// Finalize goes through all the string slice fields and sets them to nil if they contain a single none value.
+// It expands any tokens, environment variables or tilde-prefixed paths in the values for the keys where expansion
+// is supported.
+func (s *Setter) Finalize() error { //nolint:cyclop
+	for _, info := range knownKeys {
+		field, ok := s.fieldByName(info.key)
+		if !ok {
+			continue
+		}
+		switch field.Kind() { //nolint:exhaustive
+		case reflect.String:
+			newVal, err := s.ExpandString(info.key)
+			if err != nil {
+				return fmt.Errorf("%w: failed to expand %q: %w", errInvalidValue, info.key, err)
+			}
+			field.SetString(newVal)
+		case reflect.Slice:
+			if field.Len() == 1 && field.Index(0).String() == none {
+				field.Set(reflect.Zero(field.Type()))
+			}
+			if field.Type().Elem().Kind() == reflect.String {
+				newVal, err := s.ExpandSlice(info.key)
+				if err != nil {
+					return fmt.Errorf("%w: failed to expand %q: %w", errInvalidValue, info.key, err)
+				}
+				field.Set(reflect.ValueOf(newVal))
+			}
+		case reflect.Map:
+			// do nothing unless it's a map[string]string
+			if field.Type().Key().Kind() != reflect.String && field.Type().Elem().Kind() != reflect.String {
+				continue
+			}
+			if info.key != "LocalForward" && info.key != "RemoteForward" {
+				for _, k := range field.MapKeys() {
+					value := field.MapIndex(k)
+					if value.Len() == 1 && strings.Contains(value.Index(0).String(), "$") {
+						newValue, err := shellescape.Expand(value.Index(0).String(), shellescape.ExpandNoDollarVars(), shellescape.ExpandErrorIfUnset())
+						if err != nil {
+							return fmt.Errorf("%w: failed to expand localforward value %q: %w", errInvalidValue, info.key, err)
+						}
+						field.SetMapIndex(k, reflect.ValueOf([]string{newValue}))
+					}
+				}
+				continue
+			}
+		}
+	}
+	return nil
+}
+
+var tokenRe = regexp.MustCompile(`%[a-zA-Z%]`)
+
+/*
+%%
+A literal ‘%’.
+%C
+Hash of %l%h%p%r%j.
+%d
+Local user's home directory.
+%f
+The fingerprint of the server's host key.
+%H
+The known_hosts hostname or address that is being searched for.
+%h
+The remote hostname.
+%I
+A string describing the reason for a KnownHostsCommand execution: either ADDRESS when looking up a host by address (only when CheckHostIP is enabled), HOSTNAME when searching by hostname, or ORDER when preparing the host key algorithm preference list to use for the destination host.
+%i
+The local user ID.
+%j
+The contents of the ProxyJump option, or the empty string if this option is unset.
+%K
+The base64 encoded host key.
+%k
+The host key alias if specified, otherwise the original remote hostname given on the command line.
+%L
+The local hostname.
+%l
+The local hostname, including the domain name.
+%n
+The original remote hostname, as given on the command line.
+%p
+The remote port.
+%r
+The remote username.
+%T
+The local tun(4) or tap(4) network interface assigned if tunnel forwarding was requested, or none otherwise.
+%t
+The type of the server host key, e.g. ssh-ed25519.
+%u
+The local username.
+*/
+
+func sshConnectionHash(str string) string {
+	h := sha1.New() //nolint:gosec // sha1 is used for compatibility with OpenSSH
+
+	// Write data to hash
+	_, _ = io.WriteString(h, str)
+
+	// Calculate final hash
+	sum := h.Sum(nil)
+
+	// Convert to hexadecimal string
+	return hex.EncodeToString(sum)
+}
+
+func (s *Setter) expandToken(token string) (string, error) { //nolint:cyclop
+	switch token {
+	case "%%":
+		return "%", nil
+	case "%u":
+		return username(), nil
+	case "%d":
+		return s.home, nil
+	case "%h":
+		if f, err := s.get("hostname", reflect.String); err == nil {
+			if f.Len() > 0 {
+				return f.String(), nil
+			}
+		}
+		if f, err := s.get("Host", reflect.String); err == nil {
+			if f.Len() > 0 {
+				return f.String(), nil
+			}
+		}
+		return "", fmt.Errorf("%w: no hostname found for token %%h expansion", errFieldNotFound)
+	case "%p":
+		if f, err := s.get("Port", reflect.Int); err == nil {
+			if f.Int() > 0 {
+				return strconv.Itoa(int(f.Int())), nil
+			}
+		}
+
+		if f, err := s.get("Port", reflect.Uint); err == nil {
+			if f.Uint() > 0 {
+				return strconv.Itoa(int(f.Uint())), nil
+			}
+		}
+		if f, err := s.get("Port", reflect.String); err == nil {
+			if f.Len() > 0 {
+				return f.String(), nil
+			}
+		}
+		return "", fmt.Errorf("%w: no port found for token %%p expansion", errFieldNotFound)
+	case "%n":
+		return s.OriginalHost, nil
+	case "%r":
+		if f, err := s.get("User", reflect.String); err == nil {
+			if f.Len() > 0 {
+				return f.String(), nil
+			}
+		}
+		return username(), nil
+	case "%H":
+		for _, field := range []string{"HostkeyAlias", "Hostname", "Host"} {
+			if f, err := s.get(field, reflect.String); err == nil && f.Len() > 0 {
+				return f.String(), nil
+			}
+		}
+		return "", fmt.Errorf("%w: no hostname available for token %%H expansion", errFieldNotFound)
+	case "%j":
+		if f, err := s.get("ProxyJump", reflect.String); err == nil {
+			if f.Len() > 0 {
+				return f.String(), nil
+			}
+		}
+		if f, err := s.get("ProxyJump", reflect.Slice, reflect.String); err == nil {
+			if f.Len() > 0 {
+				if slice, ok := f.Interface().([]string); ok {
+					return strings.Join(slice, ","), nil
+				}
+				return "", fmt.Errorf("%w: failed to convert ProxyJump to string slice", errInvalidValue)
+			}
+		}
+		return "", nil
+	case "%L":
+		h, err := os.Hostname()
+		if err != nil {
+			return "", fmt.Errorf("%w: failed to get local hostname for token %%L expansion: %w", errFieldNotFound, err)
+		}
+		return h, nil
+	case "%C":
+		toExpand, err := s.expand("%l%h%p%r%j", keyInfo{tokens: []string{"%l", "%h", "%p", "%r", "%j"}})
+		if err != nil {
+			return "", err
+		}
+		return sshConnectionHash(toExpand), nil
+	}
+	return "", fmt.Errorf("%w: unsupported token %q", errInvalidValue, token)
+}
+
+func (s *Setter) expand(value string, info keyInfo) (string, error) { //nolint:cyclop
+	if value == "" {
+		return "", nil
+	}
+	if len(info.tokens) == 0 && !info.tilde && !info.env {
+		return value, nil
+	}
+
+	if info.env {
+		nv, err := shellescape.Expand(value, shellescape.ExpandNoDollarVars(), shellescape.ExpandErrorIfUnset())
+		if err != nil {
+			return "", fmt.Errorf("%w: failed to expand environment variables in %q: %w", errInvalidValue, value, err)
+		}
+		value = nv
+	}
+	if info.tilde {
+		if strings.HasPrefix(value, "~/") {
+			value = s.home + value[1:]
+			if value[1] == ':' {
+				value = strings.ReplaceAll(value, "\\", "/")
+			}
+		}
+	}
+	var reErr error
+	if len(info.tokens) > 0 {
+		value = tokenRe.ReplaceAllStringFunc(value, func(token string) string {
+			if slices.Contains(info.tokens, token) {
+				replacement, err := s.expandToken(token)
+				if err != nil {
+					reErr = err
+					return token
+				}
+				return replacement
+			}
+			reErr = fmt.Errorf("%w: unsupported token %q in %q", errInvalidValue, token, value)
+			return token
+		})
+	}
+	if reErr != nil {
+		return "", reErr
+	}
+	return value, nil
+}
+
+// ExpandString expands any environment variables, tokens or tilde paths in the value.
+// This is done automatically during the finalization phase, which can be disabled
+// using the parser options.
+func (s *Setter) ExpandString(key string) (string, error) {
+	info, ok := knownKeys[strings.ToLower(key)]
+	if !ok {
+		return "", fmt.Errorf("%w: unknown key %q", errFieldNotFound, key)
+	}
+	field, ok := s.fieldByName(info.key)
+	if !ok {
+		return "", fmt.Errorf("%w: field %q is not found", errFieldNotFound, key)
+	}
+	if field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return "", fmt.Errorf("%w: field %q is nil", errInvalidField, key)
+		}
+		field = field.Elem()
+	}
+	var str string
+	switch field.Kind() { //nolint:exhaustive
+	case reflect.String:
+		str = field.String()
+	case reflect.Slice:
+		return "", fmt.Errorf("%w: field %q is a slice", errInvalidField, key)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Bool:
+		return fmt.Sprint(field.Interface()), nil
+	case reflect.Struct:
+		var stringer fmt.Stringer
+		var ok bool
+		if field.CanInterface() {
+			stringer, ok = field.Interface().(fmt.Stringer)
+		} else if field.CanAddr() {
+			stringer, ok = field.Addr().Interface().(fmt.Stringer)
+		}
+		if !ok {
+			return "", fmt.Errorf("%w: field %q is not a stringer", errInvalidField, key)
+		}
+		str = stringer.String()
+	}
+	return s.expand(str, info)
+}
+
+// ExpandSlice expands any environment variables, tokens or tilde paths in the values.
+// This is done automatically during the finalization phase, which can be disabled
+// using the parser options.
+func (s *Setter) ExpandSlice(key string) ([]string, error) { //nolint:cyclop
+	info, ok := knownKeys[strings.ToLower(key)]
+	if !ok {
+		return nil, fmt.Errorf("%w: unknown key %q", errFieldNotFound, key)
+	}
+	field, ok := s.fieldByName(info.key)
+	if !ok {
+		return nil, fmt.Errorf("%w: field %q is not found", errFieldNotFound, key)
+	}
+	if field.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("%w: field %q is not a slice", errInvalidField, key)
+	}
+	if field.Len() == 0 {
+		return nil, nil
+	}
+	var values []string
+	for i := 0; i < field.Len(); i++ {
+		f := field.Index(i)
+		switch {
+		case f.Kind() == reflect.String:
+			values = append(values, f.String())
+		case f.CanInterface():
+			if str, ok := f.Interface().(fmt.Stringer); ok {
+				values = append(values, str.String())
+			}
+		case f.CanAddr():
+			if str, ok := f.Addr().Interface().(fmt.Stringer); ok {
+				values = append(values, str.String())
+			}
+		default:
+			return nil, fmt.Errorf("%w: field %q is not a stringer", errInvalidField, key)
+		}
+	}
+	for i, value := range values {
+		nv, err := s.expand(value, info)
+		if err != nil {
+			return nil, err
+		}
+		values[i] = nv
+	}
+	return values, nil
+}
+
+func (s *Setter) isInIgnoreUnknown(key string) bool {
+	field, err := s.get("IgnoreUnknown", reflect.Slice, reflect.String)
+	if err != nil {
+		return false
+	}
+	for i := 0; i < field.Len(); i++ {
+		match, err := patternMatch(key, field.Index(i).String())
+		if err != nil {
+			return false
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesHost checks if the Host directive matching conditions are met.
+func (s *Setter) matchesHost(conditions ...string) (bool, error) {
+	host, err := s.get("Host", reflect.String)
+	if err != nil {
+		return false, err
+	}
+	if host.Len() == 0 {
+		return false, fmt.Errorf("%w: host field is empty", errInvalidObject)
+	}
+	match, err := patternMatchAll(host.String(), conditions...)
+	if err != nil {
+		return false, err
+	}
+	return match, nil
+}
+
+// matchesMatch checks if the Match directive conditions are met.
+func (s *Setter) matchesMatch(conditions ...string) (bool, error) { //nolint:funlen,cyclop // TODO extract functions
+	log.Trace(context.Background(), "matching Match directive", "conditions", conditions)
+	for i := 0; i < len(conditions); i++ {
+		condition := conditions[i]
+		log.Trace(context.Background(), "matching Match directive", "condition", condition)
+		var negate bool
+		if condition[0] == '!' {
+			negate = true
+			condition = condition[1:]
+		}
+		switch condition {
+		case "all":
+			// For 'all', return true. Using '!all' is useful maybe only for
+			// commenting out a block, but it's a valid condition which is always false.
+			return !negate, nil
+		case "canonical", "final":
+			// We're going to perform canonical and final during the same pass, so
+			// we can treat them as synonyms.
+			if s.phase == phaseFinal {
+				if negate {
+					// it's the final round but !final is used, so return false
+					return false, nil
+				}
+				// Proceed to check other conditions if any
+				continue
+			}
+			// Not on the final round
+			if negate {
+				// !canonical or !final is used, so proceed to check other conditions
+				continue
+			}
+			s.wantFinal = true
+			// Not on final round, 'canonical' or 'final' is used, so return false
+			return false, nil
+		}
+
+		parts := strings.Split(condition, "=")
+		if len(parts) != 2 {
+			return false, fmt.Errorf("%w: invalid Match condition: %q", ErrSyntax, condition)
+		}
+		condition, quotedArgs := parts[0], parts[1]
+		args, err := shellescape.Unquote(quotedArgs)
+		if err != nil {
+			return false, fmt.Errorf("%w: failed to unquote match condition %q: %w", ErrSyntax, args, err)
+		}
+
+		// Deal with "exec" condition because its parameter is parsed differently.
+		if condition == "exec" { //nolint:nestif // TODO extract function
+			cmdStr, err := s.expand(args, keyInfo{
+				key:    "exec",
+				tokens: tokenset1,
+			})
+			if err != nil {
+				return false, fmt.Errorf("%w: failed to expand %q for Match exec condition: %w", ErrSyntax, args, err)
+			}
+			unq, err := shellescape.Split(cmdStr)
+			if err != nil {
+				return false, fmt.Errorf("%w: failed to process %q: %w", ErrSyntax, args, err)
+			}
+			cmd := unq[0]
+			if len(unq) > 1 {
+				unq = unq[1:]
+			} else {
+				unq = nil
+			}
+			log.Trace(context.Background(), "executing command from match directive", "condition", condition, "cmd", cmd, "args", unq)
+			if s.executor.Run(cmd, unq...) != nil {
+				log.Trace(context.Background(), "command failed", "condition", condition, "cmd", cmd, "args", unq, "error", err)
+				if negate {
+					return false, nil
+				}
+				continue
+			}
+			log.Trace(context.Background(), "command succeeded", "condition", condition, "cmd", cmd, "args", unq)
+			if negate {
+				return false, nil
+			}
+			continue
+		}
+
+		// The rest of the conditions take a comma separated list of arguments.
+		argsSlice := strings.Split(args, ",")
+
+		// Deal with "localnetwork" condition separately.
+		if condition == "localnetwork" { //nolint:nestif
+			match, err := matchLocalNetwork(argsSlice)
+			if err != nil {
+				return false, fmt.Errorf("failed to match local network: %w", err)
+			}
+			if match {
+				if negate {
+					return false, nil
+				}
+				continue
+			}
+			if negate {
+				continue
+			}
+			return false, nil
+		}
+
+		// The rest of the conditions share an equal logic:
+		// The args are patterns and depending on the condition, a different
+		// value is matched against the patterns.
+		//
+		// The patterns are already in the args and the switch statement below
+		// is used to determine the matchTarget.
+		var matchTarget string
+
+		// continue with the condition
+		switch condition {
+		case "user":
+			// consume next arg
+			user, err := s.get("User", reflect.String)
+			if err != nil {
+				return false, fmt.Errorf("%w: user field not found", ErrInvalidObject)
+			}
+			matchTarget = user.String()
+		case "originalhost":
+			matchTarget = s.OriginalHost
+		case "localuser":
+			matchTarget = username()
+		case "host":
+			if hostname, err := s.get("Hostname", reflect.String); err == nil && hostname.Len() > 0 {
+				matchTarget = hostname.String()
+			} else if host, err := s.get("Host", reflect.String); err == nil && host.Len() > 0 {
+				matchTarget = host.String()
+			} else {
+				return false, fmt.Errorf("%w: host or hostname fields not found or empty", ErrInvalidObject)
+			}
+		case "tagged":
+			tag, err := s.get("Tag", reflect.String)
+			if err != nil {
+				return false, fmt.Errorf("%w: tag field not found", ErrInvalidObject)
+			}
+			matchTarget = tag.String()
+		default:
+			return false, fmt.Errorf("%w: unknown match condition: %q", ErrSyntax, condition)
+		}
+
+		match, err := patternMatchAll(matchTarget, argsSlice...)
+		if err != nil {
+			return false, fmt.Errorf("match %q for match condition: %w", condition, err)
+		}
+		if match && !negate {
+			continue
+		}
+		if match && negate {
+			return false, nil
+		}
+		if !match && !negate {
+			return false, nil
+		}
+	}
+
+	// If none of the conditions explicitly return false, the match is successful
+	return true, nil
+}
+
+func (s *Setter) hasProxyJump() bool {
+	proxyJump, ok := s.fieldByName("ProxyJump")
+	if !ok {
+		return false
+	}
+	if proxyJump.Kind() == reflect.String {
+		return proxyJump.String() != "" && proxyJump.String() != none
+	} else if proxyJump.Kind() == reflect.Slice {
+		for i := 0; i < proxyJump.Len(); i++ {
+			if proxyJump.Index(i).String() != "" && proxyJump.Index(i).String() != none {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *Setter) hasProxyCommand() bool {
+	proxyCommand, ok := s.fieldByName("ProxyCommand")
+	if !ok {
+		return false
+	}
+	return proxyCommand.String() != "" && proxyCommand.String() != none
+}
+
+func (s *Setter) hasProxy() bool {
+	return s.hasProxyJump() || s.hasProxyCommand()
+}
+
+// determine if hostname canonicalization should be performed.
+func (s *Setter) doCanonicalize() bool { //nolint:cyclop
+	canonicalizeHostname, ok := s.fieldByName("CanonicalizeHostname")
+	if !ok {
+		return false
+	}
+
+	// CanonicalizeHostName should be set to "always" to enable hostname canonicalization when
+	// a proxy is defined.
+	hasProxy := s.hasProxy()
+
+	if canonicalizeHostname.Kind() == reflect.String {
+		switch canonicalizeHostname.String() {
+		case "always":
+			return true
+		case yes:
+			return !hasProxy
+		default:
+			return false
+		}
+	}
+
+	if canonicalizeHostname.Kind() == reflect.Bool {
+		return canonicalizeHostname.Bool()
+	}
+
+	var cfo options.CanonicalizeHostnameOption
+	ok = false
+
+	if canonicalizeHostname.CanInterface() {
+		cfo, ok = canonicalizeHostname.Interface().(options.CanonicalizeHostnameOption)
+	} else if canonicalizeHostname.CanAddr() {
+		cfo, ok = canonicalizeHostname.Addr().Interface().(options.CanonicalizeHostnameOption)
+	}
+
+	if !ok {
+		return false
+	}
+
+	switch cfo { //nolint:exhaustive
+	case options.CanonicalizeHostnameAlways:
+		return true
+	case options.CanonicalizeHostnameYes:
+		return !hasProxy
+	default:
+		return false
+	}
+}
+
+// determines if canonicalizefallbacklocal is enabled.
+func (s *Setter) allowCanonicalizeFallbackLocal() bool {
+	canonicalizeFallbackLocal, ok := s.fieldByName("CanonicalizeFallbackLocal")
+	if !ok {
+		// default is yes
+		return true
+	}
+
+	if canonicalizeFallbackLocal.Kind() == reflect.Bool {
+		return canonicalizeFallbackLocal.Bool()
+	}
+
+	if canonicalizeFallbackLocal.Kind() == reflect.String {
+		return canonicalizeFallbackLocal.String() == yes
+	}
+
+	return false
+}
+
+func (s *Setter) canonicalizeMaxDots() int {
+	if md, err := s.get("CanonicalizeMaxDots", reflect.Int); err == nil {
+		return int(md.Int())
+	} else if md, err := s.get("CanonicalizeMaxDots", reflect.Uint); err == nil {
+		return int(md.Uint())
+	}
+	return 1
+}
+
+func (s *Setter) canonicalDomains() []string {
+	if canonicalDomains, err := s.get("CanonicalDomains", reflect.Slice, reflect.String); err == nil { //nolint:nestif
+		if canonicalDomains.CanInterface() {
+			if cd, ok := canonicalDomains.Interface().([]string); ok {
+				return cd
+			}
+		}
+		if canonicalDomains.CanAddr() {
+			if cd, ok := canonicalDomains.Addr().Interface().([]string); ok {
+				return cd
+			}
+		}
+	}
+	if canonicalDomains, err := s.get("CanonicalDomains", reflect.String); err == nil {
+		return strings.Split(canonicalDomains.String(), ",")
+	}
+	return nil
+}
+
+func (s *Setter) canonicalizePermittedCNAMEs() map[string]string {
+	res := make(map[string]string)
+	if permittedCnames, err := s.get("CanonicalizePermittedCNAMEs", reflect.Slice, reflect.String); err == nil {
+		if permittedCnames.Len() == 0 || (permittedCnames.Len() == 1 && permittedCnames.Index(0).String() == none) {
+			return res
+		}
+		for i := 0; i < permittedCnames.Len(); i++ {
+			parts := strings.Split(permittedCnames.Index(i).String(), ":")
+			if len(parts) != 2 {
+				continue
+			}
+			from, to := parts[0], parts[1]
+			res[from] = to
+		}
+	}
+	return res
+}
+
+// CanonicalizeHostname performs hostname canonicalization. This is done automatically
+// during the finalization phase when using parser.Apply.
+//
+// It returns an error if the hostname couldn't be canonicalized and CanonicalizeFallbackLocal is not enabled, in which case
+// you should not proceed with the connection.
+func (s *Setter) CanonicalizeHostname() error { //nolint:cyclop
+	if !s.doCanonicalize() {
+		// CanonicalizeHostname not enabled or a proxy is defined and CanonicalizeHostname is not set to "always".
+		return nil
+	}
+
+	host := s.getHost()
+	if strings.HasSuffix(host, ".") {
+		// Hostname is already canonical (a local host)
+		return nil
+	}
+
+	if strings.Count(host, ".") > s.canonicalizeMaxDots() {
+		// Enough dots as it is
+		return nil
+	}
+
+	for _, domain := range s.canonicalDomains() {
+		fqdn := host + "." + domain
+		if _, err := net.LookupHost(fqdn); err != nil {
+			continue
+		}
+
+		cname, err := net.LookupCNAME(fqdn)
+		if err != nil {
+			return fmt.Errorf("failed to lookup CNAME for %q: %w", fqdn, err)
+		}
+
+		// If the CNAME is different than the FQDN and permitted, return the CNAME
+		if cname != fqdn { //nolint:nestif
+			for from, to := range s.canonicalizePermittedCNAMEs() {
+				match, err := patternMatchAll(fqdn, strings.Split(from, ",")...)
+				if err != nil {
+					return fmt.Errorf("failed to match fqdn %q against %q: %w", fqdn, from, err)
+				}
+				if !match {
+					continue
+				}
+				match, err = patternMatchAll(cname, to)
+				if err != nil {
+					return fmt.Errorf("failed to match cname %q against %q: %w", fqdn, to, err)
+				}
+				if match {
+					if err := s.setHost(fkHost, cname); err != nil {
+						return fmt.Errorf("failed to set host to %q: %w", cname, err)
+					}
+					return nil
+				}
+			}
+		}
+		// No acceptable CNAME, return the FQDN
+		if err := s.setHost(fkHost, fqdn); err != nil {
+			return fmt.Errorf("failed to set host to %q: %w", cname, err)
+		}
+		return nil
+	}
+
+	// No fqdn or cname found
+
+	if s.allowCanonicalizeFallbackLocal() {
+		// Fallback to the original is permitted.
+		return nil
+	}
+
+	// Fallback to the original is not permitted.
+	return fmt.Errorf("%w: failed to canonicalize %q and CanonicalizeFallbackLocal is not enabled", errCanonicalizationFailed, host)
+}
+
+// The Match condition "localnetwork" matches a list of cidrs against
+// ip addresses on local network interfaces.
+func matchLocalNetwork(cidrs []string) (bool, error) {
+	parsedCIDRs := make([]*net.IPNet, len(cidrs))
+	for i, cidr := range cidrs {
+		_, parsedCIDR, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return false, fmt.Errorf("invalid CIDR %s: %w", cidr, err)
+		}
+		parsedCIDRs[i] = parsedCIDR
+	}
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return false, fmt.Errorf("can't get network interfaces: %w", err)
+	}
+	for _, iface := range interfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return false, fmt.Errorf("can't get addresses for %s: %w", iface.Name, err)
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+
+			// Check if IP is within any of the CIDRs
+			for _, cidr := range parsedCIDRs {
+				if cidr.Contains(ip) {
+					// match found
+					return true, nil
+				}
+			}
+		}
+	}
+	// No match found
+	return false, nil
+}

--- a/sshconfig/set_test.go
+++ b/sshconfig/set_test.go
@@ -1,0 +1,1519 @@
+package sshconfig_test
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/rig/v2/sshconfig"
+	"github.com/stretchr/testify/require"
+)
+
+func ExampleNewSetter() {
+	type MyConfig struct {
+		Host string
+		Port int
+	}
+	obj := &MyConfig{}
+	setter, err := sshconfig.NewSetter(obj)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = setter.Set("Host", "example.com")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = setter.Set("Port", "2022")
+	// On most of the config keys the first value to be set will remain in effect.
+	_ = setter.Set("Port", "22")
+	fmt.Println("Host:", obj.Host)
+	fmt.Println("Port:", obj.Port)
+	// Output:
+	// Host: example.com
+	// Port: 2022
+}
+
+func ExampleSetter_Set() {
+	type MyConfig struct {
+		Port int
+	}
+	obj := &MyConfig{}
+	setter, err := sshconfig.NewSetter(obj)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = setter.Set("Port", "2022")
+	fmt.Println("Port:", obj.Port)
+	// Output:
+	// Port: 2022
+}
+
+func TestSetter(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	require.NoError(t, setter.Set("Host", "test"))
+	require.NoError(t, setter.Set("Port", "22"))
+	require.NoError(t, setter.Set("User", "root"))
+	require.Equal(t, "test", obj.Host)
+	require.Equal(t, 22, obj.Port)
+	require.Equal(t, "root", obj.User)
+}
+
+func TestSetterBasicPrecedence(t *testing.T) {
+	obj := sshconfig.Config{
+		User:               "foo",
+		UserKnownHostsFile: []string{},
+	}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	require.NoError(t, setter.Set("User", "bar"))
+	require.Equal(t, "foo", obj.User, "a set value should not override an existing value")
+	require.NoError(t, setter.Set("UserKnownHostsFile", "/test", "/test2"))
+	require.Equal(t, []string{"/test", "/test2"}, obj.UserKnownHostsFile, "an empty slice should be replaced by the new value")
+	require.NoError(t, setter.Set("UserKnownHostsFile", "/test3"))
+	require.Equal(t, []string{"/test", "/test2"}, obj.UserKnownHostsFile, "a populated list should not be appended")
+}
+
+func TestSetterBooleanOptions(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	require.NoError(t, setter.Set("BatchMode", "yes"))
+	require.True(t, obj.BatchMode.IsTrue())
+	require.False(t, obj.BatchMode.IsFalse())
+	require.NoError(t, setter.Set("BatchMode", "no"))
+	require.True(t, obj.BatchMode.IsTrue(), "a set boolean should not change value")
+}
+
+func TestSetterInvalidBoolean(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	require.Error(t, setter.Set("BatchMode", "maybe"))
+}
+
+func TestSetterFieldHost(t *testing.T) {
+	t.Run("preset value", func(t *testing.T) {
+		obj := sshconfig.Config{Host: "test"}
+		setter, err := sshconfig.NewSetter(&obj)
+		require.NoError(t, err)
+		require.Equal(t, "test", setter.OriginalHost)
+		require.NoError(t, setter.Set("Host", "test2"))
+		require.Equal(t, "test2", obj.Host)
+		require.Equal(t, "test", setter.OriginalHost)
+		require.True(t, setter.HostChanged(), "changing existing value should be considered a change")
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		obj := sshconfig.Config{}
+		setter, err := sshconfig.NewSetter(&obj)
+		require.NoError(t, err)
+		require.NoError(t, setter.Set("Host", "test"))
+		require.Equal(t, "test", obj.Host)
+		require.Equal(t, "test", setter.OriginalHost)
+		require.False(t, setter.HostChanged(), "first value should not be considered a change")
+		require.NoError(t, setter.Set("Host", "test2"))
+		require.Equal(t, "test2", obj.Host)
+		require.Equal(t, "test", setter.OriginalHost, "originalhost should remain unchanged")
+		require.True(t, setter.HostChanged(), "new value should be considered a change")
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		obj := sshconfig.Config{}
+		setter, err := sshconfig.NewSetter(&obj)
+		require.NoError(t, err)
+		require.Error(t, setter.Set("Host", ""))
+		require.Error(t, setter.Set("Host", "foo", "bar"))
+	})
+}
+
+func TestSetterFieldMatch(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("invalid", func(t *testing.T) {
+		require.Error(t, setter.Set("Match", "foo"), "Match should not be settable")
+	})
+}
+
+func TestSetterFieldAddKeysToAgent(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		_ = setter.Reset("AddKeysToAgent")
+		require.NoError(t, setter.Set("AddKeysToAgent", "yes"))
+		require.True(t, obj.AddKeysToAgent.IsTrue())
+		require.False(t, obj.AddKeysToAgent.HasInterval())
+
+		_ = setter.Reset("AddKeysToAgent")
+		require.NoError(t, setter.Set("AddKeysToAgent", "confirm", "80"))
+		require.False(t, obj.AddKeysToAgent.IsTrue())
+		require.True(t, obj.AddKeysToAgent.HasInterval())
+		iv, err := obj.AddKeysToAgent.Interval()
+		require.NoError(t, err)
+		require.Equal(t, 80*time.Second, iv)
+
+		_ = setter.Reset("AddKeysToAgent")
+		require.NoError(t, setter.Set("AddKeysToAgent", "80"))
+		require.False(t, obj.AddKeysToAgent.IsTrue())
+		require.True(t, obj.AddKeysToAgent.HasInterval())
+		iv, err = obj.AddKeysToAgent.Interval()
+		require.NoError(t, err)
+		require.Equal(t, 80*time.Second, iv)
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("AddKeysToAgent"))
+		require.Error(t, setter.Set("AddKeysToAgent", "maybe"))
+		require.Error(t, setter.Set("AddKeysToAgent", "confirm", "sometime"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("AddKeysToAgent"))
+		require.NoError(t, setter.Set("AddKeysToAgent", "confirm", "80"))
+		require.False(t, obj.AddKeysToAgent.IsTrue())
+		require.True(t, obj.AddKeysToAgent.HasInterval())
+
+		require.NoError(t, setter.Set("AddKeysToAgent", "yes"))
+		require.Equal(t, "confirm 80", obj.AddKeysToAgent.String(), "original value should stick")
+	})
+}
+
+func TestSetterBooleanOptionFields(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	basicBools := []string{
+		"AppleMultiPath",
+		"UseKeychain",
+		"BatchMode",
+		"CanonicalizeFallbackLocal",
+		"CheckHostIP",
+		"ClearAllForwardings",
+		"Compression",
+		"EnableEscapeCommandline",
+		"EnableSSHKeysign",
+		"ExitOnForwardFailure",
+		"ForkAfterAuthentication",
+		"ForwardX11",
+		"ForwardX11Trusted",
+		"GatewayPorts",
+		"GSSAPIAuthentication",
+		"GSSAPIDelegateCredentials",
+		"HashKnownHosts",
+		"HostbasedAuthentication",
+		"IdentitiesOnly",
+		"KbdInteractiveAuthentication",
+		"NoHostAuthenticationForLocalhost",
+		"PasswordAuthentication",
+		"PermitLocalCommand",
+		"ProxyUseFdpass",
+		"StdinNull",
+		"StreamLocalBindUnlink",
+		"TCPKeepAlive",
+		"VisualHostKey",
+	}
+	type boolOpt interface {
+		IsTrue() bool
+		IsFalse() bool
+	}
+	for _, field := range basicBools {
+		t.Run(field, func(t *testing.T) {
+			t.Run("valid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "no"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				var value boolOpt
+				var ok bool
+				if f.Kind() == reflect.Ptr && !f.IsNil() {
+					value, ok = f.Elem().Interface().(boolOpt)
+				} else if f.CanAddr() {
+					// Use Addr() only if the field is addressable
+					value, ok = f.Addr().Interface().(boolOpt)
+				}
+				require.True(t, ok)
+				require.False(t, value.IsTrue())
+				require.True(t, value.IsFalse())
+
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "yes"))
+				f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+				value, ok = f.Addr().Interface().(boolOpt)
+				require.True(t, ok)
+				require.True(t, value.IsTrue())
+				require.False(t, value.IsFalse())
+			})
+			t.Run("invalid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.Error(t, setter.Set(field, "maybe"))
+			})
+			t.Run("precedence", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "no"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				value, ok := f.Addr().Interface().(boolOpt)
+				require.True(t, ok)
+				require.True(t, value.IsFalse())
+
+				require.NoError(t, setter.Set(field, "yes"))
+				f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+				value, ok = f.Addr().Interface().(boolOpt)
+				require.True(t, ok)
+				require.True(t, value.IsFalse(), "original value should stick")
+			})
+		})
+	}
+}
+
+func TestSetterRegularStringFields(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	basicStrings := []string{
+		"User",
+		"Hostname",
+		"BindAddress",
+		"BindInterface",
+		"HostKeyAlias",
+		"Tag",
+		"TunnelDevice",
+		"KnownHostsCommand",
+		"LocalCommand",
+		"ProxyCommand",
+		"RemoteCommand",
+		"PKCS11Provider",
+	}
+	for _, field := range basicStrings {
+		t.Run(field, func(t *testing.T) {
+			t.Run("valid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, "value", f.String())
+			})
+			t.Run("invalid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.Error(t, setter.Set(field, ""))
+			})
+			t.Run("precedence", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, "value", f.String())
+
+				require.NoError(t, setter.Set(field, "value2"))
+				f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, "value", f.String(), "original value should stick")
+			})
+		})
+	}
+}
+
+func TestSetterRegularStringSliceFields(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	stringSlices := []string{
+		"CanonicalDomains",
+		"GlobalKnownHostsFile",
+		"IgnoreUnknown",
+		"LogVerbose",
+	}
+	for _, field := range stringSlices {
+		t.Run(field, func(t *testing.T) {
+			t.Run("valid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, 1, f.Len())
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value", "another"))
+				require.Equal(t, 2, f.Len())
+			})
+			t.Run("invalid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.Error(t, setter.Set(field, ""))
+				require.NoError(t, setter.Reset(field))
+				require.Error(t, setter.Set(field))
+			})
+			t.Run("precedence", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value", "value2"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, 2, f.Len())
+				require.NoError(t, setter.Set(field, "value3"))
+				require.Equal(t, 2, f.Len(), "original values should stick")
+				require.Equal(t, "value", f.Index(0).String(), "original values should stick")
+				require.Equal(t, "value2", f.Index(1).String(), "original values should stick")
+			})
+		})
+	}
+}
+
+func TestSetterPathFields(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	pathFields := []string{
+		"ControlPath",
+		"RevokedHostKeys",
+		"SecurityKeyProvider",
+		"XAuthLocation",
+	}
+	// regular path fields should be treated as regular strings.
+	// tilde expansion should be done elsewhere.
+	// the only directive with special relative path handling is "Include",
+	// you can put ./foo for IdentityFile in ~/.ssh/config and the resulting
+	// path will be ./foo, not /home/user/.ssh/./foo.
+	for _, field := range pathFields {
+		t.Run(field, func(t *testing.T) {
+			t.Run("valid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, "value", f.String())
+			})
+			t.Run("invalid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.Error(t, setter.Set(field, ""))
+			})
+			t.Run("precedence", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, "value", f.String())
+
+				require.NoError(t, setter.Set(field, "value2"))
+				f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, "value", f.String(), "original value should stick")
+			})
+		})
+	}
+}
+
+func TestSetterAlgoFields(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	algoFields := []string{
+		"CASignatureAlgorithms",
+		"Ciphers",
+		"HostbasedAcceptedAlgorithms",
+		"HostKeyAlgorithms",
+		"KexAlgorithms",
+		"MACs",
+		"PubkeyAcceptedAlgorithms",
+	}
+	// the precedence in these fields is standard.
+	// the modifiers only work when the field is empty.
+	// the modifiers work ONCE against the default values.
+	// for example, something like -aes128 will apply the defaults minus aes128
+	// and after that ^aes256 or +aes128 won't do anything.
+
+	for _, field := range algoFields {
+		t.Run(field, func(t *testing.T) {
+			t.Run("valid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, 1, f.Len())
+				require.Equal(t, "value", f.Index(0).String())
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value,another"))
+				f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, 2, f.Len())
+				require.Equal(t, "value", f.Index(0).String())
+				require.Equal(t, "another", f.Index(1).String())
+			})
+			t.Run("invalid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.Error(t, setter.Set(field, ""))
+				require.Error(t, setter.Set(field, "hello", "world"))
+			})
+			t.Run("precedence", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, 1, f.Len())
+				require.Equal(t, "value", f.Index(0).String())
+				require.NoError(t, setter.Set(field, "value,another"))
+				f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, 1, f.Len(), "original value should stick")
+				require.Equal(t, "value", f.Index(0).String(), "original value should stick")
+			})
+			t.Run("modifiers", func(t *testing.T) {
+				t.Run("^", func(t *testing.T) {
+					require.NoError(t, setter.Reset(field))
+					require.NoError(t, setter.Set(field, "^value,another"))
+					f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+					require.True(t, f.Len() > 2)
+					require.Equal(t, "value", f.Index(0).String())
+					require.Equal(t, "another", f.Index(1).String())
+				})
+				t.Run("+", func(t *testing.T) {
+					require.NoError(t, setter.Reset(field))
+					require.NoError(t, setter.Set(field, "+value,another"))
+					f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+					require.True(t, f.Len() > 2)
+					require.Equal(t, "value", f.Index(f.Len()-2).String())
+					require.Equal(t, "another", f.Index(f.Len()-1).String())
+				})
+				t.Run("-", func(t *testing.T) {
+					// need to run -dummy first to figure out the defaults
+					require.NoError(t, setter.Reset(field))
+					require.NoError(t, setter.Set(field, "-dummy"))
+					f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+					values, ok := f.Interface().([]string)
+					require.True(t, ok)
+					require.NotContains(t, values, "dummy")
+					origLen := len(values)
+					if origLen > 3 {
+						// the ssh version on github runners has empty CASignatureAlgorithms
+						require.True(t, origLen > 3)
+						// now we can test the actual modifier
+						require.NoError(t, setter.Reset(field))
+						remove := values[2]
+						require.NoError(t, setter.Set(field, "-"+remove))
+						f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+						values, ok = f.Interface().([]string)
+						require.True(t, ok)
+						require.NotContains(t, values, remove)
+						require.Equal(t, origLen-1, len(values))
+						// the op should only happen once
+						remove = values[2]
+						require.NoError(t, setter.Set(field, "-"+remove))
+						f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+						values, ok = f.Interface().([]string)
+						require.True(t, ok)
+						require.Contains(t, values, remove, "removal should only happen once")
+					}
+				})
+			})
+		})
+	}
+}
+
+func TestSetterFieldAddressFamily(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		for _, val := range []string{"any", "inet", "inet6"} {
+			require.NoError(t, setter.Reset("AddressFamily"))
+			require.NoError(t, setter.Set("AddressFamily", val))
+			require.Equal(t, val, obj.AddressFamily)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("AddressFamily"))
+		require.Error(t, setter.Set("AddressFamily", "none"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("AddressFamily"))
+		require.NoError(t, setter.Set("AddressFamily", "inet"))
+		require.Equal(t, "inet", obj.AddressFamily)
+		require.NoError(t, setter.Set("AddressFamily", "any"))
+		require.Equal(t, "inet", obj.AddressFamily, "original value should stick")
+	})
+}
+
+func TestSetterFieldCanonicalizeHostname(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("CanonicalizeHostname"))
+		require.NoError(t, setter.Set("CanonicalizeHostname", "yes"))
+		require.False(t, obj.CanonicalizeHostname.IsAlways())
+		require.True(t, obj.CanonicalizeHostname.IsTrue())
+		require.NoError(t, setter.Reset("CanonicalizeHostname"))
+		require.NoError(t, setter.Set("CanonicalizeHostname", "no"))
+		require.True(t, obj.CanonicalizeHostname.IsFalse())
+		require.False(t, obj.CanonicalizeHostname.IsTrue())
+		require.NoError(t, setter.Reset("CanonicalizeHostname"))
+		require.NoError(t, setter.Set("CanonicalizeHostname", "always"))
+		require.True(t, obj.CanonicalizeHostname.IsTrue())
+		require.True(t, obj.CanonicalizeHostname.IsAlways())
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("CanonicalizeHostname"))
+		require.Error(t, setter.Set("CanonicalizeHostname", "maybe"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("CanonicalizeHostname"))
+		require.NoError(t, setter.Set("CanonicalizeHostname", "yes"))
+		require.NoError(t, setter.Set("CanonicalizeHostname", "no"))
+		require.Equal(t, "yes", obj.CanonicalizeHostname.String(), "original value should stick")
+	})
+}
+
+func TestSetterIntFields(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+
+	intFields := []string{
+		"CanonicalizeMaxDots",
+		"ConnectionAttempts",
+		"NumberOfPasswordPrompts",
+		"RequiredRSASize",
+		"ServerAliveCountMax",
+	}
+	for _, field := range intFields {
+		t.Run(field, func(t *testing.T) {
+			t.Run("valid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "5"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				if f.Kind() == reflect.Ptr {
+					require.Equal(t, 5, int(f.Elem().Int()))
+				} else {
+					require.Equal(t, 5, int(f.Int()))
+				}
+			})
+			t.Run("invalid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.Error(t, setter.Set(field, ""))
+				require.Error(t, setter.Set(field, "1", "2"))
+				require.Error(t, setter.Set(field, "hello"))
+			})
+			t.Run("precedence", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "5"))
+				require.NoError(t, setter.Set(field, "1"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				if f.Kind() == reflect.Ptr {
+					require.Equal(t, 5, int(f.Elem().Int()), "original value should stick")
+				} else {
+					require.Equal(t, 5, int(f.Int()), "original value should stick")
+				}
+			})
+		})
+	}
+}
+
+func TestSetterFieldCanonicalizePermittedCNAMEs(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("CanonicalizePermittedCNAMEs"))
+		require.NoError(t, setter.Set("CanonicalizePermittedCNAMEs", "key:value", "key2:value2"))
+		require.Equal(t, "key:value", obj.CanonicalizePermittedCNAMEs[0])
+		require.Equal(t, "key2:value2", obj.CanonicalizePermittedCNAMEs[1])
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("CanonicalizePermittedCNAMEs"))
+		require.Error(t, setter.Set("CanonicalizePermittedCNAMEs", "key"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("CanonicalizePermittedCNAMEs"))
+		require.NoError(t, setter.Set("CanonicalizePermittedCNAMEs", "key:value", "key2:value2"))
+		require.Equal(t, 2, len(obj.CanonicalizePermittedCNAMEs))
+		require.NoError(t, setter.Set("CanonicalizePermittedCNAMEs", "key3:value3"))
+		require.Equal(t, 2, len(obj.CanonicalizePermittedCNAMEs), "original values should stick")
+	})
+}
+
+func TestSetterFieldCertificateFile(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("CertificateFile"))
+		require.NoError(t, setter.Set("CertificateFile", "value"))
+		require.Len(t, obj.CertificateFile, 1)
+		require.Equal(t, "value", obj.CertificateFile[0])
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("CertificateFile"))
+		require.Error(t, setter.Set("CertificateFile", ""))
+		require.Error(t, setter.Set("CertificateFile", "none", "hello"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("CertificateFile"))
+		require.NoError(t, setter.Set("CertificateFile", "value"))
+		require.Len(t, obj.CertificateFile, 1)
+		require.Equal(t, "value", obj.CertificateFile[0])
+		require.NoError(t, setter.Set("CertificateFile", "value2", "value3"))
+		require.Len(t, obj.CertificateFile, 3, "certificatefile should accumulate")
+		require.NoError(t, setter.Set("CertificateFile", "none"))
+		require.Len(t, obj.CertificateFile, 1, "none should override the whole list")
+		require.Equal(t, "none", obj.CertificateFile[0])
+		require.NoError(t, setter.Set("CertificateFile", "value2", "value3"))
+		require.Len(t, obj.CertificateFile, 1, "none should override the whole list forever")
+		require.Equal(t, "none", obj.CertificateFile[0])
+	})
+}
+
+func TestSetterFieldChannelTimeout(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ChannelTimeout"))
+		require.NoError(t, setter.Set("ChannelTimeout", "agent-connection=1m", "direct-tcpip=60"))
+		require.Len(t, obj.ChannelTimeout, 2)
+		require.Equal(t, 1*time.Minute, obj.ChannelTimeout["agent-connection"])
+		require.Equal(t, 1*time.Minute, obj.ChannelTimeout["direct-tcpip"])
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ChannelTimeout"))
+		require.Error(t, setter.Set("ChannelTimeout", "foo"))
+		require.Error(t, setter.Set("ChannelTimeout", "foo=bar"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ChannelTimeout"))
+		require.NoError(t, setter.Set("ChannelTimeout", "agent-connection=1m", "direct-tcpip=60"))
+		require.NoError(t, setter.Set("ChannelTimeout", "agent-connection=2m", "tun-connection=40"))
+		require.Len(t, obj.ChannelTimeout, 2, "original values should stick")
+		require.Equal(t, 1*time.Minute, obj.ChannelTimeout["agent-connection"], "original values should stick")
+		require.Equal(t, 1*time.Minute, obj.ChannelTimeout["direct-tcpip"], "original values should stick")
+	})
+}
+
+func TestSetterDurationFields(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+
+	durationFields := []string{
+		"ConnectTimeout",
+		"ForwardX11Timeout",
+		"ServerAliveInterval",
+	}
+
+	for _, field := range durationFields {
+		t.Run(field, func(t *testing.T) {
+			t.Run("valid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "5"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				val, ok := f.Interface().(time.Duration)
+				require.True(t, ok)
+				require.Equal(t, 5*time.Second, val)
+
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "3m"))
+				f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+				val, ok = f.Interface().(time.Duration)
+				require.True(t, ok)
+				require.Equal(t, 180*time.Second, val)
+
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "none"))
+				f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.True(t, ok)
+				require.True(t, f.IsZero() || f.IsNil())
+			})
+			t.Run("invalid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.Error(t, setter.Set(field, ""))
+				require.Error(t, setter.Set(field, "abc"))
+			})
+			t.Run("precedence", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "5"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				val, ok := f.Interface().(time.Duration)
+				require.True(t, ok)
+				require.Equal(t, 5*time.Second, val)
+
+				require.NoError(t, setter.Set(field, "3m"))
+				f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+				val, ok = f.Interface().(time.Duration)
+				require.True(t, ok)
+				require.Equal(t, 5*time.Second, val, "original value should stick")
+			})
+		})
+	}
+}
+
+func TestSetterFieldControlMaster(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ControlMaster"))
+		require.NoError(t, setter.Set("ControlMaster", "yes"))
+		require.True(t, obj.ControlMaster.IsTrue())
+		require.NoError(t, setter.Reset("ControlMaster"))
+		require.NoError(t, setter.Set("ControlMaster", "no"))
+		require.True(t, obj.ControlMaster.IsFalse())
+		require.NoError(t, setter.Reset("ControlMaster"))
+		require.NoError(t, setter.Set("ControlMaster", "auto"))
+		require.True(t, obj.ControlMaster.IsAuto())
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ControlMaster"))
+		require.Error(t, setter.Set("ControlMaster", "hmm"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ControlMaster"))
+		require.NoError(t, setter.Set("ControlMaster", "auto"))
+		require.True(t, obj.ControlMaster.IsAuto())
+		require.NoError(t, setter.Set("ControlMaster", "no"))
+		require.True(t, obj.ControlMaster.IsAuto(), "original value should stick")
+	})
+}
+
+func TestSetterFieldControlPersist(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ControlPersist"))
+		require.NoError(t, setter.Set("ControlPersist", "yes"))
+		require.False(t, obj.ControlPersist.HasInterval())
+		require.True(t, obj.ControlPersist.IsTrue())
+		_, err := obj.ControlPersist.Interval()
+		require.Error(t, err)
+		require.NoError(t, setter.Reset("ControlPersist"))
+		require.NoError(t, setter.Set("ControlPersist", "no"))
+		require.True(t, obj.ControlPersist.IsFalse())
+		require.NoError(t, setter.Reset("ControlPersist"))
+		require.NoError(t, setter.Set("ControlPersist", "5m"))
+		require.True(t, obj.ControlPersist.HasInterval())
+		iv, err := obj.ControlPersist.Interval()
+		require.NoError(t, err)
+		require.Equal(t, 5*time.Minute, iv)
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ControlPersist"))
+		require.Error(t, setter.Set("ControlPersist", "maybe"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ControlPersist"))
+		require.NoError(t, setter.Set("ControlPersist", "yes"))
+		require.NoError(t, setter.Set("ControlPersist", "no"))
+		require.True(t, obj.ControlPersist.IsTrue(), "original value should stick")
+	})
+}
+
+func TestSetterFieldDynamicForward(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("DynamicForward"))
+		require.NoError(t, setter.Set("DynamicForward", "value"))
+		require.Len(t, obj.DynamicForward, 1)
+		require.Equal(t, "value", obj.DynamicForward[0])
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("DynamicForward"))
+		require.Error(t, setter.Set("DynamicForward", ""))
+		require.Error(t, setter.Set("DynamicForward", "none", "hello"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("DynamicForward"))
+		require.NoError(t, setter.Set("DynamicForward", "value"))
+		require.Len(t, obj.DynamicForward, 1)
+		require.Equal(t, "value", obj.DynamicForward[0])
+		require.NoError(t, setter.Set("DynamicForward", "value2", "value3"))
+		require.Len(t, obj.DynamicForward, 3, "dynamicforward should accumulate")
+		require.NoError(t, setter.Set("DynamicForward", "none"))
+		require.Len(t, obj.DynamicForward, 1, "none should override the whole list")
+		require.Equal(t, "none", obj.DynamicForward[0])
+		require.NoError(t, setter.Set("DynamicForward", "value2", "value3"))
+		require.Len(t, obj.DynamicForward, 1, "none should override the whole list forever")
+		require.Equal(t, "none", obj.DynamicForward[0])
+	})
+}
+
+func TestSetterFieldFingerprintHash(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		for _, val := range []string{"MD5", "SHA256"} {
+			require.NoError(t, setter.Reset("FingerprintHash"))
+			require.NoError(t, setter.Set("FingerprintHash", val))
+			require.Equal(t, val, obj.FingerprintHash.String())
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("FingerprintHash"))
+		require.Error(t, setter.Set("FingerprintHash", "none"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("FingerprintHash"))
+		require.NoError(t, setter.Set("FingerprintHash", "MD5"))
+		require.NoError(t, setter.Set("FingerprintHash", "SHA256"))
+		require.Equal(t, "MD5", obj.FingerprintHash.String(), "original value should stick")
+	})
+}
+
+func TestSetterFieldForwardAgent(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ForwardAgent"))
+		require.NoError(t, setter.Set("ForwardAgent", "yes"))
+		require.True(t, obj.ForwardAgent.IsTrue())
+		require.NoError(t, setter.Reset("ForwardAgent"))
+		require.NoError(t, setter.Set("ForwardAgent", "no"))
+		require.True(t, obj.ForwardAgent.IsFalse())
+
+		t.Setenv("SSH_AUTH_SOCK", "/tmp/ssh-agent")
+		require.NoError(t, setter.Reset("ForwardAgent"))
+		require.NoError(t, setter.Set("ForwardAgent", "$SSH_AUTH_SOCK"))
+		require.True(t, obj.ForwardAgent.IsSocket())
+
+		require.Equal(t, "/tmp/ssh-agent", obj.ForwardAgent.Socket())
+		require.NoError(t, setter.Reset("ForwardAgent"))
+		require.NoError(t, setter.Set("ForwardAgent", "${SSH_AUTH_SOCK}"))
+		require.True(t, obj.ForwardAgent.IsSocket())
+		require.Equal(t, "/tmp/ssh-agent", obj.ForwardAgent.Socket())
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ForwardAgent"))
+		require.Error(t, setter.Set("ForwardAgent"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ForwardAgent"))
+		require.NoError(t, setter.Set("ForwardAgent", "no"))
+		require.True(t, obj.ForwardAgent.IsFalse())
+
+		t.Setenv("SSH_AUTH_SOCK", "/tmp/ssh-agent")
+		require.NoError(t, setter.Set("ForwardAgent", "$SSH_AUTH_SOCK"))
+		require.False(t, obj.ForwardAgent.IsSocket(), "original value should stick")
+		require.True(t, obj.ForwardAgent.IsFalse(), "original value should stick")
+	})
+}
+
+func TestSetterFieldGlobalKnownHostsFile(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("GlobalKnownHostsFile"))
+		require.NoError(t, setter.Set("GlobalKnownHostsFile", "value", "value2"))
+		require.Len(t, obj.GlobalKnownHostsFile, 2)
+		require.Equal(t, []string{"value", "value2"}, obj.GlobalKnownHostsFile)
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("GlobalKnownHostsFile"))
+		require.Error(t, setter.Set("GlobalKnownHostsFile", ""))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("GlobalKnownHostsFile"))
+		require.NoError(t, setter.Set("GlobalKnownHostsFile", "value", "value2"))
+		require.Len(t, obj.GlobalKnownHostsFile, 2)
+		require.Equal(t, []string{"value", "value2"}, obj.GlobalKnownHostsFile)
+		require.NoError(t, setter.Set("GlobalKnownHostsFile", "value3"))
+		require.Len(t, obj.GlobalKnownHostsFile, 2, "original values should stick")
+		require.Equal(t, []string{"value", "value2"}, obj.GlobalKnownHostsFile, "original values should stick")
+	})
+}
+
+func TestSetterFieldIdentityAgent(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("IdentityAgent"))
+		require.NoError(t, setter.Set("IdentityAgent", "foo"))
+		require.Equal(t, "foo", obj.IdentityAgent.String())
+
+		t.Setenv("SSH_AUTH_SOCK", "/tmp/ssh-agent")
+		require.NoError(t, setter.Reset("IdentityAgent"))
+		require.NoError(t, setter.Set("IdentityAgent", "SSH_AUTH_SOCK"))
+		require.Equal(t, "/tmp/ssh-agent", obj.IdentityAgent.Socket())
+
+		require.NoError(t, setter.Reset("IdentityAgent"))
+		require.NoError(t, setter.Set("IdentityAgent", "${SSH_AUTH_SOCK}"))
+		require.Equal(t, "/tmp/ssh-agent", obj.IdentityAgent.Socket())
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("IdentityAgent"))
+		require.Error(t, setter.Set("IdentityAgent", ""))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("IdentityAgent"))
+		require.NoError(t, setter.Set("IdentityAgent", "foo"))
+		require.NoError(t, setter.Set("IdentityAgent", "bar"))
+		require.Equal(t, "foo", obj.IdentityAgent.String(), "original value should stick")
+	})
+}
+
+func TestSetterFieldIdentityFile(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("IdentityFile"))
+		require.NoError(t, setter.Set("IdentityFile", "value"))
+		require.Len(t, obj.IdentityFile, 1)
+		require.Equal(t, "value", obj.IdentityFile[0])
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("IdentityFile"))
+		require.Error(t, setter.Set("IdentityFile", ""))
+		require.Error(t, setter.Set("IdentityFile", "none", "hello"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("IdentityFile"))
+		require.NoError(t, setter.Set("IdentityFile", "value"))
+		require.Len(t, obj.IdentityFile, 1)
+		require.Equal(t, "value", obj.IdentityFile[0])
+		require.NoError(t, setter.Set("IdentityFile", "value2", "value3"))
+		require.Len(t, obj.IdentityFile, 3, "identityfile should accumulate")
+		require.NoError(t, setter.Set("IdentityFile", "none"))
+		require.Len(t, obj.IdentityFile, 1, "none should override the whole list")
+		require.Equal(t, "none", obj.IdentityFile[0])
+		require.NoError(t, setter.Set("IdentityFile", "value2", "value3"))
+		require.Len(t, obj.IdentityFile, 1, "none should override the whole list forever")
+		require.Equal(t, "none", obj.IdentityFile[0])
+	})
+}
+
+func TestSetterFieldIPQoS(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		for _, val := range []string{"af11", "af12", "af13", "af21", "af22", "af23", "af31", "af32", "af33", "af41", "af42", "af43", "cs0", "cs1", "cs2", "cs3", "cs4", "cs5", "cs6", "cs7", "ef", "lowdelay", "throughput", "reliability"} {
+			require.NoError(t, setter.Reset("IPQoS"))
+			require.NoError(t, setter.Set("IPQoS", val))
+		}
+		require.NoError(t, setter.Reset("IPQoS"))
+		require.NoError(t, setter.Set("IPQoS", "af11"))
+		require.Equal(t, "af11", obj.IPQoS[0])
+
+		require.NoError(t, setter.Reset("IPQoS"))
+		require.NoError(t, setter.Set("IPQoS", "af11", "lowdelay"))
+		require.Equal(t, "af11", obj.IPQoS[0])
+		require.Equal(t, "lowdelay", obj.IPQoS[1])
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("IPQoS"))
+		require.Error(t, setter.Set("IPQoS", "af11", "lowdelay", "reliability"))
+		require.Error(t, setter.Set("IPQoS", "hello"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("IPQoS"))
+		require.NoError(t, setter.Set("IPQoS", "af11"))
+		require.Equal(t, "af11", obj.IPQoS[0])
+
+		require.NoError(t, setter.Set("IPQoS", "af11", "lowdelay"))
+		require.Equal(t, "af11", obj.IPQoS[0])
+		require.Len(t, obj.IPQoS, 1, "original values should stick")
+	})
+}
+
+func TestSetterCSVFields(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+
+	csvFields := []string{
+		"KbdInteractiveDevices",
+		"PreferredAuthentications",
+		"ProxyJump",
+	}
+	for _, field := range csvFields {
+		t.Run(field, func(t *testing.T) {
+			t.Run("valid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, 1, f.Len())
+				require.Equal(t, "value", f.Index(0).String())
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value,another"))
+				f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, 2, f.Len())
+				require.Equal(t, "value", f.Index(0).String())
+				require.Equal(t, "another", f.Index(1).String())
+			})
+			t.Run("invalid", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.Error(t, setter.Set(field, ""))
+				require.Error(t, setter.Set(field, "hello", "world"))
+			})
+			t.Run("precedence", func(t *testing.T) {
+				require.NoError(t, setter.Reset(field))
+				require.NoError(t, setter.Set(field, "value"))
+				f := reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, 1, f.Len())
+				require.Equal(t, "value", f.Index(0).String())
+				require.NoError(t, setter.Set(field, "value,another"))
+				f = reflect.ValueOf(&obj).Elem().FieldByName(field)
+				require.Equal(t, 1, f.Len(), "original value should stick")
+				require.Equal(t, "value", f.Index(0).String(), "original value should stick")
+			})
+		})
+	}
+}
+
+func TestSetterForwardFields(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("LocalForward", func(t *testing.T) {
+		t.Run("valid", func(t *testing.T) {
+			require.NoError(t, setter.Reset("LocalForward"))
+			require.NoError(t, setter.Set("LocalForward", "key", "value"))
+			require.Len(t, obj.LocalForward, 1)
+		})
+		t.Run("invalid", func(t *testing.T) {
+			require.NoError(t, setter.Reset("LocalForward"))
+			require.Error(t, setter.Set("LocalForward", "key"))
+		})
+		t.Run("precedence", func(t *testing.T) {
+			require.NoError(t, setter.Reset("LocalForward"))
+			require.NoError(t, setter.Set("LocalForward", "key", "value"))
+			require.Len(t, obj.LocalForward, 1)
+			require.Equal(t, "value", obj.LocalForward["key"])
+			require.NoError(t, setter.Set("LocalForward", "key2", "value2"))
+			require.Len(t, obj.LocalForward, 2, "forwarding fields should accumulate")
+			require.Equal(t, "value2", obj.LocalForward["key2"])
+		})
+	})
+	t.Run("RemoteForward", func(t *testing.T) {
+		t.Run("valid", func(t *testing.T) {
+			require.NoError(t, setter.Reset("RemoteForward"))
+			require.NoError(t, setter.Set("RemoteForward", "key", "value"))
+			require.Len(t, obj.RemoteForward, 1)
+		})
+		t.Run("invalid", func(t *testing.T) {
+			require.NoError(t, setter.Reset("RemoteForward"))
+			require.Error(t, setter.Set("RemoteForward", "key"))
+		})
+		t.Run("precedence", func(t *testing.T) {
+			require.NoError(t, setter.Reset("RemoteForward"))
+			require.NoError(t, setter.Set("RemoteForward", "key", "value"))
+			require.Len(t, obj.RemoteForward, 1)
+			require.Equal(t, "value", obj.RemoteForward["key"])
+			require.NoError(t, setter.Set("RemoteForward", "key2", "value2"))
+			require.Len(t, obj.RemoteForward, 2, "forwarding fields should accumulate")
+			require.Equal(t, "value2", obj.RemoteForward["key2"])
+		})
+	})
+}
+
+func TestSetterFieldLogLevel(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		for _, val := range []string{"QUIET", "FATAL", "ERROR", "INFO", "VERBOSE", "DEBUG", "DEBUG1", "DEBUG2", "DEBUG3"} {
+			require.NoError(t, setter.Reset("LogLevel"))
+			require.NoError(t, setter.Set("LogLevel", val))
+			require.Equal(t, val, obj.LogLevel)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("LogLevel"))
+		require.Error(t, setter.Set("LogLevel", "none"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("LogLevel"))
+		require.NoError(t, setter.Set("LogLevel", "QUIET"))
+		require.NoError(t, setter.Set("LogLevel", "DEBUG"))
+		require.Equal(t, "QUIET", obj.LogLevel, "original value should stick")
+	})
+}
+
+func TestSetterFieldObscureKeystrokeTiming(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ObscureKeystrokeTiming"))
+		require.NoError(t, setter.Set("ObscureKeystrokeTiming", "yes"))
+		require.True(t, obj.ObscureKeystrokeTiming.IsTrue())
+		require.NoError(t, setter.Reset("ObscureKeystrokeTiming"))
+		require.NoError(t, setter.Set("ObscureKeystrokeTiming", "no"))
+		require.True(t, obj.ObscureKeystrokeTiming.IsFalse())
+		require.NoError(t, setter.Reset("ObscureKeystrokeTiming"))
+		require.NoError(t, setter.Set("ObscureKeystrokeTiming", "interval:30"))
+		require.True(t, obj.ObscureKeystrokeTiming.HasInterval())
+		iv, err := obj.ObscureKeystrokeTiming.Interval()
+		require.NoError(t, err)
+		require.Equal(t, 30*time.Millisecond, iv)
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ObscureKeystrokeTiming"))
+		require.Error(t, setter.Set("ObscureKeystrokeTiming", "maybe"))
+		require.Error(t, setter.Set("ObscureKeystrokeTiming", "interval:5d"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ObscureKeystrokeTiming"))
+		require.NoError(t, setter.Set("ObscureKeystrokeTiming", "yes"))
+		require.NoError(t, setter.Set("ObscureKeystrokeTiming", "no"))
+		require.True(t, obj.ObscureKeystrokeTiming.IsTrue(), "original value should stick")
+	})
+}
+
+func TestSetterFieldPermitRemoteOpen(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("PermitRemoteOpen"))
+		require.NoError(t, setter.Set("PermitRemoteOpen", "key:value", "key2:value2"))
+		require.Equal(t, "key:value", obj.PermitRemoteOpen[0])
+		require.Equal(t, "key2:value2", obj.PermitRemoteOpen[1])
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("PermitRemoteOpen"))
+		require.Error(t, setter.Set("PermitRemoteOpen", "key"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("PermitRemoteOpen"))
+		require.NoError(t, setter.Set("PermitRemoteOpen", "key:value", "key2:value2"))
+		require.Equal(t, 2, len(obj.PermitRemoteOpen))
+		require.NoError(t, setter.Set("PermitRemoteOpen", "key3:value3"))
+		require.Equal(t, 2, len(obj.PermitRemoteOpen), "original values should stick")
+	})
+}
+
+func TestSetterFieldPort(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("Port"))
+		require.NoError(t, setter.Set("Port", "22"))
+		require.Equal(t, 22, obj.Port)
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("Port"))
+		require.Error(t, setter.Set("Port", "abc"))
+		require.Error(t, setter.Set("Port", "99999"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("Port"))
+		require.NoError(t, setter.Set("Port", "22"))
+		require.Equal(t, 22, obj.Port)
+		require.NoError(t, setter.Set("Port", "23"))
+		require.Equal(t, 22, obj.Port, "original value should stick")
+	})
+}
+
+func TestSetterFieldPubkeyAuthentication(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		for _, val := range []string{"yes", "no", "unbound", "host-bound"} {
+			require.NoError(t, setter.Reset("PubkeyAuthentication"))
+			require.NoError(t, setter.Set("PubkeyAuthentication", val))
+			require.Equal(t, val, obj.PubkeyAuthentication.String())
+		}
+		require.NoError(t, setter.Reset("PubkeyAuthentication"))
+		require.NoError(t, setter.Set("PubkeyAuthentication", "yes"))
+		require.True(t, obj.PubkeyAuthentication.IsTrue())
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("PubkeyAuthentication"))
+		require.Error(t, setter.Set("PubkeyAuthentication", "none"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("PubkeyAuthentication"))
+		require.NoError(t, setter.Set("PubkeyAuthentication", "yes"))
+		require.NoError(t, setter.Set("PubkeyAuthentication", "no"))
+		require.True(t, obj.PubkeyAuthentication.IsTrue(), "original value should stick")
+	})
+}
+
+func TestSetterFieldRekeyLimit(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("RekeyLimit"))
+		require.NoError(t, setter.Set("RekeyLimit", "1G", "1h"))
+		require.Equal(t, "1G 1h", obj.RekeyLimit.String())
+		require.Equal(t, 1<<30, int(obj.RekeyLimit.MaxData))
+		require.Equal(t, time.Hour, obj.RekeyLimit.MaxTime)
+		require.NoError(t, setter.Reset("RekeyLimit"))
+		require.NoError(t, setter.Set("RekeyLimit", "1K"))
+		require.Equal(t, "1K", obj.RekeyLimit.String())
+		require.Equal(t, 1024, int(obj.RekeyLimit.MaxData))
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("RekeyLimit"))
+		require.Error(t, setter.Set("RekeyLimit", "1G", "1h", "1m"))
+		require.Error(t, setter.Set("RekeyLimit", "none"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("RekeyLimit"))
+		require.NoError(t, setter.Set("RekeyLimit", "1G", "1h"))
+		require.Equal(t, "1G 1h", obj.RekeyLimit.String())
+		require.Equal(t, time.Hour, obj.RekeyLimit.MaxTime)
+		require.NoError(t, setter.Set("RekeyLimit", "1K"))
+		require.Equal(t, "1G 1h", obj.RekeyLimit.String(), "original value should stick")
+		require.Equal(t, time.Hour, obj.RekeyLimit.MaxTime, "original value should stick")
+	})
+}
+
+func TestSetterFieldRequestTTY(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		for _, val := range []string{"yes", "no", "force", "auto"} {
+			require.NoError(t, setter.Reset("RequestTTY"))
+			require.NoError(t, setter.Set("RequestTTY", val))
+			require.Equal(t, val, obj.RequestTTY.String())
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("RequestTTY"))
+		require.Error(t, setter.Set("RequestTTY", "none"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("RequestTTY"))
+		require.NoError(t, setter.Set("RequestTTY", "yes"))
+		require.NoError(t, setter.Set("RequestTTY", "no"))
+		require.True(t, obj.RequestTTY.IsTrue(), "original value should stick")
+	})
+}
+
+func TestSetterFieldSendEnv(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("SendEnv"))
+		require.NoError(t, setter.Set("SendEnv", "FOO_BAR", "BAR_FOO"))
+		require.Len(t, obj.SendEnv, 2)
+		require.Equal(t, "FOO_BAR", obj.SendEnv[0])
+		require.NoError(t, setter.Set("SendEnv", "-FOO_*"))
+		require.Len(t, obj.SendEnv, 1)
+		require.Equal(t, "BAR_FOO", obj.SendEnv[0])
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("SendEnv"))
+		require.Error(t, setter.Set("SendEnv", ""))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("SendEnv"))
+		require.NoError(t, setter.Set("SendEnv", "FOO_BAR", "BAR_FOO"))
+		require.Len(t, obj.SendEnv, 2)
+		require.Equal(t, "FOO_BAR", obj.SendEnv[0])
+		require.NoError(t, setter.Set("SendEnv", "-FOO_*"))
+		require.Len(t, obj.SendEnv, 1)
+		require.Equal(t, "BAR_FOO", obj.SendEnv[0])
+		require.NoError(t, setter.Set("SendEnv", "FOO_BAR"))
+		require.Len(t, obj.SendEnv, 2, "sendenv should accumulate")
+		require.Equal(t, "BAR_FOO", obj.SendEnv[0])
+		require.Equal(t, "FOO_BAR", obj.SendEnv[1])
+	})
+}
+
+func TestSetterFieldSessionType(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		for _, val := range []string{"none", "subsystem", "default"} {
+			require.NoError(t, setter.Reset("SessionType"))
+			require.NoError(t, setter.Set("SessionType", val))
+			require.Equal(t, val, obj.SessionType)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("SessionType"))
+		require.Error(t, setter.Set("SessionType", "hello"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("SessionType"))
+		require.NoError(t, setter.Set("SessionType", "default"))
+		require.NoError(t, setter.Set("SessionType", "subsystem"))
+		require.Equal(t, "default", obj.SessionType, "original value should stick")
+	})
+}
+
+func TestSetterFieldSetEnv(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("SetEnv"))
+		require.NoError(t, setter.Set("SetEnv", "FOO=BAR", "BAR=FOO"))
+		require.Len(t, obj.SetEnv, 2)
+		require.Equal(t, "BAR", obj.SetEnv["FOO"])
+		require.Equal(t, "FOO", obj.SetEnv["BAR"])
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("SetEnv"))
+		require.Error(t, setter.Set("SetEnv", "FOO"))
+		require.Error(t, setter.Set("SetEnv"))
+		require.Error(t, setter.Set("SetEnv", ""))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("SetEnv"))
+		require.NoError(t, setter.Set("SetEnv", "FOO=BAR", "BAR=FOO"))
+		require.NoError(t, setter.Set("SetEnv", "BAZ=FOO"))
+		require.Len(t, obj.SetEnv, 2, "original values should stick")
+		require.Equal(t, "BAR", obj.SetEnv["FOO"], "original values should stick")
+		require.Equal(t, "FOO", obj.SetEnv["BAR"], "original values should stick")
+	})
+}
+
+func TestSetterFieldStreamLocalBindMask(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("StreamLocalBindMask"))
+		require.NoError(t, setter.Set("StreamLocalBindMask", "0644"))
+		require.Equal(t, 0644, int(*obj.StreamLocalBindMask))
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("StreamLocalBindMask"))
+		require.Error(t, setter.Set("StreamLocalBindMask", "abc"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("StreamLocalBindMask"))
+		require.NoError(t, setter.Set("StreamLocalBindMask", "0644"))
+		require.NoError(t, setter.Set("StreamLocalBindMask", "0700"))
+		require.Equal(t, 0644, int(*obj.StreamLocalBindMask), "original value should stick")
+	})
+}
+
+func TestSetterFieldStrictHostKeyChecking(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		for _, val := range []string{"yes", "no", "ask", "accept-new"} {
+			require.NoError(t, setter.Reset("StrictHostKeyChecking"))
+			require.NoError(t, setter.Set("StrictHostKeyChecking", val))
+			require.Equal(t, val, obj.StrictHostKeyChecking.String())
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("StrictHostKeyChecking"))
+		require.Error(t, setter.Set("StrictHostKeyChecking", "maybe"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("StrictHostKeyChecking"))
+		require.NoError(t, setter.Set("StrictHostKeyChecking", "yes"))
+		require.NoError(t, setter.Set("StrictHostKeyChecking", "no"))
+		require.True(t, obj.StrictHostKeyChecking.IsTrue(), "original value should stick")
+	})
+}
+
+func TestSetterFieldSyslogFacility(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		for _, val := range []string{"DAEMON", "USER", "AUTH", "AUTHPRIV", "LOCAL0", "LOCAL1", "LOCAL2", "LOCAL3", "LOCAL4", "LOCAL5", "LOCAL6", "LOCAL7"} {
+			require.NoError(t, setter.Reset("SyslogFacility"))
+			require.NoError(t, setter.Set("SyslogFacility", val))
+			require.Equal(t, val, obj.SyslogFacility)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("SyslogFacility"))
+		require.Error(t, setter.Set("SyslogFacility", "none"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("SyslogFacility"))
+		require.NoError(t, setter.Set("SyslogFacility", "DAEMON"))
+		require.NoError(t, setter.Set("SyslogFacility", "USER"))
+		require.Equal(t, "DAEMON", obj.SyslogFacility, "original value should stick")
+	})
+}
+
+func TestSetterFieldUpdateHostKeys(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		for _, val := range []string{"yes", "no", "ask"} {
+			require.NoError(t, setter.Reset("UpdateHostKeys"))
+			require.NoError(t, setter.Set("UpdateHostKeys", val))
+			require.Equal(t, val, obj.UpdateHostKeys.String())
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("UpdateHostKeys"))
+		require.Error(t, setter.Set("UpdateHostKeys", "maybe"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("UpdateHostKeys"))
+		require.NoError(t, setter.Set("UpdateHostKeys", "ask"))
+		require.NoError(t, setter.Set("UpdateHostKeys", "no"))
+		require.True(t, obj.UpdateHostKeys.IsAsk())
+	})
+}
+
+func TestSetterFieldVerifyHostKeyDNS(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		for _, val := range []string{"yes", "no", "ask"} {
+			require.NoError(t, setter.Reset("VerifyHostKeyDNS"))
+			require.NoError(t, setter.Set("VerifyHostKeyDNS", val))
+			require.Equal(t, val, obj.VerifyHostKeyDNS.String())
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("VerifyHostKeyDNS"))
+		require.Error(t, setter.Set("VerifyHostKeyDNS", "maybe"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("VerifyHostKeyDNS"))
+		require.NoError(t, setter.Set("VerifyHostKeyDNS", "ask"))
+		require.NoError(t, setter.Set("VerifyHostKeyDNS", "no"))
+		require.True(t, obj.VerifyHostKeyDNS.IsAsk())
+	})
+}
+
+func TestSetterFieldEscapeChar(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("EscapeChar"))
+		require.NoError(t, setter.Set("EscapeChar", "none"))
+		require.Equal(t, "none", obj.EscapeChar.String())
+		require.NoError(t, setter.Reset("EscapeChar"))
+		require.NoError(t, setter.Set("EscapeChar", "^K"))
+		require.Equal(t, 11, int(obj.EscapeChar.Byte()))
+	})
+	t.Run("invalid", func(t *testing.T) {
+		require.NoError(t, setter.Reset("EscapeChar"))
+		require.Error(t, setter.Set("EscapeChar", ""))
+		require.Error(t, setter.Set("EscapeChar", "none", "hello"))
+	})
+	t.Run("precedence", func(t *testing.T) {
+		require.NoError(t, setter.Reset("EscapeChar"))
+		require.NoError(t, setter.Set("EscapeChar", "none"))
+		require.Equal(t, "none", obj.EscapeChar.String())
+		require.NoError(t, setter.Set("EscapeChar", "~"))
+		require.Equal(t, "none", obj.EscapeChar.String(), "original value should stick")
+	})
+}
+
+func TestSetterFinalize(t *testing.T) {
+	obj := sshconfig.Config{}
+	setter, err := sshconfig.NewSetter(&obj)
+	require.NoError(t, err)
+
+	require.NoError(t, setter.Set("CertificateFile", "none"))
+	require.Equal(t, "none", obj.CertificateFile[0])
+	require.NoError(t, setter.Finalize())
+	require.Len(t, obj.CertificateFile, 0)
+
+	obj.Port = 22
+	require.NoError(t, setter.Set("IdentityFile", "~/foo", "/tmp/%p.txt"))
+	require.Equal(t, "~/foo", obj.IdentityFile[0])
+	require.Equal(t, "/tmp/%p.txt", obj.IdentityFile[1])
+	require.NoError(t, setter.Finalize())
+	require.Len(t, obj.IdentityFile, 2)
+	require.NotEqual(t, "~/foo", obj.IdentityFile[0])
+	require.Equal(t, "/tmp/22.txt", obj.IdentityFile[1])
+}

--- a/sshconfig/setterbuilders.go
+++ b/sshconfig/setterbuilders.go
@@ -1,0 +1,139 @@
+package sshconfig
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+)
+
+// This file defines custom setter function builders.
+
+// preloadedDefaultsSetter returns a setter for the algo/cipher fields where prefixes can be used
+// to modify defaults.
+func preloadedDefaultsSetter(defaultValues string) setterFunc { //nolint:cyclop
+	defaults := strings.Split(defaultValues, ",")
+
+	return func(s *Setter, key string, values ...string) error {
+		if err := expectOne(values); err != nil {
+			return fmt.Errorf("%w: expected comma separated values, got %q", errInvalidValue, values)
+		}
+		value := values[0]
+		field, err := s.get(key, reflect.Slice, reflect.String)
+		if err != nil {
+			return err
+		}
+		if field.Len() > 0 {
+			// the precedence in these fields is standard.
+			// the modifiers only work when the field is empty.
+			// the modifiers work ONCE against the default values.
+			// for example, something like -aes128 will apply the defaults minus aes128
+			// and after that ^aes256 or +aes128 won't do anything.
+			return nil
+		}
+		var prefix string
+		switch value[0] {
+		case '+':
+			prefix = "+"
+		case '-':
+			prefix = "-"
+		case '^':
+			prefix = "^"
+		}
+		if prefix == "" {
+			// no modifier, just set the values
+			field.Set(reflect.ValueOf(strings.Split(value, ",")))
+			return nil
+		}
+		values = strings.Split(value[1:], ",")
+		var newValues []string
+		switch prefix {
+		case "+":
+			// + prefix appends to the defaults list
+			newValues = append(newValues, defaults...)
+			for _, v := range values {
+				if !slices.Contains(newValues, v) {
+					newValues = append(newValues, v)
+				}
+			}
+		case "^":
+			// ^ prefix prepends (or shifts) the values to the beginning of defaults list
+			newValues = append(newValues, values...)
+			for _, v := range defaults {
+				if !slices.Contains(newValues, v) {
+					newValues = append(newValues, v)
+				}
+			}
+		case "-":
+			// - prefix removes matching values from the defaults list
+		defaultFor:
+			for _, v := range defaults {
+				for _, value := range values {
+					matches, err := patternMatch(value, v)
+					if err != nil {
+						return fmt.Errorf("%w: invalid pattern %q: %w", errInvalidValue, value, err)
+					}
+					if matches {
+						continue defaultFor
+					}
+					newValues = append(newValues, v)
+				}
+			}
+		}
+		field.Set(reflect.ValueOf(newValues))
+		return nil
+	}
+}
+
+// enum returns a setter that can set a field to one of the predefined values.
+func enum(states ...string) setterFunc {
+	return func(s *Setter, key string, values ...string) error {
+		if err := expectOne(values); err != nil {
+			return err
+		}
+		if !slices.Contains(states, values[0]) {
+			return fmt.Errorf("%w: invalid value %q: expected one of %q", errInvalidValue, values[0], states)
+		}
+		return s.setString(key, values[0])
+	}
+}
+
+type normalizeable[T any] interface {
+	Normalize() (T, error)
+	String() string
+}
+
+// returns a setter for the bool-like fields in options/options.go.
+func extendedBoolSetter[T normalizeable[T]]() setterFunc {
+	return func(s *Setter, key string, values ...string) error { //nolint:varnamelen
+		if err := expectOne(values); err != nil {
+			return err
+		}
+
+		var extbool T
+		extboolVal := reflect.ValueOf(&extbool).Elem()
+		extboolVal.Set(reflect.ValueOf(values[0]).Convert(extboolVal.Type()))
+		normalized, err := extbool.Normalize()
+		if err != nil {
+			return fmt.Errorf("not a valid %q value %q: %w", key, values[0], err)
+		}
+
+		value := reflect.ValueOf(normalized)
+		field, err := s.get(key, value.Kind())
+		if err != nil {
+			if f, err := s.get(key, reflect.String); err == nil {
+				if f.String() != "" {
+					return nil
+				}
+				f.SetString(normalized.String())
+				return nil
+			}
+			return fmt.Errorf("%w: field %q is not a %s or a string", errInvalidField, key, reflect.TypeOf(normalized))
+		}
+		if field.String() != "" {
+			return nil
+		}
+		field.Set(value)
+		return nil
+	}
+}

--- a/sshconfig/splitargs.go
+++ b/sshconfig/splitargs.go
@@ -1,0 +1,77 @@
+package sshconfig
+
+import (
+	"errors"
+	"strings"
+	"sync"
+)
+
+var (
+	builderPool = sync.Pool{
+		New: func() interface{} {
+			return &strings.Builder{}
+		},
+	}
+
+	// errMismatchedQuotes is returned when the input string has mismatched quotes when unquoting.
+	errMismatchedQuotes = errors.New("mismatched quotes")
+)
+
+// splitArgs splits a string into arguments like argv_split in ssh C source. It is in fact almost a direct
+// copy of the original function.
+func splitArgs(input string, terminateOnComment bool) ([]string, error) { //nolint:cyclop
+	var args []string
+
+	argBuilder, ok := builderPool.Get().(*strings.Builder)
+	if !ok {
+		argBuilder = &strings.Builder{}
+	}
+	defer func() {
+		argBuilder.Reset()
+		builderPool.Put(argBuilder)
+	}()
+	argBuilder.Grow(len(input))
+
+	var quote rune
+
+	for i := 0; i < len(input); i++ {
+		currCh := rune(input[i])
+
+		// Skip leading whitespace
+		if currCh == ' ' || currCh == '\t' {
+			continue
+		}
+
+		if terminateOnComment && currCh == '#' {
+			break
+		}
+
+		// Copy the token in, removing escapes
+		for ; i < len(input); i++ { // weird stuff originates from the C sources
+			currCh = rune(input[i])
+			if currCh == '\\' { //nolint:gocritic,nestif
+				if i+1 < len(input) && (input[i+1] == '\\' || input[i+1] == '\'' || input[i+1] == '"' || (quote == 0 && input[i+1] == ' ')) {
+					i++ // Skip '\'
+				}
+				argBuilder.WriteRune(rune(input[i]))
+			} else if quote == 0 && currCh == ' ' || currCh == '\t' {
+				// done
+				break
+			} else if quote == 0 && (currCh == '"' || currCh == '\'') {
+				quote = currCh
+			} else if quote != 0 && currCh == quote {
+				quote = 0 // quote end
+			} else {
+				argBuilder.WriteRune(currCh)
+			}
+		}
+		if quote != 0 {
+			return nil, errMismatchedQuotes
+		}
+		if argBuilder.Len() > 0 {
+			args = append(args, argBuilder.String())
+			argBuilder.Reset()
+		}
+	}
+	return args, nil
+}

--- a/sshconfig/tree.go
+++ b/sshconfig/tree.go
@@ -1,0 +1,423 @@
+package sshconfig
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// This file defines a parser that converts ssh configuration files into a tree structure.
+//
+// This parsing has to be usually done just once and the same parsed tree is then used
+// to apply settings to individual ssh host configurations.
+//
+// It is not exported as there should be very little use for it outside of the actual
+// config parser.
+
+// node represents a single node in the ssh config tree.
+type node struct {
+	key      string   // node key
+	values   []string // node values (each row can have multiple values)
+	children []*node  // child nodes
+	path     string   // file path of the config file
+	row      int      // row number in the config file
+}
+
+// newNode creates a new [Node].
+func newNode(key string, values []string, path string, row int) *node {
+	return &node{key: key, values: values, path: path, row: row}
+}
+
+// Key of the node.
+func (d *node) Key() string {
+	return d.key
+}
+
+// Values of the node.
+func (d *node) Values() []string {
+	return d.values
+}
+
+// Path of the node, which is the file path of the config file.
+func (d *node) Path() string {
+	return d.path
+}
+
+// Row of the node, which is the row number in the config file.
+func (d *node) Row() int {
+	return d.row
+}
+
+// Children of the node.
+func (d *node) Children() []*node {
+	return d.children
+}
+
+// AddChild adds a child to the node.
+func (d *node) AddChild(child *node) {
+	d.children = append(d.children, child)
+}
+
+// nodeIterator is an iterator for the children of a node.
+type nodeIterator struct {
+	node    *node
+	currIdx int
+}
+
+// newNodeIterator creates a new [NodeIterator].
+func newNodeIterator(root *node) *nodeIterator {
+	return &nodeIterator{node: root, currIdx: -1}
+}
+
+// NextChild returns the next child of the node.
+func (ni *nodeIterator) NextChild() *node {
+	ni.currIdx++
+	if ni.currIdx < len(ni.node.children) {
+		return ni.node.children[ni.currIdx]
+	}
+	return nil
+}
+
+// treeIterator is an iterator for the ssh config tree.
+type treeIterator struct {
+	root  *node
+	stack []*nodeIterator
+}
+
+// newTreeIterator creates a new [TreeIterator].
+func newTreeIterator(root *node) *treeIterator {
+	return &treeIterator{root: root, stack: []*nodeIterator{newNodeIterator(root)}}
+}
+
+// Key of the current node.
+func (t *treeIterator) Key() string {
+	if len(t.stack) == 0 {
+		return ""
+	}
+	return t.stack[len(t.stack)-1].node.key
+}
+
+// Values of the current node.
+func (t *treeIterator) Values() []string {
+	if len(t.stack) == 0 {
+		return nil
+	}
+	return t.stack[len(t.stack)-1].node.values
+}
+
+// Path of the current node.
+func (t *treeIterator) Path() string {
+	if len(t.stack) == 0 {
+		return ""
+	}
+	return t.stack[len(t.stack)-1].node.path
+}
+
+// Row of the current node.
+func (t *treeIterator) Row() int {
+	if len(t.stack) == 0 {
+		return 0
+	}
+	return t.stack[len(t.stack)-1].node.row
+}
+
+// Depth of the current node.
+func (t *treeIterator) Depth() int {
+	return len(t.stack)
+}
+
+// Skip the children of the current node.
+func (t *treeIterator) Skip() {
+	t.stack[len(t.stack)-1].currIdx = len(t.stack[len(t.stack)-1].node.children)
+}
+
+// Next moves to the next node.
+func (t *treeIterator) Next() bool {
+	for len(t.stack) > 0 {
+		topIterator := t.stack[len(t.stack)-1]
+		nextChild := topIterator.NextChild()
+		if nextChild == nil {
+			// Pop the exhausted iterator
+			t.stack = t.stack[:len(t.stack)-1]
+		} else {
+			// Push an iterator for the next child onto the stack
+			t.stack = append(t.stack, newNodeIterator(nextChild))
+			if t.stack[len(t.stack)-1].node.values == nil {
+				// skip nodes without values (these are added by the parser for grouping)
+				return t.Next()
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// Reset the iterator to the root node.
+func (t *treeIterator) Reset() {
+	t.stack = []*nodeIterator{newNodeIterator(t.root)}
+}
+
+// treeParser parses ssh config files into a tree structure.
+type treeParser struct {
+	r io.Reader
+
+	// GlobalConfigPath is the path to the global ssh config file, the default is /etc/ssh/ssh_config and PROGRAMDATA/ssh/ssh_config on windows.
+	GlobalConfigPath string
+	// UserConfigPath is the path to the user ssh config file, the default is ~/.ssh/config.
+	UserConfigPath string
+	// GlobalConfigReader is the reader for the global ssh config file. This is used for testing.
+	GlobalConfigReader io.Reader
+	// UserConfigReader is the reader for the user ssh config file. This is used for testing.
+	UserConfigReader io.Reader
+
+	globalConfigDir string
+	userConfigDir   string
+}
+
+func defaultUserConfigPath() string {
+	if home := userhome(); home != "" {
+		return filepath.Join(home, ".ssh", "config")
+	}
+	return filepath.Join(".", ".ssh", "config")
+}
+
+// newTreeParser creates a new [TreeParser].
+func newTreeParser(input io.Reader) *treeParser {
+	return &treeParser{r: input, GlobalConfigPath: defaultGlobalConfigPath(), UserConfigPath: defaultUserConfigPath()}
+}
+
+func (p *treeParser) setupDirs() {
+	if p.r != nil {
+		return
+	}
+	if p.userConfigDir == "" {
+		p.userConfigDir = filepath.Dir(p.UserConfigPath)
+	}
+	if p.userConfigDir == "" && p.UserConfigReader != nil {
+		if nr, ok := p.UserConfigReader.(withName); ok {
+			p.userConfigDir = filepath.Dir(nr.Name())
+		}
+	}
+	if p.globalConfigDir == "" {
+		p.globalConfigDir = filepath.Dir(p.GlobalConfigPath)
+	}
+	if p.globalConfigDir == "" && p.GlobalConfigReader != nil {
+		if nr, ok := p.GlobalConfigReader.(withName); ok {
+			p.globalConfigDir = filepath.Dir(nr.Name())
+		}
+	}
+}
+
+type withName interface {
+	Name() string
+}
+
+// Parse the ssh config files into a tree structure and return a [TreeIterator].
+func (p *treeParser) Parse() (*treeIterator, error) { //nolint:cyclop
+	p.setupDirs()
+
+	root := newNode("root", nil, "", 0)
+	if p.r != nil { //nolint:nestif
+		var readerPath string
+		if nr, ok := p.r.(withName); ok {
+			readerPath = nr.Name()
+		} else {
+			readerPath = "./unknown"
+		}
+		if prc, ok := p.r.(io.Closer); ok {
+			defer prc.Close()
+		}
+		customConfig := newNode("custom", nil, readerPath, 0)
+		root.AddChild(customConfig)
+		if err := p.parseTree(p.r, customConfig, make(map[string]struct{})); err != nil {
+			return nil, fmt.Errorf("failed to parse supplied ssh config: %w", err)
+		}
+	} else {
+		var userReader io.Reader
+		var err error
+		if p.UserConfigReader != nil {
+			userReader = p.UserConfigReader
+		} else {
+			userReader, err = os.Open(p.UserConfigPath)
+			if err != nil && !os.IsNotExist(err) {
+				return nil, fmt.Errorf("failed to open user ssh config %q: %w", p.UserConfigPath, err)
+			}
+		}
+		if ucc, ok := userReader.(io.Closer); ok {
+			defer ucc.Close()
+		}
+		if err == nil {
+			userConfig := newNode("custom", nil, p.UserConfigPath, 0)
+			root.AddChild(userConfig)
+			if err := p.parseTree(userReader, userConfig, make(map[string]struct{})); err != nil {
+				return nil, fmt.Errorf("failed to parse user ssh config %q: %w", p.UserConfigPath, err)
+			}
+		}
+		var globalReader io.Reader
+		err = nil
+		if p.GlobalConfigReader != nil {
+			globalReader = p.GlobalConfigReader
+		} else {
+			globalReader, err = os.Open(p.GlobalConfigPath)
+			if err != nil && !os.IsNotExist(err) {
+				return nil, fmt.Errorf("failed to open global ssh config %q: %w", p.GlobalConfigPath, err)
+			}
+		}
+		if gcc, ok := globalReader.(io.Closer); ok {
+			defer gcc.Close()
+		}
+		if err == nil {
+			globalConfig := newNode("global", nil, p.GlobalConfigPath, 0)
+			root.AddChild(globalConfig)
+			if err := p.parseTree(globalReader, globalConfig, make(map[string]struct{})); err != nil {
+				return nil, fmt.Errorf("failed to parse global ssh config %q: %w", p.GlobalConfigPath, err)
+			}
+		}
+	}
+
+	dc := strings.NewReader(sshDefaultConfig)
+	defaultConfig := newNode("default", nil, "__default__", 0)
+	root.AddChild(defaultConfig)
+	if err := p.parseTree(dc, defaultConfig, make(map[string]struct{})); err != nil {
+		return nil, fmt.Errorf("failed to parse default ssh config: %w", err)
+	}
+
+	// finally set a default username
+	if u := username(); u != "" {
+		root.AddChild(newNode("user", []string{u}, "default", 0))
+	}
+
+	return newTreeIterator(root), nil
+}
+
+// tokenizeRow splits a line into a key and a value.
+// any comments are stripped from the value.
+//
+// The OpenSSH client does this by testing the list of known keys against
+// the position of the first non-space character of the line, so it doesn't
+// actually even look for a separator.
+func tokenizeRow(s string) (key string, values []string, err error) {
+	// find the first non-space character
+	idx := strings.IndexFunc(s, func(r rune) bool { return !unicode.IsSpace(r) })
+
+	// skip comments
+	if idx == -1 || s[idx] == '#' {
+		return "", nil, nil
+	}
+
+	leftTrimmed := s[idx:]
+
+	// find separator
+	idx = strings.IndexFunc(leftTrimmed, func(r rune) bool { return r == '=' || unicode.IsSpace(r) })
+
+	// if there is no separator, the line is invalid
+	if idx == -1 {
+		if strings.HasPrefix(leftTrimmed, "canonicaldomains") {
+			// some versions of ssh output a broken line for canonicaldomains that doesn't include a value
+			return "canonicaldomains", []string{"none"}, nil
+		}
+		return "", nil, fmt.Errorf("%w: missing separator: %q", ErrSyntax, s)
+	}
+
+	key = strings.ToLower(leftTrimmed[:idx])
+	if len(leftTrimmed) < idx+1 {
+		return "", nil, fmt.Errorf("%w: missing value: %q", ErrSyntax, s)
+	}
+
+	leftTrimmed = leftTrimmed[idx+1:]
+
+	idx = strings.IndexFunc(leftTrimmed, func(r rune) bool { return !unicode.IsSpace(r) && r != '=' })
+	breakOnComment := true
+	switch key {
+	case "knownhostscommand", "proxycommand", "localcommand", "remotecommand":
+		// the comment is a part of the value for commands
+		breakOnComment = false
+	}
+	values, err = splitArgs(leftTrimmed[idx:], breakOnComment)
+	if err != nil {
+		return "", nil, fmt.Errorf("%w: %w", ErrSyntax, err)
+	}
+
+	if len(values) == 0 {
+		return "", nil, fmt.Errorf("%w: missing value: %q", ErrSyntax, s)
+	}
+
+	return key, values, nil
+}
+
+func (p *treeParser) parseTree(reader io.Reader, root *node, includes map[string]struct{}) error { //nolint:cyclop
+	scanner := bufio.NewScanner(reader)
+	currNode := root
+	var row int
+	for scanner.Scan() {
+		row++
+		key, values, err := tokenizeRow(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("%w: parse error on row %d: %w", ErrSyntax, row, err)
+		}
+		if key == "" {
+			continue
+		}
+		switch key {
+		case "host", "match":
+			newNode := newNode(key, values, currNode.Path(), row)
+			root.AddChild(newNode)
+			currNode = newNode
+		case "include":
+			for _, value := range values {
+				value = filepath.Clean(value)
+				if slices.Contains(strings.Split(value, string(os.PathSeparator)), "..") {
+					return fmt.Errorf("%w: parse error on row %d: include directive contains a path traversing relative path", ErrSyntax, row)
+				}
+				if !filepath.IsAbs(value) {
+					if strings.HasPrefix(currNode.Path(), p.globalConfigDir) {
+						value = filepath.Join(p.globalConfigDir, value)
+					} else {
+						value = filepath.Join(p.userConfigDir, value)
+					}
+				}
+				if _, ok := includes[value]; ok {
+					return fmt.Errorf("%w: parse error on row %d: circular include directive", ErrSyntax, row)
+				}
+				matches, err := filepath.Glob(value)
+				if err != nil {
+					return fmt.Errorf("can't glob include path %q: %w", value, err)
+				}
+				sort.Strings(matches)
+				for _, match := range matches {
+					f, err := os.Open(match) //nolint:varnamelen
+					if err != nil {
+						return fmt.Errorf("can't open include path %q: %w", match, err)
+					}
+					newIncludes := make(map[string]struct{})
+					for k := range includes {
+						newIncludes[k] = struct{}{}
+					}
+					newIncludes[match] = struct{}{}
+					childDirective := newNode("include", values, match, row)
+					currNode.AddChild(childDirective)
+					err = p.parseTree(f, childDirective, newIncludes)
+					f.Close()
+					if err != nil {
+						return fmt.Errorf("failed to parse include file %q in %s:%d: %w", match, currNode.Path(), row, err)
+					}
+					f.Close()
+				}
+			}
+		default:
+			currNode.AddChild(newNode(key, values, currNode.Path(), row))
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading input from %q: %w", currNode.Path(), err)
+	}
+
+	return nil
+}

--- a/sshconfig/tree_test.go
+++ b/sshconfig/tree_test.go
@@ -1,0 +1,111 @@
+package sshconfig
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO This file contains tests for unexported functions and structs.
+// The tests can be modified to use the exported API.
+
+func TestTreeParser(t *testing.T) {
+	for _, tc := range []struct{ name, content string }{
+		{"spaces",
+			`
+				GlobalKnownHostsFile /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
+				Host example.com
+					IdentityFile ~/.ssh/id_new # comment
+				Host foo.example.com
+					StrictHostKeyChecking yes
+			    Weird "=foo #foo"
+			`,
+		},
+		{"equals",
+			`
+				GlobalKnownHostsFile=/etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
+				Host example.com
+					IdentityFile=~/.ssh/id_new # comment
+				Host=foo.example.com
+					StrictHostKeyChecking=yes
+			    Weird="=foo #foo"
+			`,
+		},
+		{"equals with spaces",
+			`
+				GlobalKnownHostsFile = /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
+				Host example.com
+					IdentityFile = ~/.ssh/id_new # comment
+				Host = foo.example.com
+					StrictHostKeyChecking=yes
+			    Weird = "=foo #foo"
+			`,
+		},
+		{"tabs",
+			strings.ReplaceAll(strings.ReplaceAll(`
+				GlobalKnownHostsFile=/etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
+				Host=example.com
+				IdentityFile=~/.ssh/id_new # comment
+				Host=foo.example.com
+				StrictHostKeyChecking=yes
+			  Weird='?foo #foo'
+			`, "=", "\t"), "?", "="),
+		},
+		{"crazy spaces and equals",
+			`
+				GlobalKnownHostsFile     =      /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
+				Host                     =      example.com
+					IdentityFile           =      ~/.ssh/id_new # comment
+				Host                     =      foo.example.com
+					StrictHostKeyChecking  =      yes
+			    Weird                  =      "=foo #foo"
+			`,
+		},
+		{"crazy spaces",
+			`
+				GlobalKnownHostsFile            /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
+				Host                            example.com
+					IdentityFile                  ~/.ssh/id_new # comment
+				Host                            foo.example.com
+					StrictHostKeyChecking         yes
+			    Weird                         '=foo #foo'
+			`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parser := newTreeParser(strings.NewReader(tc.content))
+			iter, err := parser.Parse()
+			require.NoError(t, err)
+			sawFields := make(map[string][]string)
+			for iter.Next() {
+				if _, ok := sawFields[iter.Key()]; !ok {
+					sawFields[iter.Key()] = iter.Values()
+				}
+				if iter.Key() == "host" && iter.Values()[0] == "example.com" {
+					iter.Skip()
+				}
+			}
+			saw, ok := sawFields["globalknownhostsfile"]
+			assert.True(t, ok)
+			assert.Equal(t, []string{"/etc/ssh/ssh_known_hosts", "/etc/ssh/ssh_known_hosts2"}, saw)
+
+			saw, ok = sawFields["identityfile"]
+			assert.True(t, ok)
+			assert.NotEqual(t, []string{"~/.ssh/id_new"}, saw, "Host example.com block should have been skipped")
+
+			saw, ok = sawFields["host"]
+			assert.True(t, ok)
+			assert.Equal(t, []string{"example.com"}, saw) // the iter-loop only captures the first occurence
+
+			saw, ok = sawFields["stricthostkeychecking"]
+			assert.True(t, ok)
+			assert.Equal(t, []string{"yes"}, saw)
+
+			saw, ok = sawFields["weird"]
+			assert.True(t, ok)
+			assert.Equal(t, []string{"=foo #foo"}, saw)
+		})
+	}
+}


### PR DESCRIPTION
There are several problems in both of the available ssh config parsers for go. After looking at the spec, it's no wonder, it's quite complicated. 

For specifics, see the [README](https://github.com/k0sproject/rig/blob/fd7d2ef650c181c64f111027b07466c181004bf8/sshconfig/README.md).

