### PR TITLE
[Backport release-0.x] Run stat in empty env with C locale

### DIFF
--- a/pkg/rigfs/posixfsys.go
+++ b/pkg/rigfs/posixfsys.go
@@ -274,8 +274,8 @@ func (f *PosixFile) Seek(offset int64, whence int) (int64, error) {
 }
 
 var (
-	statCmdGNU = "stat -c '%%#f %%s %%.9Y //%%n//' -- %s 2> /dev/null"
-	statCmdBSD = "stat -f '%%#p %%z %%Fm //%%N//' -- %s 2> /dev/null"
+	statCmdGNU = "env -i LC_ALL=C stat -c '%%#f %%s %%.9Y //%%n//' -- %s 2> /dev/null"
+	statCmdBSD = "env -i LC_ALL=C stat -f '%%#p %%z %%Fm //%%N//' -- %s 2> /dev/null"
 )
 
 func (fsys *PosixFsys) initStat() error {


### PR DESCRIPTION
Backport to `release-0.x`:
* #183

See:
* k0sproject/k0sctl#664