### PR TITLE
[release-0.x] Bump Go to v1.23.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/k0sproject/rig
 
-go 1.23.2
+go 1.23
+
+toolchain go1.23.3
 
 require (
 	github.com/Microsoft/go-winio v0.6.2


### PR DESCRIPTION
Also don't enforce patch versions on downstream projects.