### PR TITLE
Add Dir, Base, CommandExist to remotefs.OS interface

### DIFF
--- a/remotefs/hostinfo_test.go
+++ b/remotefs/hostinfo_test.go
@@ -326,3 +326,94 @@ func TestWindowsIsContainer(t *testing.T) {
 	require.ErrorIs(t, err, remotefs.ErrNotSupported)
 	require.False(t, ok)
 }
+
+func TestPosixDir(t *testing.T) {
+	f := remotefs.NewPosixFS(rigtest.NewMockRunner())
+	require.Equal(t, "/foo/bar", f.Dir("/foo/bar/baz"))
+	require.Equal(t, "/foo", f.Dir("/foo/bar"))
+	require.Equal(t, "/", f.Dir("/foo"))
+	require.Equal(t, ".", f.Dir("foo"))
+	require.Equal(t, ".", f.Dir(""))
+}
+
+func TestPosixBase(t *testing.T) {
+	f := remotefs.NewPosixFS(rigtest.NewMockRunner())
+	require.Equal(t, "baz", f.Base("/foo/bar/baz"))
+	require.Equal(t, "bar", f.Base("/foo/bar"))
+	require.Equal(t, "foo", f.Base("/foo"))
+	require.Equal(t, "foo", f.Base("foo"))
+}
+
+func TestPosixCommandExist(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
+		f := remotefs.NewPosixFS(mr)
+		require.True(t, f.CommandExist("curl"))
+	})
+	t.Run("not found", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Equal("command -v curl"), errors.New("not found"))
+		f := remotefs.NewPosixFS(mr)
+		require.False(t, f.CommandExist("curl"))
+	})
+}
+
+func TestWindowsDir(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.Windows = true
+	f := remotefs.NewWindowsFS(mr)
+	require.Equal(t, `C:\foo\bar`, f.Dir(`C:\foo\bar\baz`))
+	require.Equal(t, `C:\foo`, f.Dir(`C:\foo\bar`))
+	require.Equal(t, `C:\`, f.Dir(`C:\foo`))
+	require.Equal(t, `C:\`, f.Dir(`C:\`))
+	require.Equal(t, ".", f.Dir("foo"))
+	require.Equal(t, ".", f.Dir(""))
+	require.Equal(t, `\`, f.Dir(`\`))
+	require.Equal(t, `/`, f.Dir(`/`))
+	// forward slashes preserved
+	require.Equal(t, "C:/foo", f.Dir("C:/foo/bar"))
+	require.Equal(t, "C:/", f.Dir("C:/foo"))
+	require.Equal(t, "C:/", f.Dir("C:/"))
+}
+
+func TestWindowsBase(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.Windows = true
+	f := remotefs.NewWindowsFS(mr)
+	require.Equal(t, "baz", f.Base(`C:\foo\bar\baz`))
+	require.Equal(t, "bar", f.Base(`C:\foo\bar`))
+	require.Equal(t, "foo", f.Base(`C:\foo`))
+	require.Equal(t, "foo", f.Base("foo"))
+	require.Equal(t, ".", f.Base(""))
+	require.Equal(t, `\`, f.Base(`\`))
+	require.Equal(t, `\`, f.Base(`\\`))
+	require.Equal(t, `/`, f.Base(`/`))
+	// drive roots
+	require.Equal(t, `C:\`, f.Base(`C:\`))
+	require.Equal(t, `C:/`, f.Base(`C:/`))
+}
+
+func TestWindowsCommandExist(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), `C:\Windows\System32\curl.exe`)
+		f := remotefs.NewWindowsFS(mr)
+		require.True(t, f.CommandExist("curl"))
+	})
+	t.Run("not found via error", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("not found"))
+		f := remotefs.NewWindowsFS(mr)
+		require.False(t, f.CommandExist("curl"))
+	})
+	t.Run("not found via empty output", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "")
+		f := remotefs.NewWindowsFS(mr)
+		require.False(t, f.CommandExist("curl"))
+	})
+}

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -686,6 +686,22 @@ func (s *PosixFS) Join(elem ...string) string {
 	return path.Join(elem...)
 }
 
+// Dir returns all but the last element of path, typically the path's directory.
+func (s *PosixFS) Dir(p string) string {
+	return path.Dir(p)
+}
+
+// Base returns the last element of path.
+func (s *PosixFS) Base(p string) string {
+	return path.Base(p)
+}
+
+// CommandExist reports whether the named command is available on the remote host.
+func (s *PosixFS) CommandExist(name string) bool {
+	_, err := s.LookPath(name)
+	return err == nil
+}
+
 // Getenv returns the value of the environment variable named by the key.
 func (s *PosixFS) Getenv(key string) string {
 	out, err := s.ExecOutput(fmt.Sprintf("echo ${%s}", key), cmd.HideOutput())

--- a/remotefs/types.go
+++ b/remotefs/types.go
@@ -60,6 +60,9 @@ type OS interface { //nolint:interfacebloat // intentionally large interface
 	UserCacheDir() string
 	UserConfigDir() string
 	UserHomeDir() string
+	Dir(path string) string
+	Base(path string) string
+	CommandExist(name string) bool
 }
 
 // Opener is a file opener interface, modeled after stdlib's OS package.

--- a/remotefs/upload_test.go
+++ b/remotefs/upload_test.go
@@ -70,6 +70,9 @@ func (f *uploadFS) TempDir() string                                         { pa
 func (f *uploadFS) UserCacheDir() string                                    { panic("not implemented") }
 func (f *uploadFS) UserConfigDir() string                                   { panic("not implemented") }
 func (f *uploadFS) UserHomeDir() string                                     { panic("not implemented") }
+func (f *uploadFS) Dir(_ string) string                                     { panic("not implemented") }
+func (f *uploadFS) Base(_ string) string                                    { panic("not implemented") }
+func (f *uploadFS) CommandExist(_ string) bool                              { panic("not implemented") }
 
 // uploadFile is a minimal File stub that captures written bytes.
 type uploadFile struct {

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -260,16 +260,85 @@ func (s *WinFS) FileExist(name string) bool {
 
 // LookPath checks if a command exists on the host.
 func (s *WinFS) LookPath(name string) (string, error) {
-	path, err := s.ExecOutput(fmt.Sprintf("Get-Command %s -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source", ps.DoubleQuotePath(name)), cmd.PS())
+	out, err := s.ExecOutput(fmt.Sprintf("Get-Command %s -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Source", ps.DoubleQuotePath(name)), cmd.PS())
 	if err != nil {
 		return "", fmt.Errorf("lookpath %s: %w", name, err)
 	}
-	return toSlashes(path), nil
+	for line := range strings.SplitSeq(out, "\n") {
+		if p := toSlashes(strings.TrimSpace(line)); p != "" {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("lookpath %s: %w", name, fs.ErrNotExist)
 }
 
 // Join joins any number of path elements into a single path, adding a separating slash if necessary.
 func (s *WinFS) Join(elem ...string) string {
 	return strings.Join(elem, "\\")
+}
+
+// winTrimPath strips trailing separators from p and identifies paths that have
+// no further components to split, returning them as a ready-to-return value.
+// Returns (trimmed, shortCircuit): when shortCircuit is non-empty the caller
+// should return it directly without further processing. shortCircuit is set for:
+//   - empty input ("") → "."
+//   - separator-only input ("\" or "/") → the leading separator character
+//   - bare drive root ("C:\") → the drive letter plus its separator ("C:\")
+func winTrimPath(p string) (trimmed, shortCircuit string) {
+	trimmed = strings.TrimRight(p, "/\\")
+	if trimmed == "" {
+		if p == "" {
+			return "", "."
+		}
+		return "", string(p[0]) // separator-only path is a root
+	}
+	// Bare drive letter after stripping a trailing separator ("C:" from "C:\") is a root.
+	if len(trimmed) == 2 && trimmed[1] == ':' && len(p) > len(trimmed) {
+		return "", trimmed + string(p[len(trimmed)]) // preserve the separator style
+	}
+	return trimmed, ""
+}
+
+// Dir returns all but the last element of path, typically the path's directory.
+// Both forward and backward slashes are recognised as separators.
+func (s *WinFS) Dir(path string) string {
+	trimmed, shortCircuit := winTrimPath(path)
+	if shortCircuit != "" {
+		return shortCircuit
+	}
+	idx := strings.LastIndexAny(trimmed, "/\\")
+	if idx < 0 {
+		return "."
+	}
+	dir := trimmed[:idx]
+	// "C:\foo" or "C:/foo" splits into dir="C:" — restore the root separator.
+	if len(dir) == 2 && dir[1] == ':' {
+		return dir + string(trimmed[idx])
+	}
+	if dir == "" {
+		return string(trimmed[idx])
+	}
+	return dir
+}
+
+// Base returns the last element of path.
+// Both forward and backward slashes are recognised as separators.
+func (s *WinFS) Base(path string) string {
+	trimmed, shortCircuit := winTrimPath(path)
+	if shortCircuit != "" {
+		return shortCircuit
+	}
+	idx := strings.LastIndexAny(trimmed, "/\\")
+	if idx < 0 {
+		return trimmed
+	}
+	return trimmed[idx+1:]
+}
+
+// CommandExist reports whether the named command is available on the remote host.
+func (s *WinFS) CommandExist(name string) bool {
+	_, err := s.LookPath(name)
+	return err == nil
 }
 
 // Touch creates a new file with the given name if it does not exist.


### PR DESCRIPTION
Dir and Base are OS-aware path splitting companions to the existing Join. PosixFS delegates to path.Dir/path.Base. WinFS provides a custom implementation handling both \ and / separators, including drive-root preservation (C:\ stays C:\).

CommandExist is a bool convenience wrapper around LookPath, avoiding error unwrapping at k0sctl call sites that only need a yes/no answer.

Part of the rig v2 final mile effort. Rig v2 is not released yet so breaking the API is not a problem.
