### PR TITLE
sudo testing using -l

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -294,7 +294,7 @@ func (c *Connection) configureSudo() {
 			c.sudofunc = sudoNoop
 			return
 		}
-		if c.Exec(`sudo -n true`) == nil {
+		if c.Exec(`sudo -n -l`) == nil {
 			// user has passwordless sudo
 			c.sudofunc = sudoSudo
 			return


### PR DESCRIPTION
- previous sudo validation using `sudo -n true` is not really needed when there is a `sudo -l` option that will validate general sudo access

PRODENG-2503 sudo cleanup in launchpad
Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>