### PR TITLE
OS resolver missing os-release file fallback / guess

### DIFF
--- a/os/defaultprovider.go
+++ b/os/defaultprovider.go
@@ -13,6 +13,7 @@ var (
 	DefaultRegistry = sync.OnceValue(func() *Registry {
 		provider := NewRegistry()
 		provider.Register(ResolveLinux)
+		provider.Register(ResolveLinuxCompat)
 		provider.Register(ResolveWindows)
 		provider.Register(ResolveDarwin)
 		return provider

--- a/os/linux_compat.go
+++ b/os/linux_compat.go
@@ -1,0 +1,85 @@
+package os
+
+import (
+	"context"
+	"strings"
+
+	"github.com/k0sproject/rig/v2/cmd"
+	"github.com/k0sproject/rig/v2/log"
+)
+
+// packageManagerID maps a package manager binary name to a synthesized os.Release.
+// Order matters: the slice is probed in sequence and the first hit wins.
+var packageManagerID = []struct {
+	bin     string
+	id      string
+	idLike  []string
+	name    string
+}{
+	{"apk", "alpine", nil, "Alpine Linux"},
+	{"pacman", "arch", nil, "Arch Linux"},
+	{"emerge", "gentoo", nil, "Gentoo"},
+	{"xbps-install", "void", nil, "Void Linux"},
+	{"dnf", "fedora", []string{"rhel", "fedora"}, "Linux"},
+	{"yum", "centos", []string{"rhel", "centos", "fedora"}, "Linux"},
+	{"zypper", "opensuse-leap", []string{"suse", "opensuse"}, "Linux"},
+	{"apt-get", "debian", nil, "Linux"},
+}
+
+// ResolveLinuxCompat is a fallback resolver for Linux hosts where /etc/os-release
+// and /usr/lib/os-release are absent (distroless containers, minimal images, etc.).
+// It probes for well-known package managers and synthesizes a *Release from the
+// result. When confident (apk → Alpine, pacman → Arch, etc.) it sets ID directly;
+// for family-based managers it sets IDLike so k0sctl's configurer fallback loop
+// can still find a match. Name is set to "Linux (compatibility mode)" when the
+// result is ambiguous, or the distro name when the package manager is unambiguous.
+func ResolveLinuxCompat(conn cmd.SimpleRunner) (*Release, bool) {
+	if conn.IsWindows() {
+		return nil, false
+	}
+
+	if err := conn.Exec("uname | grep -q Linux"); err != nil {
+		return nil, false
+	}
+
+	release := &Release{
+		ID:   "linux",
+		Name: "Linux (compatibility mode)",
+	}
+
+	if arch, err := conn.ExecOutput("uname -m"); err == nil {
+		release.arch = strings.TrimSpace(arch)
+	}
+
+	for _, pm := range packageManagerID {
+		if err := conn.Exec("command -v " + pm.bin + " > /dev/null 2>&1"); err == nil {
+			release.ID = pm.id
+			release.IDLike = pm.idLike
+			if pm.idLike == nil {
+				// unambiguous mapping: use the real distro name
+				release.Name = pm.name
+			} else {
+				release.Name = pm.name + " (compatibility mode)"
+			}
+			log.Trace(context.Background(), "linux compat resolver: detected OS via package manager",
+				log.HostAttr(conn),
+				"package_manager", pm.bin,
+				"id", release.ID,
+			)
+			return release, true
+		}
+	}
+
+	log.Trace(context.Background(), "linux compat resolver: no package manager detected, using generic linux release",
+		log.HostAttr(conn),
+	)
+
+	return release, true
+}
+
+// RegisterLinuxCompat registers the Linux compatibility resolver to a provider.
+// It should be registered after ResolveLinux so it only activates when the
+// standard os-release files are absent.
+func RegisterLinuxCompat(provider *Registry) {
+	provider.Register(ResolveLinuxCompat)
+}

--- a/os/linux_compat.go
+++ b/os/linux_compat.go
@@ -8,31 +8,32 @@ import (
 	"github.com/k0sproject/rig/v2/log"
 )
 
-// packageManagerID maps a package manager binary name to a synthesized os.Release.
+// packageManagerID maps a package manager binary name to a synthesized *Release.
 // Order matters: the slice is probed in sequence and the first hit wins.
+// Entries with a nil idLike are unambiguous (one package manager → one distro);
+// entries with a non-nil idLike are family-based and only IDLike is set on the result.
 var packageManagerID = []struct {
-	bin     string
-	id      string
-	idLike  []string
-	name    string
+	bin    string
+	id     string   // set on Release only when idLike is nil (unambiguous)
+	idLike []string // non-nil means ambiguous family; ID stays "linux"
+	name   string   // distro display name; empty for ambiguous entries
 }{
 	{"apk", "alpine", nil, "Alpine Linux"},
 	{"pacman", "arch", nil, "Arch Linux"},
 	{"emerge", "gentoo", nil, "Gentoo"},
 	{"xbps-install", "void", nil, "Void Linux"},
-	{"dnf", "fedora", []string{"rhel", "fedora"}, "Linux"},
-	{"yum", "centos", []string{"rhel", "centos", "fedora"}, "Linux"},
-	{"zypper", "opensuse-leap", []string{"suse", "opensuse"}, "Linux"},
-	{"apt-get", "debian", nil, "Linux"},
+	{"dnf", "", []string{"rhel", "fedora"}, ""},
+	{"yum", "", []string{"rhel", "centos", "fedora"}, ""},
+	{"zypper", "", []string{"suse", "opensuse"}, ""},
+	{"apt-get", "", []string{"debian"}, ""},
 }
 
 // ResolveLinuxCompat is a fallback resolver for Linux hosts where /etc/os-release
 // and /usr/lib/os-release are absent (distroless containers, minimal images, etc.).
 // It probes for well-known package managers and synthesizes a *Release from the
-// result. When confident (apk → Alpine, pacman → Arch, etc.) it sets ID directly;
-// for family-based managers it sets IDLike so k0sctl's configurer fallback loop
-// can still find a match. Name is set to "Linux (compatibility mode)" when the
-// result is ambiguous, or the distro name when the package manager is unambiguous.
+// result. Unambiguous mappings (apk → alpine, pacman → arch, etc.) set ID directly;
+// family-based managers set IDLike only, leaving ID as "linux", so downstream
+// configurers can still match via the IDLike fallback chain.
 func ResolveLinuxCompat(conn cmd.SimpleRunner) (*Release, bool) {
 	if conn.IsWindows() {
 		return nil, false
@@ -51,23 +52,23 @@ func ResolveLinuxCompat(conn cmd.SimpleRunner) (*Release, bool) {
 		release.arch = strings.TrimSpace(arch)
 	}
 
-	for _, pm := range packageManagerID {
-		if err := conn.Exec("command -v " + pm.bin + " > /dev/null 2>&1"); err == nil {
-			release.ID = pm.id
-			release.IDLike = pm.idLike
-			if pm.idLike == nil {
-				// unambiguous mapping: use the real distro name
-				release.Name = pm.name
-			} else {
-				release.Name = pm.name + " (compatibility mode)"
-			}
-			log.Trace(context.Background(), "linux compat resolver: detected OS via package manager",
-				log.HostAttr(conn),
-				"package_manager", pm.bin,
-				"id", release.ID,
-			)
-			return release, true
+	for _, entry := range packageManagerID {
+		if err := conn.Exec("command -v " + entry.bin + " > /dev/null 2>&1"); err != nil {
+			continue
 		}
+		if entry.idLike == nil {
+			release.ID = entry.id
+			release.Name = entry.name
+		} else {
+			release.IDLike = entry.idLike
+		}
+		log.Trace(context.Background(), "linux compat resolver: detected OS via package manager",
+			log.HostAttr(conn),
+			"package_manager", entry.bin,
+			"id", release.ID,
+			"id_like", release.IDLike,
+		)
+		return release, true
 	}
 
 	log.Trace(context.Background(), "linux compat resolver: no package manager detected, using generic linux release",

--- a/os/linux_compat_test.go
+++ b/os/linux_compat_test.go
@@ -1,0 +1,116 @@
+package os
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/rigtest"
+)
+
+func setupCompatRunner(pm string) *rigtest.MockRunner {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommand(rigtest.HasPrefix("uname"), func(_ *rigtest.A) error { return nil })
+	mr.AddCommandOutput(rigtest.Equal("uname -m"), "x86_64")
+	for _, entry := range packageManagerID {
+		if entry.bin == pm {
+			mr.AddCommand(rigtest.Equal("command -v "+entry.bin+" > /dev/null 2>&1"), func(_ *rigtest.A) error { return nil })
+		} else {
+			mr.AddCommandFailure(rigtest.Equal("command -v "+entry.bin+" > /dev/null 2>&1"), errCommandFailed)
+		}
+	}
+	return mr
+}
+
+var errCommandFailed = errors.New("not found")
+
+func TestResolveLinuxCompatUnambiguous(t *testing.T) {
+	cases := []struct {
+		pm   string
+		id   string
+		name string
+	}{
+		{"apk", "alpine", "Alpine Linux"},
+		{"pacman", "arch", "Arch Linux"},
+		{"emerge", "gentoo", "Gentoo"},
+		{"xbps-install", "void", "Void Linux"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.pm, func(t *testing.T) {
+			mr := setupCompatRunner(tc.pm)
+			r, ok := ResolveLinuxCompat(mr)
+			if !ok {
+				t.Fatal("ResolveLinuxCompat returned false")
+			}
+			if r.ID != tc.id {
+				t.Errorf("ID: got %q, want %q", r.ID, tc.id)
+			}
+			if r.Name != tc.name {
+				t.Errorf("Name: got %q, want %q", r.Name, tc.name)
+			}
+			if len(r.IDLike) != 0 {
+				t.Errorf("IDLike should be empty for unambiguous entry, got %v", r.IDLike)
+			}
+		})
+	}
+}
+
+func TestResolveLinuxCompatAmbiguous(t *testing.T) {
+	cases := []struct {
+		pm     string
+		idLike []string
+	}{
+		{"dnf", []string{"rhel", "fedora"}},
+		{"yum", []string{"rhel", "centos", "fedora"}},
+		{"zypper", []string{"suse", "opensuse"}},
+		{"apt-get", []string{"debian"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.pm, func(t *testing.T) {
+			mr := setupCompatRunner(tc.pm)
+			r, ok := ResolveLinuxCompat(mr)
+			if !ok {
+				t.Fatal("ResolveLinuxCompat returned false")
+			}
+			if r.ID != "linux" {
+				t.Errorf("ID: got %q, want %q (ambiguous entry must not claim specific distro)", r.ID, "linux")
+			}
+			if len(r.IDLike) != len(tc.idLike) {
+				t.Errorf("IDLike: got %v, want %v", r.IDLike, tc.idLike)
+				return
+			}
+			for i, v := range tc.idLike {
+				if r.IDLike[i] != v {
+					t.Errorf("IDLike[%d]: got %q, want %q", i, r.IDLike[i], v)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveLinuxCompatNoPackageManager(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommand(rigtest.HasPrefix("uname"), func(_ *rigtest.A) error { return nil })
+	mr.AddCommandOutput(rigtest.Equal("uname -m"), "x86_64")
+	for _, entry := range packageManagerID {
+		mr.AddCommandFailure(rigtest.Equal("command -v "+entry.bin+" > /dev/null 2>&1"), errCommandFailed)
+	}
+	r, ok := ResolveLinuxCompat(mr)
+	if !ok {
+		t.Fatal("ResolveLinuxCompat returned false")
+	}
+	if r.ID != "linux" {
+		t.Errorf("ID: got %q, want %q", r.ID, "linux")
+	}
+	if len(r.IDLike) != 0 {
+		t.Errorf("IDLike should be empty when no package manager found, got %v", r.IDLike)
+	}
+}
+
+func TestResolveLinuxCompatNotLinux(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandFailure(rigtest.HasPrefix("uname"), errCommandFailed)
+	_, ok := ResolveLinuxCompat(mr)
+	if ok {
+		t.Error("ResolveLinuxCompat should return false for non-Linux")
+	}
+}


### PR DESCRIPTION
When an `os-release` file is not found, try to guess based on an installed package manager.