### PR TITLE
WithOSIDOverride client option

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -222,29 +222,48 @@ func TestConfiguredConnectionUnmarshal(t *testing.T) {
 }
 
 func TestWithOSIDOverride(t *testing.T) {
-	conn := rigtest.NewMockConnection()
-
 	detectedRelease := &os.Release{
 		ID:     "detected-os",
 		Name:   "Detected OS",
 		IDLike: []string{"family"},
 	}
+	releaseProvider := func(_ cmd.SimpleRunner) (*os.Release, error) {
+		return detectedRelease, nil
+	}
 
-	client, err := rig.NewClient(
-		rig.WithConnection(conn),
-		rig.WithOSReleaseProvider(func(_ cmd.SimpleRunner) (*os.Release, error) {
-			return detectedRelease, nil
-		}),
-		rig.WithOSIDOverride("override-id"),
-	)
-	require.NoError(t, err)
-	require.NoError(t, client.Connect(context.Background()))
+	t.Run("override after provider", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		client, err := rig.NewClient(
+			rig.WithConnection(conn),
+			rig.WithOSReleaseProvider(releaseProvider),
+			rig.WithOSIDOverride("override-id"),
+		)
+		require.NoError(t, err)
+		require.NoError(t, client.Connect(context.Background()))
 
-	release, err := client.OS()
-	require.NoError(t, err)
-	require.Equal(t, "override-id", release.ID)
-	require.Equal(t, "Detected OS", release.Name)
-	require.Equal(t, []string{"family"}, release.IDLike)
+		release, err := client.OS()
+		require.NoError(t, err)
+		require.Equal(t, "override-id", release.ID)
+		require.Equal(t, "Detected OS", release.Name)
+		require.Equal(t, []string{"family"}, release.IDLike)
+	})
+
+	t.Run("override before provider", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		client, err := rig.NewClient(
+			rig.WithConnection(conn),
+			rig.WithOSIDOverride("override-id"),
+			rig.WithOSReleaseProvider(releaseProvider),
+		)
+		require.NoError(t, err)
+		require.NoError(t, client.Connect(context.Background()))
+
+		release, err := client.OS()
+		require.NoError(t, err)
+		require.Equal(t, "override-id", release.ID)
+		require.Equal(t, "Detected OS", release.Name)
+		require.Equal(t, []string{"family"}, release.IDLike)
+	})
 }
 
 // TestConfiguredConnectionConnectOptsApplied is a regression test verifying that

--- a/client_test.go
+++ b/client_test.go
@@ -264,6 +264,22 @@ func TestWithOSIDOverride(t *testing.T) {
 		require.Equal(t, "Detected OS", release.Name)
 		require.Equal(t, []string{"family"}, release.IDLike)
 	})
+
+	t.Run("nil release from provider", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		client, err := rig.NewClient(
+			rig.WithConnection(conn),
+			rig.WithOSReleaseProvider(func(_ cmd.SimpleRunner) (*os.Release, error) {
+				return nil, nil
+			}),
+			rig.WithOSIDOverride("override-id"),
+		)
+		require.NoError(t, err)
+		require.NoError(t, client.Connect(context.Background()))
+
+		_, err = client.OS()
+		require.Error(t, err)
+	})
 }
 
 // TestConfiguredConnectionConnectOptsApplied is a regression test verifying that

--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/k0sproject/rig/v2"
 	"github.com/k0sproject/rig/v2/cmd"
+	"github.com/k0sproject/rig/v2/os"
 	"github.com/k0sproject/rig/v2/packagemanager"
 	"github.com/k0sproject/rig/v2/remotefs"
 	"github.com/k0sproject/rig/v2/rigtest"
@@ -218,6 +219,32 @@ func TestConfiguredConnectionUnmarshal(t *testing.T) {
 	out, err := conn.ExecOutput("echo hello")
 	require.NoError(t, err)
 	require.Equal(t, "hello", out)
+}
+
+func TestWithOSIDOverride(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+
+	detectedRelease := &os.Release{
+		ID:     "detected-os",
+		Name:   "Detected OS",
+		IDLike: []string{"family"},
+	}
+
+	client, err := rig.NewClient(
+		rig.WithConnection(conn),
+		rig.WithOSReleaseProvider(func(_ cmd.SimpleRunner) (*os.Release, error) {
+			return detectedRelease, nil
+		}),
+		rig.WithOSIDOverride("override-id"),
+	)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(context.Background()))
+
+	release, err := client.OS()
+	require.NoError(t, err)
+	require.Equal(t, "override-id", release.ID)
+	require.Equal(t, "Detected OS", release.Name)
+	require.Equal(t, []string{"family"}, release.IDLike)
 }
 
 // TestConfiguredConnectionConnectOptsApplied is a regression test verifying that

--- a/clientoptions.go
+++ b/clientoptions.go
@@ -1,6 +1,7 @@
 package rig
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/k0sproject/rig/v2/cmd"
@@ -12,6 +13,8 @@ import (
 	"github.com/k0sproject/rig/v2/remotefs"
 	"github.com/k0sproject/rig/v2/sudo"
 )
+
+var errNilOSRelease = errors.New("os release provider returned nil release without error")
 
 // ConnectionFactory can create connections. When a connection is not given, the factory is used
 // to build a connection.
@@ -67,11 +70,29 @@ func (p *remoteFSProviderConfig) GetRemoteFSProvider(runner cmd.Runner) *remotef
 }
 
 type osReleaseProviderConfig struct {
-	provider os.ReleaseProvider
+	provider   os.ReleaseProvider
+	idOverride string
 }
 
 func (p *osReleaseProviderConfig) GetOSReleaseProvider(runner cmd.Runner) *os.Provider {
-	return os.NewOSReleaseProvider(p.provider, runner)
+	provider := p.provider
+	if p.idOverride != "" {
+		idOverride := p.idOverride
+		original := p.provider
+		provider = func(r cmd.SimpleRunner) (*os.Release, error) {
+			release, err := original(r)
+			if err != nil {
+				return nil, err
+			}
+			if release == nil {
+				return nil, errNilOSRelease
+			}
+			result := *release
+			result.ID = idOverride
+			return &result, nil
+		}
+	}
+	return os.NewOSReleaseProvider(provider, runner)
 }
 
 type sudoProviderConfig struct {
@@ -204,7 +225,7 @@ func WithInitSystemProvider(provider initsystem.ServiceManagerProvider) ClientOp
 // WithOSReleaseProvider is a functional option that sets the os release provider to use for the connection's OSReleaseProvider.
 func WithOSReleaseProvider(provider os.ReleaseProvider) ClientOption {
 	return func(o *ClientOptions) {
-		o.osReleaseProviderConfig = osReleaseProviderConfig{provider: provider}
+		o.osReleaseProviderConfig.provider = provider
 	}
 }
 
@@ -216,18 +237,7 @@ func WithOSReleaseProvider(provider os.ReleaseProvider) ClientOption {
 // of a supported distro).
 func WithOSIDOverride(id string) ClientOption {
 	return func(o *ClientOptions) {
-		original := o.osReleaseProviderConfig.provider
-		o.osReleaseProviderConfig = osReleaseProviderConfig{
-			provider: func(runner cmd.SimpleRunner) (*os.Release, error) {
-				release, err := original(runner)
-				if err != nil {
-					return nil, err
-				}
-				override := *release
-				override.ID = id
-				return &override, nil
-			},
-		}
+		o.idOverride = id
 	}
 }
 

--- a/clientoptions.go
+++ b/clientoptions.go
@@ -208,6 +208,29 @@ func WithOSReleaseProvider(provider os.ReleaseProvider) ClientOption {
 	}
 }
 
+// WithOSIDOverride is a functional option that overrides the OS ID reported by the
+// host's detected [os.Release]. Detection still runs normally; only the ID field of
+// the result is replaced. IDLike from actual detection is preserved so callers can
+// still inspect the distro family. This is useful when the detected ID does not match
+// any known configurer but a compatible one is known (e.g. an unsupported derivative
+// of a supported distro).
+func WithOSIDOverride(id string) ClientOption {
+	return func(o *ClientOptions) {
+		original := o.osReleaseProviderConfig.provider
+		o.osReleaseProviderConfig = osReleaseProviderConfig{
+			provider: func(runner cmd.SimpleRunner) (*os.Release, error) {
+				release, err := original(runner)
+				if err != nil {
+					return nil, err
+				}
+				override := *release
+				override.ID = id
+				return &override, nil
+			},
+		}
+	}
+}
+
 // WithPackageManagerProvider is a functional option that sets the package manager provider to use for the connection's PackageManagerProvider.
 func WithPackageManagerProvider(provider packagemanager.ManagerProvider) ClientOption {
 	return func(o *ClientOptions) {


### PR DESCRIPTION
Adds a functional option to make it easier to build the client with an OS detection override.

Part of the last-mile rig v2 stretch smoothing the migration. Breaking API is not a problem, rig v2 is not in use yet.


