### PR TITLE
Add ChownInt, ChownTree, ChownTreeInt to remotefs.OS interface

### DIFF
--- a/remotefs/hostinfo_test.go
+++ b/remotefs/hostinfo_test.go
@@ -417,3 +417,57 @@ func TestWindowsCommandExist(t *testing.T) {
 		require.False(t, f.CommandExist("curl"))
 	})
 }
+
+func TestPosixChownInt(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandSuccess(rigtest.Contains("chown -- 1000:2000"))
+		f := remotefs.NewPosixFS(mr)
+		require.NoError(t, f.ChownInt("/tmp/file", 1000, 2000))
+	})
+	t.Run("not exist", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Contains("chown -- 1000:2000"), errors.New("No such file or directory"))
+		f := remotefs.NewPosixFS(mr)
+		require.ErrorIs(t, f.ChownInt("/tmp/file", 1000, 2000), fs.ErrNotExist)
+	})
+}
+
+func TestPosixChownTree(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandSuccess(rigtest.Contains("chown -R -- root:root"))
+		f := remotefs.NewPosixFS(mr)
+		require.NoError(t, f.ChownTree("/srv", "root:root"))
+	})
+	t.Run("not exist", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Contains("chown -R -- root:root"), errors.New("No such file or directory"))
+		f := remotefs.NewPosixFS(mr)
+		require.ErrorIs(t, f.ChownTree("/srv", "root:root"), fs.ErrNotExist)
+	})
+}
+
+func TestPosixChownTreeInt(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandSuccess(rigtest.Contains("chown -R -- 0:0"))
+		f := remotefs.NewPosixFS(mr)
+		require.NoError(t, f.ChownTreeInt("/srv", 0, 0))
+	})
+	t.Run("not exist", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Contains("chown -R -- 0:0"), errors.New("No such file or directory"))
+		f := remotefs.NewPosixFS(mr)
+		require.ErrorIs(t, f.ChownTreeInt("/srv", 0, 0), fs.ErrNotExist)
+	})
+}
+
+func TestWindowsChownVariantsNotSupported(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.Windows = true
+	f := remotefs.NewWindowsFS(mr)
+	require.ErrorIs(t, f.ChownInt("/tmp/file", 1000, 2000), remotefs.ErrNotSupported)
+	require.ErrorIs(t, f.ChownTree("/tmp", "root"), remotefs.ErrNotSupported)
+	require.ErrorIs(t, f.ChownTreeInt("/tmp", 0, 0), remotefs.ErrNotSupported)
+}

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -360,6 +360,42 @@ func (s *PosixFS) Chown(name string, owner string) error {
 	return nil
 }
 
+// ChownInt changes the ownership of the named file using numeric uid and gid.
+func (s *PosixFS) ChownInt(name string, uid, gid int) error {
+	owner := fmt.Sprintf("%d:%d", uid, gid)
+	if err := s.Exec(sh.Command("chown", "--", owner, name)); err != nil {
+		if isNotExist(err) {
+			return PathError("chown", name, fs.ErrNotExist)
+		}
+		return fmt.Errorf("chown %s: %w", name, err)
+	}
+	return nil
+}
+
+// ChownTree recursively changes the ownership of path and all its contents.
+// The owner parameter follows the standard chown format: "user", "user:group", or ":group".
+func (s *PosixFS) ChownTree(name string, owner string) error {
+	if err := s.Exec(sh.Command("chown", "-R", "--", owner, name)); err != nil {
+		if isNotExist(err) {
+			return PathError("chown -R", name, fs.ErrNotExist)
+		}
+		return fmt.Errorf("chown -R %s: %w", name, err)
+	}
+	return nil
+}
+
+// ChownTreeInt recursively changes the ownership of path and all its contents using numeric uid and gid.
+func (s *PosixFS) ChownTreeInt(name string, uid, gid int) error {
+	owner := fmt.Sprintf("%d:%d", uid, gid)
+	if err := s.Exec(sh.Command("chown", "-R", "--", owner, name)); err != nil {
+		if isNotExist(err) {
+			return PathError("chown -R", name, fs.ErrNotExist)
+		}
+		return fmt.Errorf("chown -R %s: %w", name, err)
+	}
+	return nil
+}
+
 // DownloadURL downloads the contents of url to dst. It prefers curl when available
 // and falls back to wget. Returns a descriptive error if neither is available.
 func (s *PosixFS) DownloadURL(url, dst string) error {

--- a/remotefs/types.go
+++ b/remotefs/types.go
@@ -44,6 +44,9 @@ type OS interface { //nolint:interfacebloat // intentionally large interface
 	Join(elem ...string) string
 	Chmod(path string, mode fs.FileMode) error
 	Chown(path string, owner string) error
+	ChownInt(path string, uid, gid int) error
+	ChownTree(path string, owner string) error
+	ChownTreeInt(path string, uid, gid int) error
 	Chtimes(path string, atime, mtime int64) error
 	Touch(path string, ts ...time.Time) error
 	Truncate(path string, size int64) error

--- a/remotefs/upload_test.go
+++ b/remotefs/upload_test.go
@@ -54,6 +54,9 @@ func (f *uploadFS) FileExist(_ string) bool                                 { pa
 func (f *uploadFS) LookPath(_ string) (string, error)                       { panic("not implemented") }
 func (f *uploadFS) Join(_ ...string) string                                 { panic("not implemented") }
 func (f *uploadFS) Chown(_ string, _ string) error                          { panic("not implemented") }
+func (f *uploadFS) ChownInt(_ string, _, _ int) error                       { panic("not implemented") }
+func (f *uploadFS) ChownTree(_ string, _ string) error                      { panic("not implemented") }
+func (f *uploadFS) ChownTreeInt(_ string, _, _ int) error                   { panic("not implemented") }
 func (f *uploadFS) Chtimes(_ string, _, _ int64) error                      { panic("not implemented") }
 func (f *uploadFS) Touch(_ string, _ ...time.Time) error                    { panic("not implemented") }
 func (f *uploadFS) Truncate(_ string, _ int64) error                        { panic("not implemented") }

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -381,9 +381,24 @@ func (s *WinFS) Chmod(name string, mode fs.FileMode) error {
 	return nil
 }
 
-// Chown changes the ownership of the named file. On windows it returns an error.
+// Chown changes the ownership of the named file. On Windows it returns an error.
 func (s *WinFS) Chown(name string, _ string) error {
 	return fmt.Errorf("chown %s: %w", name, ErrNotSupported)
+}
+
+// ChownInt changes the ownership using numeric uid and gid. On Windows it returns an error.
+func (s *WinFS) ChownInt(name string, _, _ int) error {
+	return fmt.Errorf("chown %s: %w", name, ErrNotSupported)
+}
+
+// ChownTree recursively changes the ownership. On Windows it returns an error.
+func (s *WinFS) ChownTree(name string, _ string) error {
+	return fmt.Errorf("chown -R %s: %w", name, ErrNotSupported)
+}
+
+// ChownTreeInt recursively changes the ownership using numeric uid and gid. On Windows it returns an error.
+func (s *WinFS) ChownTreeInt(name string, _, _ int) error {
+	return fmt.Errorf("chown -R %s: %w", name, ErrNotSupported)
 }
 
 // DownloadURL downloads the contents of url to dst using Invoke-WebRequest.


### PR DESCRIPTION
Numeric uid/gid variant (ChownInt) and recursive variants (ChownTree, ChownTreeInt) complement the existing string-based Chown. PosixFS implements all four via chown/chown -R. WinFS returns ErrNotSupported for all three new methods, consistent with Chown.

Part of the rig v2 final mile effort. Rig v2 is not released yet so breaking the API is not a problem.