### PR TITLE
Make Upload take fs.FileMode for permissions

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"testing"
 
 	"github.com/creasty/defaults"
@@ -19,15 +20,15 @@ type mockClient struct {
 	commands []string
 }
 
-func (m *mockClient) Connect() error                             { return nil }
-func (m *mockClient) Disconnect()                                {}
-func (m *mockClient) Upload(_, _ string, _ ...exec.Option) error { return nil }
-func (m *mockClient) IsWindows() bool                            { return false }
-func (m *mockClient) ExecInteractive(_ string) error             { return nil }
-func (m *mockClient) String() string                             { return "mockclient" }
-func (m *mockClient) Protocol() string                           { return "null" }
-func (m *mockClient) IPAddress() string                          { return "127.0.0.1" }
-func (m *mockClient) IsConnected() bool                          { return true }
+func (m *mockClient) Connect() error                                            { return nil }
+func (m *mockClient) Disconnect()                                               {}
+func (m *mockClient) Upload(_, _ string, _ fs.FileMode, _ ...exec.Option) error { return nil }
+func (m *mockClient) IsWindows() bool                                           { return false }
+func (m *mockClient) ExecInteractive(_ string) error                            { return nil }
+func (m *mockClient) String() string                                            { return "mockclient" }
+func (m *mockClient) Protocol() string                                          { return "null" }
+func (m *mockClient) IPAddress() string                                         { return "127.0.0.1" }
+func (m *mockClient) IsConnected() bool                                         { return true }
 func (m *mockClient) Exec(cmd string, opts ...exec.Option) error {
 	o := exec.Build(opts...)
 	cmd, err := o.Command(cmd)
@@ -39,6 +40,7 @@ func (m *mockClient) Exec(cmd string, opts ...exec.Option) error {
 
 	return nil
 }
+
 func (m *mockClient) ExecStreams(cmd string, stdin io.ReadCloser, stdout, stderr io.Writer, opts ...exec.Option) (exec.Waiter, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/examples/upload/upload.go
+++ b/examples/upload/upload.go
@@ -100,7 +100,7 @@ func main() {
 	if *sudo {
 		opts = append(opts, exec.Sudo(h))
 	}
-	if err := h.Upload(*sf, *df, opts...); err != nil {
+	if err := h.Upload(*sf, *df, 0o600, opts...); err != nil {
 		panic(err)
 	}
 	fmt.Println("Done, file now at", *df)

--- a/os/host.go
+++ b/os/host.go
@@ -2,13 +2,14 @@ package os
 
 import (
 	"io"
+	"io/fs"
 
 	"github.com/k0sproject/rig/exec"
 )
 
 // Host is an interface to a host object that has the functions needed by the various OS support packages
 type Host interface {
-	Upload(source, destination string, opts ...exec.Option) error
+	Upload(source, destination string, perm fs.FileMode, opts ...exec.Option) error
 	Exec(cmd string, opts ...exec.Option) error
 	ExecOutput(cmd string, opts ...exec.Option) (string, error)
 	Execf(cmd string, argsOrOpts ...any) error

--- a/test/rig_test.go
+++ b/test/rig_test.go
@@ -411,7 +411,7 @@ func (s *ConfigurerSuite) TestUpload() {
 			defer s.Host.Configurer.DeleteFile(s.Host, s.TempPath(pathBase(fn)))
 
 			s.Run("Upload file", func() {
-				s.Require().NoError(s.Host.Upload(fn, s.TempPath(pathBase(fn))))
+				s.Require().NoError(s.Host.Upload(fn, s.TempPath(pathBase(fn)), 0o600))
 			})
 
 			s.Run("Verify file size", func() {


### PR DESCRIPTION
Blindly copying the source file permissions is bad.

For example when uploading to a temp file, the file could have insecure permissions before it is moved into place after completion, making it possible to perhaps execute or modify the partial binary.

