### PR TITLE
[release-0.x] Update golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -5,17 +5,22 @@ on:
       - main
       - release-*
     paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
+      - "**.go"
+      - go.mod
+      - go.sum
+      - .github/workflows/golangci-lint.yaml
   pull_request:
     branches:
       - main
       - release-*
     paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
+      - "**.go"
+      - go.mod
+      - go.sum
+      - .github/workflows/golangci-lint.yaml
+
+permissions:
+  pull-requests: read
 
 jobs:
   lint:
@@ -48,9 +53,9 @@ jobs:
         run: go mod tidy -v && git diff --exit-code
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: latest
+          version: v2.11.4
           skip-cache: true
-          only-new-issues: false
+          only-new-issues: true
           args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,70 +1,71 @@
+version: "2"
 run:
-  timeout: 8m
-
-  skip-dirs-use-default: false
-  skip-files:
-    - ".*\\.gen\\.go"
-    - examples/*
-    - test/*
   tests: false
   allow-parallel-runners: true
-
 linters:
-  enable-all: true
+  default: all
   disable:
-    - exhaustivestruct
+    - depguard
+    - dogsled
+    - embeddedstructfieldcheck
     - exhaustruct
     - forbidigo
+    - funcorder
     - gochecknoglobals
     - gochecknoinits
     - godot
     - godox
-    - golint
-    - interfacer
+    - goheader
     - ireturn
-    - maligned
+    - lll
+    - mnd
     - nlreturn
+    - noinlineerr
     - paralleltest
-    - scopelint
+    - tagalign
+    - tagliatelle
     - tparallel
     - wsl
-    - tagliatelle
-    - structcheck
-    - nosnakecase
-    - deadcode
-    - varcheck
-    - ifshort
-    - goheader
-    - dogsled
-    - lll
-    - gomnd
-    - depguard
-    - tagalign
-
-linters-settings:
-  funlen:
-    lines: 100
-    statements: 75
-  varnamelen:
-    max-distance: 10
-    ignore-decls:
-      - w http.ResponseWriter
-      - r *http.Request
-      - i int
-      - n int
-      - p []byte
-      - mu sync.Mutex
-      - wg sync.WaitGroup
-      - h Host
-  cyclop:
-    max-complexity: 12
-
+    - wsl_v5
+  settings:
+    funlen:
+      lines: 100
+      statements: 75
+    varnamelen:
+      max-distance: 10
+      ignore-decls:
+        - w http.ResponseWriter
+        - r *http.Request
+        - i int
+        - n int
+        - p []byte
+        - mu sync.Mutex
+        - wg sync.WaitGroup
+        - h Host
+    cyclop:
+      max-complexity: 12
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  include:
-    - EXC0002
-    - EXC0012
-    - EXC0013
-    - EXC0014
-    - EXC0015
   max-issues-per-linter: 0
   max-same-issues: 0
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/os/linux.go
+++ b/os/linux.go
@@ -428,7 +428,7 @@ func (c Linux) Stat(h Host, path string, opts ...exec.Option) (*FileInfo, error)
 
 	fields := strings.SplitN(out, "|", 4)
 	if len(fields) != 4 {
-		err = fmt.Errorf("failed to stat %s: unrecognized output: %s", path, out) //nolint:goerr113
+		err = fmt.Errorf("failed to stat %s: unrecognized output: %s", path, out) //nolint:err113
 		return nil, err
 	}
 

--- a/pkg/rigfs/winfile.go
+++ b/pkg/rigfs/winfile.go
@@ -218,7 +218,7 @@ func (f *winFile) open(flags int) error {
 		return f.pathErr(OpOpen, err)
 	}
 	if resp.Err != "" {
-		return f.pathErr(OpOpen, fmt.Errorf("remote error: %s", resp.Err)) //nolint:goerr113
+		return f.pathErr(OpOpen, fmt.Errorf("remote error: %s", resp.Err)) //nolint:err113
 	}
 
 	return nil

--- a/pkg/rigfs/winfsys.go
+++ b/pkg/rigfs/winfsys.go
@@ -53,7 +53,7 @@ func (fsys *WinFsys) Stat(name string) (fs.FileInfo, error) {
 		if strings.Contains(fi.Err, "does not exist") {
 			return nil, &fs.PathError{Op: OpStat, Path: name, Err: fs.ErrNotExist}
 		}
-		return nil, &fs.PathError{Op: OpStat, Path: name, Err: fmt.Errorf("stat: %v", fi.Err)} //nolint:goerr113
+		return nil, &fs.PathError{Op: OpStat, Path: name, Err: fmt.Errorf("stat: %v", fi.Err)} //nolint:err113
 	}
 	return fi, nil
 }


### PR DESCRIPTION
Migrate the config file to v2 and add some more linters to the ignored list which are already ignored on the main branch. Since there are still quite a few linter warnings left, turn on only-new-issues. Add the workflow file to the list of paths so that the workflow is triggered even if only the file itself changes.