### PR TITLE
Add CreateTemp(dir, prefix) to remotefs.OS interface

### DIFF
--- a/remotefs/hostinfo_test.go
+++ b/remotefs/hostinfo_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/rig/v2/powershell"
 	"github.com/k0sproject/rig/v2/remotefs"
 	"github.com/k0sproject/rig/v2/rigtest"
 	"github.com/stretchr/testify/require"
@@ -470,4 +471,39 @@ func TestWindowsChownVariantsNotSupported(t *testing.T) {
 	require.ErrorIs(t, f.ChownInt("/tmp/file", 1000, 2000), remotefs.ErrNotSupported)
 	require.ErrorIs(t, f.ChownTree("/tmp", "root"), remotefs.ErrNotSupported)
 	require.ErrorIs(t, f.ChownTreeInt("/tmp", 0, 0), remotefs.ErrNotSupported)
+}
+
+func TestPosixCreateTemp(t *testing.T) {
+	t.Run("with prefix", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.Equal("echo ${TMPDIR:-/tmp}"), "/tmp")
+		mr.AddCommandOutput(rigtest.Contains("mktemp"), "/tmp/rig-abc123")
+		f := remotefs.NewPosixFS(mr)
+		path, err := f.CreateTemp("", "rig-")
+		require.NoError(t, err)
+		require.Equal(t, "/tmp/rig-abc123", path)
+		require.NoError(t, mr.Received(rigtest.Contains("mktemp -- /tmp/rig-XXXXXX")))
+	})
+	t.Run("failure", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Contains("mktemp"), errors.New("permission denied"))
+		f := remotefs.NewPosixFS(mr)
+		_, err := f.CreateTemp("/srv", "rig-")
+		require.Error(t, err)
+	})
+}
+
+func TestWindowsCreateTemp(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		// Stub TempDir's TEMP lookup first (exact match), then the CreateTemp script (broad prefix).
+		// PS commands are base64-encoded so the exact match distinguishes the two calls.
+		mr.AddCommandOutput(rigtest.Equal(powershell.Cmd("[System.Environment]::GetEnvironmentVariable('TEMP')")), `C:\Windows\Temp`)
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), `C:\Windows\Temp\rig-abc123.tmp`)
+		f := remotefs.NewWindowsFS(mr)
+		path, err := f.CreateTemp("", "rig-")
+		require.NoError(t, err)
+		require.Equal(t, "C:/Windows/Temp/rig-abc123.tmp", path)
+	})
 }

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -696,9 +696,22 @@ func (s *PosixFS) MkdirTemp(dir, prefix string) (string, error) {
 	if dir == "" {
 		dir = s.TempDir()
 	}
-	out, err := s.ExecOutput(sh.Command("mktemp", "-d", s.Join(dir, prefix+"XXXXXX")))
+	out, err := s.ExecOutput(sh.Command("mktemp", "-d", "--", s.Join(dir, prefix+"XXXXXX")))
 	if err != nil {
 		return "", fmt.Errorf("mkdir temp %s: %w", dir, err)
+	}
+	return out, nil
+}
+
+// CreateTemp creates a new temporary file in the directory dir with a name beginning with prefix
+// and returns the path of the new file. If dir is empty, TempDir() is used.
+func (s *PosixFS) CreateTemp(dir, prefix string) (string, error) {
+	if dir == "" {
+		dir = s.TempDir()
+	}
+	out, err := s.ExecOutput(sh.Command("mktemp", "--", s.Join(dir, prefix+"XXXXXX")))
+	if err != nil {
+		return "", fmt.Errorf("create temp %s: %w", dir, err)
 	}
 	return out, nil
 }

--- a/remotefs/types.go
+++ b/remotefs/types.go
@@ -38,6 +38,7 @@ type OS interface { //nolint:interfacebloat // intentionally large interface
 	Mkdir(path string, perm fs.FileMode) error
 	MkdirAll(path string, perm fs.FileMode) error
 	MkdirTemp(dir, prefix string) (string, error)
+	CreateTemp(dir, prefix string) (string, error)
 	WriteFile(path string, data []byte, perm fs.FileMode) error
 	FileExist(path string) bool
 	LookPath(cmd string) (string, error)

--- a/remotefs/upload_test.go
+++ b/remotefs/upload_test.go
@@ -49,6 +49,7 @@ func (f *uploadFS) RemoveAll(_ string) error                                { pa
 func (f *uploadFS) Mkdir(_ string, _ fs.FileMode) error                     { panic("not implemented") }
 func (f *uploadFS) MkdirAll(_ string, _ fs.FileMode) error                  { panic("not implemented") }
 func (f *uploadFS) MkdirTemp(_, _ string) (string, error)                   { panic("not implemented") }
+func (f *uploadFS) CreateTemp(_, _ string) (string, error)                  { panic("not implemented") }
 func (f *uploadFS) WriteFile(_ string, _ []byte, _ fs.FileMode) error       { panic("not implemented") }
 func (f *uploadFS) FileExist(_ string) bool                                 { panic("not implemented") }
 func (f *uploadFS) LookPath(_ string) (string, error)                       { panic("not implemented") }

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -180,6 +180,27 @@ func (s *WinFS) MkdirTemp(dir, prefix string) (string, error) {
 	return toSlashes(path), nil
 }
 
+// CreateTemp creates a new temporary file in the directory dir with a name beginning with prefix
+// and returns the path of the new file. If dir is empty, TempDir() is used.
+func (s *WinFS) CreateTemp(dir, prefix string) (string, error) {
+	if dir == "" {
+		dir = s.TempDir()
+	}
+
+	// Use FileMode.CreateNew inside a PS retry loop so creation is atomic and never clobbers
+	// an existing file, matching os.CreateTemp semantics.
+	script := fmt.Sprintf(
+		`$dir = %s; $prefix = %s; for ($i = 0; $i -lt 10000; $i++) { $name = $prefix + ([System.IO.Path]::GetRandomFileName() -replace '\.', '') + '.tmp'; $path = [System.IO.Path]::Combine($dir, $name); try { $f = [System.IO.File]::Open($path, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None); $f.Close(); Write-Output $path; return } catch [System.IO.IOException] { if (-not (Test-Path -LiteralPath $path)) { throw } } }; throw 'create temp: too many retries'`,
+		ps.DoubleQuotePath(dir),
+		ps.SingleQuote(prefix),
+	)
+	out, err := s.ExecOutput(script, cmd.PS())
+	if err != nil {
+		return "", fmt.Errorf("create temp %s: %w", dir, err)
+	}
+	return toSlashes(out), nil
+}
+
 type opener interface {
 	open(flags int) error
 }


### PR DESCRIPTION
Path-returning variant of temp file creation, complementing the existing package-level remotefs.CreateTemp(FS, ...) (File, error). This method returns just the path, matching k0sctl's TempFile usage where the caller passes the path around and writes to it separately.

PosixFS: delegates to mktemp, mirrors MkdirTemp.
WinFS: uses [System.IO.File]::Create with a client-generated unique name.

Part of the rig v2 last mile effort. Breaking API is not a problem as rig v2 has not been released yet.
