### PR TITLE
Add MachineID and SystemTime to remotefs.OS interface

### DIFF
--- a/remotefs/hostinfo_test.go
+++ b/remotefs/hostinfo_test.go
@@ -1,0 +1,99 @@
+package remotefs_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/rig/v2/remotefs"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPosixMachineID(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.Equal("cat /etc/machine-id"), "abc123def456")
+		fs := remotefs.NewPosixFS(mr)
+		id, err := fs.MachineID()
+		require.NoError(t, err)
+		require.Equal(t, "abc123def456", id)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.Equal("cat /etc/machine-id"), "")
+		fs := remotefs.NewPosixFS(mr)
+		_, err := fs.MachineID()
+		require.Error(t, err)
+	})
+
+	t.Run("command fails", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Equal("cat /etc/machine-id"), errors.New("no such file"))
+		fs := remotefs.NewPosixFS(mr)
+		_, err := fs.MachineID()
+		require.Error(t, err)
+	})
+}
+
+func TestPosixSystemTime(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.Equal("date -u +%s"), "1700000000")
+		fs := remotefs.NewPosixFS(mr)
+		got, err := fs.SystemTime()
+		require.NoError(t, err)
+		require.Equal(t, time.Unix(1700000000, 0), got)
+	})
+
+	t.Run("invalid output", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.Equal("date -u +%s"), "not-a-number")
+		fs := remotefs.NewPosixFS(mr)
+		_, err := fs.SystemTime()
+		require.Error(t, err)
+	})
+}
+
+func TestWindowsMachineID(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+		fs := remotefs.NewWindowsFS(mr)
+		id, err := fs.MachineID()
+		require.NoError(t, err)
+		require.Equal(t, "6ba7b810-9dad-11d1-80b4-00c04fd430c8", id)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "")
+		fs := remotefs.NewWindowsFS(mr)
+		_, err := fs.MachineID()
+		require.Error(t, err)
+	})
+}
+
+func TestWindowsSystemTime(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "1700000000")
+		fs := remotefs.NewWindowsFS(mr)
+		got, err := fs.SystemTime()
+		require.NoError(t, err)
+		require.Equal(t, time.Unix(1700000000, 0), got)
+	})
+
+	t.Run("invalid output", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "not-a-number")
+		fs := remotefs.NewWindowsFS(mr)
+		_, err := fs.SystemTime()
+		require.Error(t, err)
+	})
+}

--- a/remotefs/hostinfo_test.go
+++ b/remotefs/hostinfo_test.go
@@ -25,7 +25,7 @@ func TestPosixMachineID(t *testing.T) {
 		mr.AddCommandOutput(rigtest.Equal("cat /etc/machine-id"), "")
 		fs := remotefs.NewPosixFS(mr)
 		_, err := fs.MachineID()
-		require.Error(t, err)
+		require.ErrorIs(t, err, remotefs.ErrEmptyMachineID)
 	})
 
 	t.Run("command fails", func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestWindowsMachineID(t *testing.T) {
 		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "")
 		fs := remotefs.NewWindowsFS(mr)
 		_, err := fs.MachineID()
-		require.Error(t, err)
+		require.ErrorIs(t, err, remotefs.ErrEmptyMachineID)
 	})
 }
 

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -613,6 +613,32 @@ func (s *PosixFS) Hostname() (string, error) {
 	return out, nil
 }
 
+// MachineID returns the unique machine ID from /etc/machine-id.
+func (s *PosixFS) MachineID() (string, error) {
+	out, err := s.ExecOutput("cat /etc/machine-id")
+	if err != nil {
+		return "", fmt.Errorf("machine-id: %w", err)
+	}
+	if out == "" {
+		return "", ErrEmptyMachineID
+	}
+	return out, nil
+}
+
+// SystemTime returns the current UTC time on the remote host.
+// Note: date +%s is not POSIX but is supported on GNU coreutils, busybox, and macOS.
+func (s *PosixFS) SystemTime() (time.Time, error) {
+	out, err := s.ExecOutput("date -u +%s")
+	if err != nil {
+		return time.Time{}, fmt.Errorf("system time: %w", err)
+	}
+	secs, err := strconv.ParseInt(out, 10, 64)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("system time: parse %q: %w", out, err)
+	}
+	return time.Unix(secs, 0), nil
+}
+
 // LongHostname returns the FQDN of the host.
 func (s *PosixFS) LongHostname() (string, error) {
 	out, err := s.ExecOutput("hostname -f 2> /dev/null")

--- a/remotefs/types.go
+++ b/remotefs/types.go
@@ -1,9 +1,14 @@
 package remotefs
 
 import (
+	"errors"
 	"io"
 	"io/fs"
+	"time"
 )
+
+// ErrEmptyMachineID is returned by MachineID when the host returns an empty value.
+var ErrEmptyMachineID = errors.New("machine-id: empty")
 
 // FS is a filesystem on the remote host.
 type FS interface {
@@ -46,6 +51,8 @@ type OS interface { //nolint:interfacebloat // intentionally large interface
 	Rename(oldpath, newpath string) error
 	Hostname() (string, error)
 	LongHostname() (string, error)
+	MachineID() (string, error)
+	SystemTime() (time.Time, error)
 	TempDir() string
 	UserCacheDir() string
 	UserConfigDir() string

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -334,6 +334,31 @@ func (s *WinFS) Hostname() (string, error) {
 	return out, nil
 }
 
+// MachineID returns the unique machine ID from the Windows registry.
+func (s *WinFS) MachineID() (string, error) {
+	out, err := s.ExecOutput("(Get-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Cryptography' -Name MachineGuid).MachineGuid", cmd.PS())
+	if err != nil {
+		return "", fmt.Errorf("machine-id: %w", err)
+	}
+	if out == "" {
+		return "", ErrEmptyMachineID
+	}
+	return out, nil
+}
+
+// SystemTime returns the current UTC time on the remote host.
+func (s *WinFS) SystemTime() (time.Time, error) {
+	out, err := s.ExecOutput("[DateTimeOffset]::UtcNow.ToUnixTimeSeconds()", cmd.PS())
+	if err != nil {
+		return time.Time{}, fmt.Errorf("system time: %w", err)
+	}
+	secs, err := strconv.ParseInt(out, 10, 64)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("system time: parse %q: %w", out, err)
+	}
+	return time.Unix(secs, 0), nil
+}
+
 // LongHostname resolves the FQDN (long) hostname.
 func (s *WinFS) LongHostname() (string, error) {
 	out, err := s.ExecOutput("([System.Net.Dns]::GetHostByName(($env:COMPUTERNAME))).Hostname", cmd.PS())


### PR DESCRIPTION
Moving some stuff that is generic from k0sctl to rig

Breaking rig's v2 api here is not a problem as it's not released and not in use anywhere yet.