### PR TITLE
Run stat in empty env with C locale

### DIFF
--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -23,8 +23,8 @@ var (
 	_          fs.FS = (*PosixFS)(nil)
 	_          FS    = (*PosixFS)(nil)
 	errInvalid       = errors.New("invalid")
-	statCmdGNU       = "stat -c '%%#f %%s %%.9Y //%%n//' -- %s 2> /dev/null"
-	statCmdBSD       = "stat -f '%%#p %%z %%Fm //%%N//' -- %s 2> /dev/null"
+	statCmdGNU       = "env -i LC_ALL=C stat -c '%%#f %%s %%.9Y //%%n//' -- %s 2> /dev/null"
+	statCmdBSD       = "env -i LC_ALL=C stat -f '%%#p %%z %%Fm //%%N//' -- %s 2> /dev/null"
 )
 
 const (


### PR DESCRIPTION
This allows for a stable output in case the target systems use a locale with a different number format.

Speculatively fixes k0sproject/k0sctl#664.