### PR TITLE
Add Service.SetEnvironment and Service.DaemonReload

### DIFF
--- a/client.go
+++ b/client.go
@@ -250,7 +250,7 @@ func (c *Client) Service(name string) (*Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get service manager: %w", err)
 	}
-	return &Service{runner: c.Runner, initsys: is, name: name}, nil
+	return &Service{runner: c.Runner, initsys: is, name: name, fs: c.FS()}, nil
 }
 
 // String returns a printable representation of the connection, which will usually look

--- a/initsystem/env_test.go
+++ b/initsystem/env_test.go
@@ -1,0 +1,56 @@
+package initsystem_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/initsystem"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemdServiceEnvironmentPath(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandOutput(
+		rigtest.Equal(`systemctl show -p FragmentPath mysvc.service | cut '-d"="' -f2`),
+		"/etc/systemd/system/mysvc.service\n",
+	)
+
+	got, err := initsystem.Systemd{}.ServiceEnvironmentPath(context.Background(), mr, "mysvc")
+	require.NoError(t, err)
+	require.Equal(t, "/etc/systemd/system/mysvc.service.d/env.conf", got)
+}
+
+func TestSystemdServiceEnvironmentContent(t *testing.T) {
+	t.Run("keys are sorted", func(t *testing.T) {
+		env := map[string]string{
+			"ZEBRA": "last",
+			"ALPHA": "first",
+			"MANGO": "middle",
+		}
+		content := initsystem.Systemd{}.ServiceEnvironmentContent(env)
+		require.Equal(t, "[Service]\nEnvironment=ALPHA=first\nEnvironment=MANGO=middle\nEnvironment=ZEBRA=last\n", content)
+	})
+
+	t.Run("values with spaces are quoted", func(t *testing.T) {
+		env := map[string]string{"KEY": "hello world"}
+		content := initsystem.Systemd{}.ServiceEnvironmentContent(env)
+		require.Equal(t, "[Service]\nEnvironment='KEY=hello world'\n", content)
+	})
+}
+
+func TestOpenRCServiceEnvironmentPath(t *testing.T) {
+	got, err := initsystem.OpenRC{}.ServiceEnvironmentPath(context.Background(), rigtest.NewMockRunner(), "mysvc")
+	require.NoError(t, err)
+	require.Equal(t, "/etc/conf.d/mysvc", got)
+}
+
+func TestOpenRCServiceEnvironmentContent(t *testing.T) {
+	env := map[string]string{
+		"ZEBRA": "last",
+		"ALPHA": "first",
+		"MANGO": "middle",
+	}
+	content := initsystem.OpenRC{}.ServiceEnvironmentContent(env)
+	require.Equal(t, "export ALPHA=first\nexport MANGO=middle\nexport ZEBRA=last\n", content)
+}

--- a/initsystem/env_test.go
+++ b/initsystem/env_test.go
@@ -10,13 +10,7 @@ import (
 )
 
 func TestSystemdServiceEnvironmentPath(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.AddCommandOutput(
-		rigtest.Equal(`systemctl show -p FragmentPath mysvc.service | cut '-d"="' -f2`),
-		"/etc/systemd/system/mysvc.service\n",
-	)
-
-	got, err := initsystem.Systemd{}.ServiceEnvironmentPath(context.Background(), mr, "mysvc")
+	got, err := initsystem.Systemd{}.ServiceEnvironmentPath(context.Background(), rigtest.NewMockRunner(), "mysvc")
 	require.NoError(t, err)
 	require.Equal(t, "/etc/systemd/system/mysvc.service.d/env.conf", got)
 }
@@ -46,11 +40,19 @@ func TestOpenRCServiceEnvironmentPath(t *testing.T) {
 }
 
 func TestOpenRCServiceEnvironmentContent(t *testing.T) {
-	env := map[string]string{
-		"ZEBRA": "last",
-		"ALPHA": "first",
-		"MANGO": "middle",
-	}
-	content := initsystem.OpenRC{}.ServiceEnvironmentContent(env)
-	require.Equal(t, "export ALPHA=first\nexport MANGO=middle\nexport ZEBRA=last\n", content)
+	t.Run("keys are sorted", func(t *testing.T) {
+		env := map[string]string{
+			"ZEBRA": "last",
+			"ALPHA": "first",
+			"MANGO": "middle",
+		}
+		content := initsystem.OpenRC{}.ServiceEnvironmentContent(env)
+		require.Equal(t, "export ALPHA=first\nexport MANGO=middle\nexport ZEBRA=last\n", content)
+	})
+
+	t.Run("values with spaces are quoted", func(t *testing.T) {
+		env := map[string]string{"KEY": "hello world"}
+		content := initsystem.OpenRC{}.ServiceEnvironmentContent(env)
+		require.Equal(t, "export 'KEY=hello world'\n", content)
+	})
 }

--- a/initsystem/openrc.go
+++ b/initsystem/openrc.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/k0sproject/rig/v2/cmd"
 	"github.com/k0sproject/rig/v2/sh"
+	"github.com/k0sproject/rig/v2/sh/shellescape"
 )
 
 // OpenRC is found on some linux systems, often installed on Alpine for example.
@@ -88,7 +89,9 @@ func (i OpenRC) ServiceEnvironmentContent(env map[string]string) string {
 	var b strings.Builder
 	b.Grow(len(env) * 24)
 	for _, k := range keys {
-		_, _ = fmt.Fprintf(&b, "export %s=%s\n", k, env[k])
+		b.WriteString("export ")
+		b.WriteString(shellescape.Quote(k + "=" + env[k]))
+		b.WriteByte('\n')
 	}
 	return b.String()
 }

--- a/initsystem/openrc.go
+++ b/initsystem/openrc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/k0sproject/rig/v2/cmd"
@@ -78,12 +79,17 @@ func (i OpenRC) ServiceEnvironmentPath(_ context.Context, _ cmd.ContextRunner, s
 
 // ServiceEnvironmentContent returns a formatted string for a service environment override file.
 func (i OpenRC) ServiceEnvironmentContent(env map[string]string) string {
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	var b strings.Builder
 	b.Grow(len(env) * 24)
-	for k, v := range env {
-		_, _ = fmt.Fprintf(&b, "export %s=%s\n", k, v)
+	for _, k := range keys {
+		_, _ = fmt.Fprintf(&b, "export %s=%s\n", k, env[k])
 	}
-
 	return b.String()
 }
 

--- a/initsystem/systemd.go
+++ b/initsystem/systemd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -88,20 +89,25 @@ func (i Systemd) ServiceEnvironmentPath(ctx context.Context, h cmd.ContextRunner
 		return "", err
 	}
 	dn := path.Dir(sp)
-	return path.Join(dn, s+"service.d", "env.conf"), nil
+	return path.Join(dn, s+".service.d", "env.conf"), nil
 }
 
 // ServiceEnvironmentContent returns a formatted string for a service environment override file.
 func (i Systemd) ServiceEnvironmentContent(env map[string]string) string {
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	var b strings.Builder
 	b.Grow(10 + (len(env) * 30))
 	b.WriteString("[Service]\n")
-	for k, v := range env {
+	for _, k := range keys {
 		b.WriteString("Environment=")
-		b.WriteString(shellescape.Quote(k + "=" + v))
+		b.WriteString(shellescape.Quote(k + "=" + env[k]))
 		b.WriteByte('\n')
 	}
-
 	return b.String()
 }
 

--- a/initsystem/systemd.go
+++ b/initsystem/systemd.go
@@ -3,7 +3,6 @@ package initsystem
 import (
 	"context"
 	"fmt"
-	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -82,14 +81,11 @@ func (i Systemd) ServiceScriptPath(ctx context.Context, h cmd.ContextRunner, s s
 	return strings.TrimSpace(out), nil
 }
 
-// ServiceEnvironmentPath returns a path to an environment override file path.
-func (i Systemd) ServiceEnvironmentPath(ctx context.Context, h cmd.ContextRunner, s string) (string, error) {
-	sp, err := i.ServiceScriptPath(ctx, h, s)
-	if err != nil {
-		return "", err
-	}
-	dn := path.Dir(sp)
-	return path.Join(dn, s+".service.d", "env.conf"), nil
+// ServiceEnvironmentPath returns the drop-in environment override path for the service.
+// Drop-ins always go under /etc/systemd/system/ regardless of where the unit file is
+// installed, so that overrides survive package updates and are always writable.
+func (i Systemd) ServiceEnvironmentPath(_ context.Context, _ cmd.ContextRunner, s string) (string, error) {
+	return "/etc/systemd/system/" + s + ".service.d/env.conf", nil
 }
 
 // ServiceEnvironmentContent returns a formatted string for a service environment override file.

--- a/service.go
+++ b/service.go
@@ -117,11 +117,11 @@ func (m *Service) Disable(ctx context.Context) error {
 
 // ScriptPath returns the path to the service script.
 func (m *Service) ScriptPath(ctx context.Context) (string, error) {
-	path, err := m.initsys.ServiceScriptPath(ctx, m.runner, m.name)
+	scriptPath, err := m.initsys.ServiceScriptPath(ctx, m.runner, m.name)
 	if err != nil {
 		return "", fmt.Errorf("failed to get service script path: %w", err)
 	}
-	return path, nil
+	return scriptPath, nil
 }
 
 // IsRunning returns true if the service is running.
@@ -169,7 +169,7 @@ func (m *Service) SetEnvironment(ctx context.Context, env map[string]string) err
 		return fmt.Errorf("create environment directory for service '%s': %w", m.name, err)
 	}
 	content := envManager.ServiceEnvironmentContent(env)
-	if err := m.fs.WriteFile(envPath, []byte(content), 0o644); err != nil {
+	if err := m.fs.WriteFile(envPath, []byte(content), 0o600); err != nil {
 		return fmt.Errorf("write environment file for service '%s': %w", m.name, err)
 	}
 	if reloader, ok := m.initsys.(initsystem.ServiceManagerReloader); ok {

--- a/service.go
+++ b/service.go
@@ -4,10 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
+	"path"
 
 	"github.com/k0sproject/rig/v2/cmd"
 	"github.com/k0sproject/rig/v2/initsystem"
 )
+
+// serviceFS is the subset of remotefs.FS that Service uses for SetEnvironment.
+type serviceFS interface {
+	MkdirAll(path string, perm fs.FileMode) error
+	WriteFile(path string, data []byte, perm fs.FileMode) error
+}
 
 type serviceState int
 
@@ -23,6 +31,7 @@ type Service struct {
 	runner  cmd.ContextRunner
 	name    string
 	initsys initsystem.ServiceManager
+	fs      serviceFS
 }
 
 // Name returns the name of the service.
@@ -120,7 +129,12 @@ func (m *Service) IsRunning(ctx context.Context) bool {
 	return m.initsys.ServiceIsRunning(ctx, m.runner, m.name)
 }
 
-var errLogReaderNotSupported = errors.New("init system provider does not implement log reader")
+var (
+	errLogReaderNotSupported    = errors.New("init system provider does not implement log reader")
+	errEnvManagerNotSupported   = errors.New("init system provider does not support service environment management")
+	errDaemonReloadNotSupported = errors.New("init system provider does not support daemon-reload")
+	errServiceFSNotAvailable    = errors.New("service has no filesystem access; use client.Service() instead of GetService()")
+)
 
 // Logs returns latest log lines for the service.
 func (m *Service) Logs(ctx context.Context, lines int) ([]string, error) {
@@ -134,6 +148,49 @@ func (m *Service) Logs(ctx context.Context, lines int) ([]string, error) {
 		return nil, fmt.Errorf("get logs: %w", err)
 	}
 	return rows, nil
+}
+
+// SetEnvironment writes environment variable overrides for the service and triggers a daemon-reload
+// if the init system requires it (e.g. systemd). The init system determines the file path and format;
+// any existing content is replaced.
+func (m *Service) SetEnvironment(ctx context.Context, env map[string]string) error {
+	envManager, ok := m.initsys.(initsystem.ServiceEnvironmentManager)
+	if !ok {
+		return errEnvManagerNotSupported
+	}
+	if m.fs == nil {
+		return errServiceFSNotAvailable
+	}
+	envPath, err := envManager.ServiceEnvironmentPath(ctx, m.runner, m.name)
+	if err != nil {
+		return fmt.Errorf("get environment path for service '%s': %w", m.name, err)
+	}
+	if err := m.fs.MkdirAll(path.Dir(envPath), 0o755); err != nil {
+		return fmt.Errorf("create environment directory for service '%s': %w", m.name, err)
+	}
+	content := envManager.ServiceEnvironmentContent(env)
+	if err := m.fs.WriteFile(envPath, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("write environment file for service '%s': %w", m.name, err)
+	}
+	if reloader, ok := m.initsys.(initsystem.ServiceManagerReloader); ok {
+		if err := reloader.DaemonReload(ctx, m.runner); err != nil {
+			return fmt.Errorf("daemon-reload after setting environment for service '%s': %w", m.name, err)
+		}
+	}
+	return nil
+}
+
+// DaemonReload triggers a daemon-reload on the init system, if supported. This is useful after
+// manually writing service unit files outside of rig. Enable and Disable call this automatically.
+func (m *Service) DaemonReload(ctx context.Context) error {
+	reloader, ok := m.initsys.(initsystem.ServiceManagerReloader)
+	if !ok {
+		return errDaemonReloadNotSupported
+	}
+	if err := reloader.DaemonReload(ctx, m.runner); err != nil {
+		return fmt.Errorf("daemon-reload: %w", err)
+	}
+	return nil
 }
 
 // GetService returns a manager for a single service using an auto-detected service manager implementation from the default providers.

--- a/service_test.go
+++ b/service_test.go
@@ -1,0 +1,202 @@
+package rig
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/cmd"
+	"github.com/k0sproject/rig/v2/initsystem"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+// mockEnvManager is a ServiceManager that also implements ServiceEnvironmentManager.
+type mockEnvManager struct {
+	envPath    string
+	envContent string
+}
+
+func (m *mockEnvManager) StartService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockEnvManager) StopService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockEnvManager) ServiceScriptPath(_ context.Context, _ cmd.ContextRunner, _ string) (string, error) {
+	return "", nil
+}
+
+func (m *mockEnvManager) EnableService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockEnvManager) DisableService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockEnvManager) ServiceIsRunning(_ context.Context, _ cmd.ContextRunner, _ string) bool {
+	return false
+}
+
+func (m *mockEnvManager) ServiceEnvironmentPath(_ context.Context, _ cmd.ContextRunner, _ string) (string, error) {
+	return m.envPath, nil
+}
+
+func (m *mockEnvManager) ServiceEnvironmentContent(env map[string]string) string {
+	return m.envContent
+}
+
+// mockReloadEnvManager adds DaemonReload support to mockEnvManager.
+type mockReloadEnvManager struct {
+	mockEnvManager
+	reloaded bool
+}
+
+func (m *mockReloadEnvManager) DaemonReload(_ context.Context, _ cmd.ContextRunner) error {
+	m.reloaded = true
+	return nil
+}
+
+// mockBasicManager is a ServiceManager without env or reload support.
+type mockBasicManager struct{}
+
+func (m *mockBasicManager) StartService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockBasicManager) StopService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockBasicManager) ServiceScriptPath(_ context.Context, _ cmd.ContextRunner, _ string) (string, error) {
+	return "", nil
+}
+
+func (m *mockBasicManager) EnableService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockBasicManager) DisableService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockBasicManager) ServiceIsRunning(_ context.Context, _ cmd.ContextRunner, _ string) bool {
+	return false
+}
+
+// mockFS captures WriteFile and MkdirAll calls.
+type mockFS struct {
+	mkdirAllPath string
+	writtenPath  string
+	writtenData  []byte
+}
+
+func (f *mockFS) MkdirAll(path string, _ fs.FileMode) error {
+	f.mkdirAllPath = path
+	return nil
+}
+
+func (f *mockFS) WriteFile(path string, data []byte, _ fs.FileMode) error {
+	f.writtenPath = path
+	f.writtenData = data
+	return nil
+}
+
+func TestServiceSetEnvironment(t *testing.T) {
+	ctx := context.Background()
+	env := map[string]string{"FOO": "bar"}
+
+	t.Run("with reloader", func(t *testing.T) {
+		mgr := &mockReloadEnvManager{
+			mockEnvManager: mockEnvManager{
+				envPath:    "/etc/systemd/system/mysvc.service.d/env.conf",
+				envContent: "[Service]\nEnvironment='FOO=bar'\n",
+			},
+		}
+		mfs := &mockFS{}
+		svc := &Service{
+			runner:  rigtest.NewMockRunner(),
+			name:    "mysvc",
+			initsys: mgr,
+			fs:      mfs,
+		}
+
+		require.NoError(t, svc.SetEnvironment(ctx, env))
+		require.Equal(t, "/etc/systemd/system/mysvc.service.d", mfs.mkdirAllPath)
+		require.Equal(t, "/etc/systemd/system/mysvc.service.d/env.conf", mfs.writtenPath)
+		require.Equal(t, mgr.envContent, string(mfs.writtenData))
+		require.True(t, mgr.reloaded)
+	})
+
+	t.Run("without reloader", func(t *testing.T) {
+		mgr := &mockEnvManager{
+			envPath:    "/etc/conf.d/mysvc",
+			envContent: "export FOO=bar\n",
+		}
+		mfs := &mockFS{}
+		svc := &Service{
+			runner:  rigtest.NewMockRunner(),
+			name:    "mysvc",
+			initsys: mgr,
+			fs:      mfs,
+		}
+
+		require.NoError(t, svc.SetEnvironment(ctx, env))
+		require.Equal(t, "/etc/conf.d", mfs.mkdirAllPath)
+		require.Equal(t, "/etc/conf.d/mysvc", mfs.writtenPath)
+	})
+
+	t.Run("env manager not supported", func(t *testing.T) {
+		svc := &Service{
+			runner:  rigtest.NewMockRunner(),
+			name:    "mysvc",
+			initsys: &mockBasicManager{},
+			fs:      &mockFS{},
+		}
+		err := svc.SetEnvironment(ctx, env)
+		require.ErrorIs(t, err, errEnvManagerNotSupported)
+	})
+
+	t.Run("fs not available", func(t *testing.T) {
+		svc := &Service{
+			runner:  rigtest.NewMockRunner(),
+			name:    "mysvc",
+			initsys: &mockEnvManager{envPath: "/etc/conf.d/mysvc"},
+		}
+		err := svc.SetEnvironment(ctx, env)
+		require.ErrorIs(t, err, errServiceFSNotAvailable)
+	})
+}
+
+func TestServiceDaemonReload(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("supported", func(t *testing.T) {
+		mgr := &mockReloadEnvManager{}
+		svc := &Service{
+			runner:  rigtest.NewMockRunner(),
+			name:    "mysvc",
+			initsys: mgr,
+		}
+		require.NoError(t, svc.DaemonReload(ctx))
+		require.True(t, mgr.reloaded)
+	})
+
+	t.Run("not supported", func(t *testing.T) {
+		svc := &Service{
+			runner:  rigtest.NewMockRunner(),
+			name:    "mysvc",
+			initsys: &mockBasicManager{},
+		}
+		err := svc.DaemonReload(ctx)
+		require.ErrorIs(t, err, errDaemonReloadNotSupported)
+	})
+}
+
+// Ensure initsystem.ServiceEnvironmentManager is satisfied by types implementing it.
+var _ initsystem.ServiceEnvironmentManager = (*mockEnvManager)(nil)
+var _ initsystem.ServiceManagerReloader = (*mockReloadEnvManager)(nil)
+var _ initsystem.ServiceManager = (*mockBasicManager)(nil)


### PR DESCRIPTION
Expose service environment management and explicit daemon-reload on rig.Service, wiring up the existing initsystem.ServiceEnvironmentManager and ServiceManagerReloader interfaces.

SetEnvironment writes env variable overrides to the init system's path and creates parent directories as needed, then triggers daemon-reload when required.

DaemonReload is an explicit public call for callers that write unit files outside of rig. 

A narrow serviceFS interface (MkdirAll + WriteFile) avoids coupling Service to the full remotefs.FS

Part of the rig v2 last-mile effort. Breaking API is not a concern as rig v2 is not in use yet.
