### PR TITLE
Improve winrm channel close panic recovery workaround

### DIFF
--- a/winrm.go
+++ b/winrm.go
@@ -321,6 +321,12 @@ func (c *WinRM) Exec(cmd string, opts ...exec.Option) error { //nolint:cyclop
 
 	wg.Add(1)
 	go func() {
+		// ignore channel close panics
+		defer func() {
+			if r := recover(); r != nil {
+				log.Debugf("recovered from a panic while reading stderr: %v", r)
+			}
+		}()
 		defer wg.Done()
 		if execOpts.Writer == nil {
 			outputScanner := bufio.NewScanner(command.Stdout)
@@ -344,6 +350,12 @@ func (c *WinRM) Exec(cmd string, opts ...exec.Option) error { //nolint:cyclop
 
 	wg.Add(1)
 	go func() {
+		// ignore channel close panics
+		defer func() {
+			if r := recover(); r != nil {
+				log.Debugf("recovered from a panic while reading stderr: %v", r)
+			}
+		}()
 		defer wg.Done()
 		outputScanner := bufio.NewScanner(command.Stderr)
 


### PR DESCRIPTION
Looks like #209 wasn't enough as seen in this workflow failure: https://github.com/k0sproject/rig/actions/runs/10193510624/job/28198254766?pr=213#step:6:643

This adds additional recovers for the stdout/stderr read loops which run in a different goroutine.


