### PR TITLE
Drop kevinburke/ssh_config dependency in favor of rig/v2/sshconfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 require (
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/davidmz/go-pageant v1.0.2
-	github.com/kevinburke/ssh_config v1.2.0
 	github.com/masterzen/winrm v0.0.0-20231128182143-52a9e15d5730
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
-github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -67,7 +67,7 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 	}
 
 	if ConfigParser != nil {
-		if err := ConfigParser.Apply(c.sshConfig, ""); err != nil {
+		if err := ConfigParser.Apply(c.sshConfig, c.Config.Address); err != nil {
 			return nil, fmt.Errorf("failed to apply ssh config: %w", err)
 		}
 	}

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -60,8 +60,12 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 	c.sshConfig = &sshconfig.Config{
 		User: c.Config.User,
 		Host: c.Config.Address,
-		Port: c.Config.Port,
 	}
+
+	if c.Config.Port != 0 && c.Config.Port != 22 {
+		c.sshConfig.Port = c.Config.Port
+	}
+
 	if c.Config.KeyPath != nil {
 		c.sshConfig.IdentityFile = []string{*c.Config.KeyPath}
 	}
@@ -71,6 +75,8 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 			return nil, fmt.Errorf("failed to apply ssh config: %w", err)
 		}
 	}
+
+	c.Config.Port = c.sshConfig.Port
 
 	return c, nil
 }

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -76,10 +76,10 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 }
 
 var (
-	authMethodCache   = sync.Map{}
-	dummyhostKeyPaths []string
-	knownHostsMU      sync.Mutex
-	globalOnce        sync.Once
+	authMethodCache = sync.Map{}
+
+	knownHostsMU sync.Mutex
+	globalOnce   sync.Once
 
 	// ErrChecksumMismatch is returned when the checksum of an uploaded file does not match expectation.
 	ErrChecksumMismatch = errors.New("checksum mismatch")
@@ -94,8 +94,6 @@ func init() {
 		}
 	})
 }
-
-const hopefullyNonexistentHost = "thisH0stDoe5not3xist"
 
 // Dial initiates a connection to the addr from the remote host.
 func (c *Connection) Dial(network, address string) (net.Conn, error) {
@@ -159,6 +157,7 @@ func (c *Connection) IsConnected() bool {
 	return err == nil
 }
 
+// ConfigParser is an instance of rig/v2/sshconfig.Parser - it is exported here for weird design decisions made in rig v0.x and will be removed in rig v2 final.
 var ConfigParser *sshconfig.Parser
 
 // String returns the connection's printable name.

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,8 +20,7 @@ import (
 	"github.com/k0sproject/rig/v2/protocol"
 	"github.com/k0sproject/rig/v2/protocol/ssh/agent"
 	"github.com/k0sproject/rig/v2/protocol/ssh/hostkey"
-	"github.com/k0sproject/rig/v2/sh/shellescape"
-	"github.com/kevinburke/ssh_config"
+	"github.com/k0sproject/rig/v2/sshconfig"
 	ssh "golang.org/x/crypto/ssh"
 	"golang.org/x/term"
 )
@@ -33,6 +31,8 @@ var errNotConnected = errors.New("not connected")
 type Connection struct {
 	log.LoggerInjectable `yaml:"-"`
 	Config               `yaml:",inline"`
+
+	sshConfig *sshconfig.Config
 
 	options *Options
 
@@ -55,22 +55,45 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 	options.InjectLoggerTo(cfg, log.KeyProtocol, "ssh-config")
 	cfg.SetDefaults()
 
-	c := &Connection{Config: cfg, options: options}
+	c := &Connection{Config: cfg, options: options} //nolint:varnamelen
 	options.InjectLoggerTo(c, log.KeyProtocol, "ssh")
+	c.sshConfig = &sshconfig.Config{
+		User: c.Config.User,
+		Host: c.Config.Address,
+		Port: c.Config.Port,
+	}
+	if c.Config.KeyPath != nil {
+		c.sshConfig.IdentityFile = []string{*c.Config.KeyPath}
+	}
+
+	if ConfigParser != nil {
+		if err := ConfigParser.Apply(c.sshConfig, ""); err != nil {
+			return nil, fmt.Errorf("failed to apply ssh config: %w", err)
+		}
+	}
 
 	return c, nil
 }
 
 var (
 	authMethodCache   = sync.Map{}
-	defaultKeypaths   = []string{"~/.ssh/id_rsa", "~/.ssh/identity", "~/.ssh/id_dsa", "~/.ssh/id_ecdsa", "~/.ssh/id_ed25519"}
 	dummyhostKeyPaths []string
-	globalOnce        sync.Once
 	knownHostsMU      sync.Mutex
+	globalOnce        sync.Once
 
 	// ErrChecksumMismatch is returned when the checksum of an uploaded file does not match expectation.
 	ErrChecksumMismatch = errors.New("checksum mismatch")
 )
+
+// TODO make the parser initialization more elegant.
+func init() {
+	globalOnce.Do(func() {
+		parser, err := sshconfig.NewParser(nil)
+		if err == nil {
+			ConfigParser = parser
+		}
+	})
+}
 
 const hopefullyNonexistentHost = "thisH0stDoe5not3xist"
 
@@ -85,13 +108,7 @@ func (c *Connection) Dial(network, address string) (net.Conn, error) {
 
 func (c *Connection) keypathsFromConfig() []string {
 	log.Trace(context.Background(), "trying to get a keyfile path from ssh config", log.KeyHost, c)
-	idf := c.getConfigAll("IdentityFile")
-	// https://github.com/kevinburke/ssh_config/blob/master/config.go#L254 says:
-	// TODO: IdentityFile has multiple default values that we should return
-	// To work around this, the hard coded list of known defaults are appended to the list
-	idf = append(idf, defaultKeypaths...)
-	sort.Strings(idf)
-	idf = slices.Compact(idf)
+	idf := slices.Compact(c.sshConfig.IdentityFile)
 
 	if len(idf) > 0 {
 		log.Trace(context.Background(), fmt.Sprintf("detected %d identity file paths from ssh config", len(idf)), log.KeyFile, idf)
@@ -101,69 +118,17 @@ func (c *Connection) keypathsFromConfig() []string {
 	return []string{}
 }
 
-func (c *Connection) initGlobalDefaults() {
-	dummyHostIdentityFiles := SSHConfigGetAll(hopefullyNonexistentHost, "IdentityFile")
-	// https://github.com/kevinburke/ssh_config/blob/master/config.go#L254 says:
-	// TODO: IdentityFile has multiple default values that we should return
-	// To work around this, the hard coded list of known defaults are appended to the list
-	dummyHostIdentityFiles = append(dummyHostIdentityFiles, defaultKeypaths...)
-	sort.Strings(dummyHostIdentityFiles)
-	dummyHostIdentityFiles = slices.Compact(dummyHostIdentityFiles)
-	for _, keyPath := range dummyHostIdentityFiles {
-		if expanded, err := homedir.Expand(keyPath); err == nil {
-			dummyhostKeyPaths = append(dummyhostKeyPaths, expanded)
-		}
-	}
-}
-
-func findUniq(a, b []string) (string, bool) {
-	for _, s := range a {
-		found := false
-		for _, t := range b {
-			if s == t {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return s, true
-		}
-	}
-	return "", false
-}
-
 // SetDefaults sets various default values.
 func (c *Connection) SetDefaults() {
-	globalOnce.Do(c.initGlobalDefaults)
 	c.once.Do(func() {
-		if c.KeyPath != nil && *c.KeyPath != "" {
-			if expanded, err := homedir.Expand(*c.KeyPath); err == nil {
-				c.keyPaths = append(c.keyPaths, expanded)
-			}
-			// keypath is explicitly set, accept the fact even if it's invalid and
-			// don't try to find it from ssh config/defaults
-			return
-		}
-		c.KeyPath = nil
+		c.Port = c.sshConfig.Port
 
-		paths := c.keypathsFromConfig()
-
-		if c.Port == 0 || c.Port == 22 {
-			ports := c.getConfigAll("Port")
-			if len(ports) > 0 {
-				if p, err := strconv.Atoi(ports[0]); err == nil {
-					c.Port = p
-				}
-			}
-		}
-
-		addrs := c.getConfigAll("HostName")
-		if len(addrs) > 0 {
+		if c.sshConfig.Hostname != "" {
 			c.alias = c.Address
-			c.Address = addrs[0]
+			c.Address = c.sshConfig.Hostname
 		}
 
-		for _, p := range paths {
+		for _, p := range c.keypathsFromConfig() {
 			expanded, err := homedir.ExpandFile(p)
 			if err != nil {
 				log.Trace(context.Background(), "expand and validate", log.KeyFile, p, log.KeyError, err)
@@ -171,12 +136,6 @@ func (c *Connection) SetDefaults() {
 			}
 			c.Log().Debug("using identity file", log.KeyFile, expanded)
 			c.keyPaths = append(c.keyPaths, expanded)
-		}
-
-		// check if all the paths that were found are global defaults
-		// errors are handled differently when a keypath is explicitly set vs when it's defaulted
-		if uniq, found := findUniq(c.keyPaths, dummyhostKeyPaths); found {
-			c.KeyPath = &uniq
 		}
 	})
 }
@@ -200,16 +159,7 @@ func (c *Connection) IsConnected() bool {
 	return err == nil
 }
 
-// SSHConfigGetAll by default points to ssh_config package's GetAll() function
-// you can override it with your own implementation for testing purposes.
-var SSHConfigGetAll = ssh_config.GetAll
-
-func (c *Connection) getConfigAll(key string) []string {
-	if c.alias != "" {
-		return SSHConfigGetAll(c.alias, key)
-	}
-	return SSHConfigGetAll(c.Address, key)
-}
+var ConfigParser *sshconfig.Parser
 
 // String returns the connection's printable name.
 func (c *Connection) String() string {
@@ -275,7 +225,7 @@ func knownhostsCallback(path string, permissive, hash bool) (ssh.HostKeyCallback
 }
 
 func isPermissive(c *Connection) bool {
-	if strict := c.getConfigAll("StrictHostkeyChecking"); len(strict) > 0 && strict[0] == "no" {
+	if c.sshConfig.StrictHostKeyChecking.IsFalse() {
 		log.Trace(context.Background(), "config StrictHostkeyChecking is set to 'no'", log.KeyHost, c)
 		return true
 	}
@@ -284,14 +234,11 @@ func isPermissive(c *Connection) bool {
 }
 
 func shouldHash(c *Connection) bool {
-	var hash bool
-	if hashKnownHosts := c.getConfigAll("HashKnownHosts"); len(hashKnownHosts) == 1 {
-		hash := hashKnownHosts[0] == "yes"
-		if hash {
-			log.Trace(context.Background(), "config HashKnownHosts is set", log.KeyHost, c)
-		}
+	if c.sshConfig.HashKnownHosts.IsTrue() {
+		log.Trace(context.Background(), "config HashKnownHosts is set", log.KeyHost, c)
+		return true
 	}
-	return hash
+	return false
 }
 
 func (c *Connection) hostkeyCallback() (ssh.HostKeyCallback, error) {
@@ -311,33 +258,21 @@ func (c *Connection) hostkeyCallback() (ssh.HostKeyCallback, error) {
 
 	var khPath string
 
-	// Ask ssh_config for a known hosts file
-	kfs := c.getConfigAll("UserKnownHostsFile")
-	// splitting the result as for some reason ssh_config sometimes seems to
-	// return a single string containing space separated paths
-	if files, err := shellescape.Split(strings.Join(kfs, " ")); err == nil {
-		for _, f := range files {
-			log.Trace(context.Background(), "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
-			exp, err := homedir.Expand(f)
-			if err == nil {
-				khPath = exp
-				break
-			}
+	for _, f := range c.sshConfig.UserKnownHostsFile {
+		log.Trace(context.Background(), "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
+		exp, err := homedir.Expand(f)
+		if err == nil {
+			khPath = exp
+			break
 		}
 	}
 
 	if khPath != "" {
-		log.Trace(context.Background(), "using known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, khPath)
+		log.Trace(context.Background(), "using known_hosts file", log.KeyHost, c, log.KeyFile, khPath)
 		return knownhostsCallback(khPath, permissive, hash)
 	}
 
-	log.Trace(context.Background(), "using default known_hosts file", log.KeyHost, c, log.KeyFile, hostkey.DefaultKnownHostsPath)
-	defaultPath, err := homedir.Expand(hostkey.DefaultKnownHostsPath)
-	if err != nil {
-		return nil, fmt.Errorf("expand known_hosts file path: %w", err)
-	}
-
-	return knownhostsCallback(defaultPath, permissive, hash)
+	return nil, fmt.Errorf("%w: no known_hosts file found", protocol.ErrAbort)
 }
 
 func (c *Connection) clientConfig() (*ssh.ClientConfig, error) { //nolint:cyclop

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -25,9 +25,6 @@ var (
 	// InsecureIgnoreHostKeyCallback is an insecure HostKeyCallback that accepts any host key.
 	InsecureIgnoreHostKeyCallback = ssh.InsecureIgnoreHostKey() //nolint:gosec
 
-	// DefaultKnownHostsPath is the default path to the known_hosts file - make sure to homedir-expand it.
-	DefaultKnownHostsPath = "~/.ssh/known_hosts"
-
 	mu sync.Mutex
 )
 
@@ -73,6 +70,8 @@ func KnownHostsFileCallback(path string, permissive, hash bool) (ssh.HostKeyCall
 // is not found in the known_hosts file but instead adds it to the file as new
 // entry.
 func wrapCallback(hkc ssh.HostKeyCallback, path string, permissive, hash bool) ssh.HostKeyCallback {
+	// TODO this should use the HostKeyAlias from the ssh config. It should also support the
+	// "accept-new" of StrictHostNameChecking and possibly some other options.
 	return ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 		mu.Lock()
 		defer mu.Unlock()

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,7 @@
 KEY_TYPE ?= rsa
 KEY_SIZE ?= 4096
 KEY_PASSPHRASE ?= ""
-KEY_PATH ?= ".ssh/identity"
+KEY_PATH ?= ".ssh/id_ed25519"
 REPLICAS ?= 1
 LINUX_IMAGE ?= "quay.io/k0sproject/bootloose-ubuntu20.04"
 
@@ -34,20 +34,20 @@ $(bootloose):
 gomod: 
 	go mod download
 
-.ssh/identity: .ssh
-	rm -f .ssh/identity
-	ssh-keygen -t $(KEY_TYPE) -b $(KEY_SIZE) -f .ssh/identity -N $(KEY_PASSPHRASE)
+.ssh/id_ed25519: .ssh
+	rm -f .ssh/id_ed25519
+	ssh-keygen -t $(KEY_TYPE) -b $(KEY_SIZE) -f .ssh/id_ed25519 -N $(KEY_PASSPHRASE)
 
 .PHONY: docker-network
 docker-network:
 	docker network inspect bootloose-cluster || docker network create bootloose-cluster --subnet 172.16.86.0/24 --gateway 172.16.86.1 --attachable
 
-bootloose.yaml: .ssh/identity $(bootloose)
+bootloose.yaml: .ssh/id_ed25519 $(bootloose)
 	$(bootloose) config create \
 		--config bootloose.yaml \
 	  --image $(LINUX_IMAGE) \
 		--name rigtest \
-	  --key .ssh/identity \
+	  --key .ssh/id_ed25519 \
 		--networks bootloose-cluster \
     --override \
 		--replicas $(REPLICAS)
@@ -62,7 +62,7 @@ delete-host: bootloose.yaml
 
 .PHONY: clean
 clean: delete-host
-	rm -f bootloose.yaml identity
+	rm -f bootloose.yaml
 	rm -rf .ssh
 	docker network rm bootloose-cluster || true
 

--- a/test/rig_test.go
+++ b/test/rig_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/k0sproject/rig/v2/protocol/ssh"
 	"github.com/k0sproject/rig/v2/protocol/winrm"
 	"github.com/k0sproject/rig/v2/remotefs"
+	"github.com/k0sproject/rig/v2/sshconfig"
 	"github.com/k0sproject/rig/v2/stattime"
-	"github.com/kevinburke/ssh_config"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -88,17 +88,12 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			panic(err)
 		}
-		cfg, err := ssh_config.Decode(f)
+		defer f.Close()
+		parser, err := sshconfig.NewParser(f)
 		if err != nil {
 			panic(err)
 		}
-		ssh.SSHConfigGetAll = func(dst, key string) []string {
-			res, err := cfg.GetAll(dst, key)
-			if err != nil {
-				return nil
-			}
-			return res
-		}
+		ssh.ConfigParser = parser
 	}
 
 	// Run tests

--- a/test/rig_test.go
+++ b/test/rig_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/k0sproject/rig/v2/protocol/ssh"
 	"github.com/k0sproject/rig/v2/protocol/winrm"
 	"github.com/k0sproject/rig/v2/remotefs"
+	"github.com/k0sproject/rig/v2/rigtest"
 	"github.com/k0sproject/rig/v2/sshconfig"
 	"github.com/k0sproject/rig/v2/stattime"
 
@@ -44,6 +45,7 @@ var (
 	onlyConnect     bool
 	privateKey      string
 	enableMultiplex bool
+	traceLog        bool
 )
 
 func pathBase(p string) string {
@@ -66,9 +68,14 @@ func TestMain(m *testing.M) {
 	flag.BoolVar(&useHTTPS, "winrm-https", false, "use https for winrm")
 	flag.BoolVar(&enableMultiplex, "openssh-multiplex", true, "use ssh multiplexing")
 	flag.BoolVar(&onlyConnect, "connect", false, "only connect to host, dont run other tests")
+	flag.BoolVar(&traceLog, "trace", false, "turn on trace logging")
 
 	// Parse the flags
 	flag.Parse()
+
+	if traceLog {
+		rigtest.TraceToStderr()
+	}
 
 	if targetHost == "" {
 		// no host, nothing to test

--- a/test/test.sh
+++ b/test/test.sh
@@ -193,7 +193,7 @@ rig_test_ssh_config_no_strict() {
   echo "[127.0.0.1]:$port ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBgejI9UJnRY/i4HNM/os57oFcRjE77gEbVfUkuGr5NRh3N7XxUnnBKdzrAiQNPttUjKmUm92BN7nCUxbwsoSPw=" > .ssh/known
   echo "[127.0.0.1]:$port ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBGZKwBdFeIPlDWe7otNy4E2Im8+GnQtsukJ5dIuzDGb" >> .ssh/known
   set +e
-  HOME=$(pwd) go test -v ./ -args -ssh-configpath .ssh/config -host testhost -connect
+  HOME=$(pwd) go test -v ./ -args -ssh-configpath .ssh/config -host testhost -connect -trace
   exit_code=$?
   set -e
   RET=$exit_code


### PR DESCRIPTION
This is a quick and dirty replacing of the usages without trying to improve the functionality or design.

Still, fixes #87 
