### PR TITLE
Use full patch version for go directives in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k0sproject/rig/v2
 
-go 1.23
+go 1.23.0
 
 toolchain go1.23.3
 


### PR DESCRIPTION
It turns out that since Go 1.21, in which Go started using fully qualified versions and not omitting zeros (i.e. "1.21.0" instead of just "1.21"), just stating the minor version without the patch version is actually considered a development version of Go. Who would have thought? The correct way to use the Go directive is to set it to "go 1.23.0".