### PR TITLE
Add missing call to client setup in Clone()

### DIFF
--- a/client.go
+++ b/client.go
@@ -249,9 +249,13 @@ func (c *Client) String() string {
 func (c *Client) Clone(opts ...ClientOption) *Client {
 	options := c.options.Clone()
 	options.Apply(opts...)
-	return &Client{
+	clone := &Client{
 		options: options,
 	}
+	if err := clone.setup(); err != nil {
+		return nil
+	}
+	return clone
 }
 
 // Sudo returns a copy of the connection with a Runner that uses sudo.

--- a/client.go
+++ b/client.go
@@ -252,9 +252,7 @@ func (c *Client) Clone(opts ...ClientOption) *Client {
 	clone := &Client{
 		options: options,
 	}
-	if err := clone.setup(); err != nil {
-		return nil
-	}
+	_ = clone.setup()
 	return clone
 }
 


### PR DESCRIPTION
- client Clone() now runs setup() before returning (prevents nil segfault panic as clone is missing plumbing)