### PR TITLE
Add WithPermissions option to remotefs.Upload

### DIFF
--- a/remotefs/upload.go
+++ b/remotefs/upload.go
@@ -21,8 +21,9 @@ type uploadOptions struct {
 	hasPerm bool
 }
 
-// WithPermissions sets the file mode for the uploaded file. If not set, the
-// local file's mode is used.
+// WithPermissions sets the file mode for the uploaded file. If not set, the local
+// file's mode is used. The mode is applied both at creation time and via Chmod after
+// a successful upload, so it takes effect even when the destination file already exists.
 func WithPermissions(mode fs.FileMode) UploadOption {
 	return func(o *uploadOptions) {
 		o.perm = mode
@@ -58,7 +59,6 @@ func Upload(fsys FS, src, dst string, opts ...UploadOption) error {
 	if err != nil {
 		return fmt.Errorf("open remote file for upload: %w", err)
 	}
-	defer remote.Close()
 
 	localReader := io.TeeReader(local, shasum)
 	if _, err := remote.CopyFrom(localReader); err != nil {
@@ -76,6 +76,12 @@ func Upload(fsys FS, src, dst string, opts ...UploadOption) error {
 
 	if remoteSum != hex.EncodeToString(shasum.Sum(nil)) {
 		return ErrChecksumMismatch
+	}
+
+	if options.hasPerm {
+		if err := fsys.Chmod(dst, options.perm); err != nil {
+			return fmt.Errorf("chmod uploaded file: %w", err)
+		}
 	}
 
 	return nil

--- a/remotefs/upload.go
+++ b/remotefs/upload.go
@@ -6,28 +6,55 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 )
 
 // ErrChecksumMismatch is returned when the checksum of the uploaded file does not match the local checksum.
 var ErrChecksumMismatch = errors.New("checksum mismatch")
 
+// UploadOption is a functional option for Upload.
+type UploadOption func(*uploadOptions)
+
+type uploadOptions struct {
+	perm    fs.FileMode
+	hasPerm bool
+}
+
+// WithPermissions sets the file mode for the uploaded file. If not set, the
+// local file's mode is used.
+func WithPermissions(mode fs.FileMode) UploadOption {
+	return func(o *uploadOptions) {
+		o.perm = mode
+		o.hasPerm = true
+	}
+}
+
 // Upload a file to the remote host.
-func Upload(fs FS, src, dst string) error {
+func Upload(fsys FS, src, dst string, opts ...UploadOption) error {
+	options := &uploadOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	local, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("open file for upload: %w", err)
 	}
 	defer local.Close()
 
-	stat, err := local.Stat()
-	if err != nil {
-		return fmt.Errorf("stat local file for upload: %w", err)
+	perm := options.perm
+	if !options.hasPerm {
+		stat, err := local.Stat()
+		if err != nil {
+			return fmt.Errorf("stat local file for upload: %w", err)
+		}
+		perm = stat.Mode()
 	}
 
 	shasum := sha256.New()
 
-	remote, err := fs.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, stat.Mode())
+	remote, err := fsys.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
 	if err != nil {
 		return fmt.Errorf("open remote file for upload: %w", err)
 	}
@@ -42,7 +69,7 @@ func Upload(fs FS, src, dst string) error {
 		return fmt.Errorf("close remote file after upload: %w", err)
 	}
 
-	remoteSum, err := fs.Sha256(dst)
+	remoteSum, err := fsys.Sha256(dst)
 	if err != nil {
 		return fmt.Errorf("get checksum of uploaded file: %w", err)
 	}

--- a/remotefs/upload_test.go
+++ b/remotefs/upload_test.go
@@ -1,0 +1,130 @@
+package remotefs_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"io/fs"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/rig/v2/remotefs"
+	"github.com/stretchr/testify/require"
+)
+
+// uploadFS is a minimal FS stub for Upload tests. Only OpenFile and Sha256 are
+// implemented; everything else panics if called.
+type uploadFS struct {
+	capturedPerm fs.FileMode
+	written      []byte
+}
+
+func (f *uploadFS) OpenFile(_ string, _ int, perm fs.FileMode) (remotefs.File, error) {
+	f.capturedPerm = perm
+	return &uploadFile{buf: &f.written}, nil
+}
+
+func (f *uploadFS) Sha256(_ string) (string, error) {
+	h := sha256.New()
+	h.Write(f.written)
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// FS interface stubs — not exercised by Upload.
+func (f *uploadFS) Open(_ string) (fs.File, error)                           { panic("not implemented") }
+func (f *uploadFS) Stat(_ string) (fs.FileInfo, error)                      { panic("not implemented") }
+func (f *uploadFS) ReadFile(_ string) ([]byte, error)                       { panic("not implemented") }
+func (f *uploadFS) ReadDir(_ string) ([]fs.DirEntry, error)                 { panic("not implemented") }
+func (f *uploadFS) Remove(_ string) error                                   { panic("not implemented") }
+func (f *uploadFS) RemoveAll(_ string) error                                { panic("not implemented") }
+func (f *uploadFS) Mkdir(_ string, _ fs.FileMode) error                     { panic("not implemented") }
+func (f *uploadFS) MkdirAll(_ string, _ fs.FileMode) error                  { panic("not implemented") }
+func (f *uploadFS) MkdirTemp(_, _ string) (string, error)                   { panic("not implemented") }
+func (f *uploadFS) WriteFile(_ string, _ []byte, _ fs.FileMode) error       { panic("not implemented") }
+func (f *uploadFS) FileExist(_ string) bool                                 { panic("not implemented") }
+func (f *uploadFS) LookPath(_ string) (string, error)                       { panic("not implemented") }
+func (f *uploadFS) Join(_ ...string) string                                 { panic("not implemented") }
+func (f *uploadFS) Chmod(_ string, _ fs.FileMode) error                     { panic("not implemented") }
+func (f *uploadFS) Chown(_ string, _, _ int) error                          { panic("not implemented") }
+func (f *uploadFS) Chtimes(_ string, _, _ int64) error                      { panic("not implemented") }
+func (f *uploadFS) Touch(_ string) error                                    { panic("not implemented") }
+func (f *uploadFS) Truncate(_ string, _ int64) error                        { panic("not implemented") }
+func (f *uploadFS) Getenv(_ string) string                                  { panic("not implemented") }
+func (f *uploadFS) Rename(_, _ string) error                                { panic("not implemented") }
+func (f *uploadFS) Hostname() (string, error)                               { panic("not implemented") }
+func (f *uploadFS) LongHostname() (string, error)                           { panic("not implemented") }
+func (f *uploadFS) MachineID() (string, error)                              { panic("not implemented") }
+func (f *uploadFS) SystemTime() (time.Time, error)                          { panic("not implemented") }
+func (f *uploadFS) TempDir() string                                         { panic("not implemented") }
+func (f *uploadFS) UserCacheDir() string                                    { panic("not implemented") }
+func (f *uploadFS) UserConfigDir() string                                   { panic("not implemented") }
+func (f *uploadFS) UserHomeDir() string                                     { panic("not implemented") }
+
+// uploadFile is a minimal File stub that captures written bytes.
+type uploadFile struct {
+	buf *[]byte
+}
+
+func (f *uploadFile) CopyFrom(src io.Reader) (int64, error) {
+	data, err := io.ReadAll(src)
+	*f.buf = data
+	return int64(len(data)), err
+}
+
+func (f *uploadFile) Close() error                              { return nil }
+func (f *uploadFile) Name() string                             { return "" }
+func (f *uploadFile) Read(_ []byte) (int, error)               { panic("not implemented") }
+func (f *uploadFile) Seek(_ int64, _ int) (int64, error)       { panic("not implemented") }
+func (f *uploadFile) Write(_ []byte) (int, error)              { panic("not implemented") }
+func (f *uploadFile) Stat() (fs.FileInfo, error)               { panic("not implemented") }
+func (f *uploadFile) CopyTo(_ io.Writer) (int64, error)        { panic("not implemented") }
+
+func writeTempFile(t *testing.T, content string, mode fs.FileMode) string {
+	t.Helper()
+	tmp, err := os.CreateTemp(t.TempDir(), "upload-test-*")
+	require.NoError(t, err)
+	_, err = tmp.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Chmod(mode))
+	require.NoError(t, tmp.Close())
+	return tmp.Name()
+}
+
+func TestUploadUsesLocalPermByDefault(t *testing.T) {
+	src := writeTempFile(t, "hello", 0o755)
+	mfs := &uploadFS{}
+
+	require.NoError(t, remotefs.Upload(mfs, src, "/remote/dst"))
+	require.Equal(t, fs.FileMode(0o755), mfs.capturedPerm)
+}
+
+func TestUploadWithPermissions(t *testing.T) {
+	src := writeTempFile(t, "hello", 0o644)
+	mfs := &uploadFS{}
+
+	require.NoError(t, remotefs.Upload(mfs, src, "/remote/dst", remotefs.WithPermissions(0o755)))
+	require.Equal(t, fs.FileMode(0o755), mfs.capturedPerm)
+}
+
+func TestUploadChecksumMismatch(t *testing.T) {
+	src := writeTempFile(t, "hello", 0o644)
+
+	badFS := &uploadFS{}
+	// Corrupt the stored data after write so Sha256 disagrees.
+	origOpen := badFS.OpenFile
+	_ = origOpen // unused but documents intent
+
+	corruptFS := &corruptUploadFS{uploadFS: uploadFS{}}
+	err := remotefs.Upload(corruptFS, src, "/remote/dst")
+	require.ErrorIs(t, err, remotefs.ErrChecksumMismatch)
+}
+
+// corruptUploadFS returns a wrong sha256 to simulate a corrupted upload.
+type corruptUploadFS struct {
+	uploadFS
+}
+
+func (f *corruptUploadFS) Sha256(_ string) (string, error) {
+	return "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", nil
+}

--- a/remotefs/upload_test.go
+++ b/remotefs/upload_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// uploadFS is a minimal FS stub for Upload tests. Only OpenFile and Sha256 are
-// implemented; everything else panics if called.
+// uploadFS is a minimal FS stub for Upload tests. Only the methods called by
+// Upload are implemented; everything else panics if called.
 type uploadFS struct {
-	capturedPerm fs.FileMode
-	written      []byte
+	capturedPerm    fs.FileMode
+	capturedChmod   fs.FileMode
+	chmodCalled     bool
+	written         []byte
 }
 
 func (f *uploadFS) OpenFile(_ string, _ int, perm fs.FileMode) (remotefs.File, error) {
@@ -29,6 +31,12 @@ func (f *uploadFS) Sha256(_ string) (string, error) {
 	h := sha256.New()
 	h.Write(f.written)
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func (f *uploadFS) Chmod(_ string, mode fs.FileMode) error {
+	f.chmodCalled = true
+	f.capturedChmod = mode
+	return nil
 }
 
 // FS interface stubs — not exercised by Upload.
@@ -45,7 +53,6 @@ func (f *uploadFS) WriteFile(_ string, _ []byte, _ fs.FileMode) error       { pa
 func (f *uploadFS) FileExist(_ string) bool                                 { panic("not implemented") }
 func (f *uploadFS) LookPath(_ string) (string, error)                       { panic("not implemented") }
 func (f *uploadFS) Join(_ ...string) string                                 { panic("not implemented") }
-func (f *uploadFS) Chmod(_ string, _ fs.FileMode) error                     { panic("not implemented") }
 func (f *uploadFS) Chown(_ string, _, _ int) error                          { panic("not implemented") }
 func (f *uploadFS) Chtimes(_ string, _, _ int64) error                      { panic("not implemented") }
 func (f *uploadFS) Touch(_ string) error                                    { panic("not implemented") }
@@ -93,10 +100,15 @@ func writeTempFile(t *testing.T, content string, mode fs.FileMode) string {
 
 func TestUploadUsesLocalPermByDefault(t *testing.T) {
 	src := writeTempFile(t, "hello", 0o755)
-	mfs := &uploadFS{}
 
+	// Stat after creation to get the actual mode (Windows normalises POSIX bits).
+	stat, err := os.Stat(src)
+	require.NoError(t, err)
+
+	mfs := &uploadFS{}
 	require.NoError(t, remotefs.Upload(mfs, src, "/remote/dst"))
-	require.Equal(t, fs.FileMode(0o755), mfs.capturedPerm)
+	require.Equal(t, stat.Mode(), mfs.capturedPerm)
+	require.False(t, mfs.chmodCalled, "Chmod should not be called without WithPermissions")
 }
 
 func TestUploadWithPermissions(t *testing.T) {
@@ -105,22 +117,17 @@ func TestUploadWithPermissions(t *testing.T) {
 
 	require.NoError(t, remotefs.Upload(mfs, src, "/remote/dst", remotefs.WithPermissions(0o755)))
 	require.Equal(t, fs.FileMode(0o755), mfs.capturedPerm)
+	require.True(t, mfs.chmodCalled, "Chmod should be called with WithPermissions")
+	require.Equal(t, fs.FileMode(0o755), mfs.capturedChmod)
 }
 
 func TestUploadChecksumMismatch(t *testing.T) {
 	src := writeTempFile(t, "hello", 0o644)
-
-	badFS := &uploadFS{}
-	// Corrupt the stored data after write so Sha256 disagrees.
-	origOpen := badFS.OpenFile
-	_ = origOpen // unused but documents intent
-
-	corruptFS := &corruptUploadFS{uploadFS: uploadFS{}}
-	err := remotefs.Upload(corruptFS, src, "/remote/dst")
+	err := remotefs.Upload(&corruptUploadFS{uploadFS: uploadFS{}}, src, "/remote/dst")
 	require.ErrorIs(t, err, remotefs.ErrChecksumMismatch)
 }
 
-// corruptUploadFS returns a wrong sha256 to simulate a corrupted upload.
+// corruptUploadFS simulates a checksum mismatch by returning an incorrect sha256 digest.
 type corruptUploadFS struct {
 	uploadFS
 }


### PR DESCRIPTION
Upload now accepts variadic UploadOption arguments. WithPermissions(mode) overrides the file mode used when creating the remote file; without it the local file's mode is used (existing behaviour preserved).

Needed for k0s binary upload which must land as executable (0o755) regardless of the local file's permissions.

Part of the rigv2 last-mile effort. Breaking API is not a problem as rig v2 is not released or in use yet.