### PR TITLE
[Backport release-0.x] Use full patch version for go directives in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k0sproject/rig
 
-go 1.23
+go 1.23.0
 
 toolchain go1.23.3
 


### PR DESCRIPTION
Backport to `release-0.x`:

* #240