### PR TITLE
[release-0.x] ENGINE-1383 winrm fixes for reboot and panic resolve.

### DIFF
--- a/os/windows.go
+++ b/os/windows.go
@@ -177,11 +177,46 @@ func (c Windows) CommandExist(h Host, cmd string) bool {
 	return h.Execf("where /q %s", cmd) == nil
 }
 
-// Reboot executes the reboot command
+// Reboot triggers an immediate forced restart by scheduling a SYSTEM-context
+// one-shot task that runs 'shutdown /r /f /t 5', then immediately triggering
+// and deleting it within the 5-second countdown window.
+//
+// Running via a scheduled task bypasses the filtered Administrator token used
+// by WinRM sessions (e.g. AWS EC2) which lacks SeShutdownPrivilege. Issuing
+// 'shutdown /r' directly in the WinRM session is silently ignored in that
+// context.
+//
+// /sc onstart is used instead of /sc once to avoid schtasks writing a
+// stderr warning about the start time being in the past, which rig treats
+// as an error. The task is deleted immediately after triggering (while the
+// 5-second timer counts down) so it does not re-fire on subsequent startups.
 func (c Windows) Reboot(h Host) error {
-	if err := h.Exec("shutdown /r /t 5"); err != nil {
-		return fmt.Errorf("failed to reboot: %w", err)
+	const taskName = "RigReboot"
+	// Create a SYSTEM-context ONSTART task that runs 'shutdown /r /f /t 5'.
+	// The 5-second delay gives us time to delete the task before the OS
+	// actually executes the reboot, preventing it from firing again on the
+	// next startup.
+	create := fmt.Sprintf(`schtasks /create /tn "%s" /tr "shutdown /r /f /t 5" /sc onstart /f /ru SYSTEM`, taskName)
+	if err := h.Exec(create); err != nil {
+		return fmt.Errorf("failed to create reboot task: %w", err)
 	}
+	run := fmt.Sprintf(`schtasks /run /tn "%s"`, taskName)
+	if err := h.Exec(run); err != nil {
+		// Tolerate connection-level errors; the OS may kill WinRM as it starts
+		// rebooting before the run command returns.
+		errMsg := err.Error()
+		if !strings.Contains(errMsg, "connection") && !strings.Contains(errMsg, "closed") && !strings.Contains(errMsg, "EOF") {
+			return fmt.Errorf("failed to run reboot task: %w", err)
+		}
+	}
+	// Delete the task immediately while the 5-second shutdown timer is still
+	// counting down. This prevents it from re-firing on subsequent startups.
+	del := fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName)
+	// Best-effort: ignore delete errors — if the task fires before we can
+	// delete it, the caller is expected to delete it after reconnecting.
+	_ = h.Exec(del)
+	// Allow Windows time to complete shutdown before waitForHost begins polling.
+	time.Sleep(15 * time.Second)
 	return nil
 }
 

--- a/os/windows.go
+++ b/os/windows.go
@@ -207,16 +207,16 @@ func isWinRMConnectionError(err error) bool {
 // 'shutdown /r' directly in the WinRM session is silently ignored in that
 // context.
 //
-// The task is scheduled for a fixed far-future date to avoid past-start-time
-// warnings without depending on the controller's clock or timezone. The /z
-// flag auto-deletes the task after it fires. A best-effort delete is also
-// attempted immediately after /run; if the machine is already rebooting the
-// delete will fail silently.
+// The task omits /sd to avoid locale-sensitive date parsing; /st 23:59 is
+// accepted universally. The task is immediately triggered via /run so the
+// scheduled time is irrelevant. The /z flag auto-deletes the task after it
+// fires. A best-effort delete is also attempted immediately after /run; if
+// the machine is already rebooting the delete will fail silently.
 func (c Windows) Reboot(h Host) error {
 	taskName := fmt.Sprintf("RigReboot%d", time.Now().UnixNano())
 	const shutdownDelay = 5
 	create := fmt.Sprintf(
-		`schtasks /create /tn "%s" /tr "shutdown /r /f /t %d" /sc once /sd 12/31/2099 /st 23:59 /z /f /ru SYSTEM`,
+		`schtasks /create /tn "%s" /tr "shutdown /r /f /t %d" /sc once /st 23:59 /z /f /ru SYSTEM`,
 		taskName, shutdownDelay,
 	)
 	if err := h.Exec(create, exec.AllowWinStderr()); err != nil {

--- a/os/windows.go
+++ b/os/windows.go
@@ -192,24 +192,23 @@ func (c Windows) CommandExist(h Host, cmd string) bool {
 func (c Windows) Reboot(h Host) error {
 	taskName := fmt.Sprintf("RigReboot%d", time.Now().UnixNano())
 	const shutdownDelay = 5
-	startTime := time.Now().Add(time.Minute).Format("15:04")
+	scheduled := time.Now().Add(time.Minute)
 	create := fmt.Sprintf(
-		`schtasks /create /tn "%s" /tr "shutdown /r /f /t %d" /sc once /st %s /f /ru SYSTEM`,
-		taskName, shutdownDelay, startTime,
+		`schtasks /create /tn "%s" /tr "shutdown /r /f /t %d" /sc once /sd %s /st %s /z /f /ru SYSTEM`,
+		taskName, shutdownDelay, scheduled.Format("01/02/2006"), scheduled.Format("15:04"),
 	)
 	if err := h.Exec(create, exec.AllowWinStderr()); err != nil {
 		return fmt.Errorf("failed to create reboot task: %w", err)
 	}
-	// Best-effort cleanup deferred immediately after create; /sc once guarantees
-	// the task won't re-fire even if delete fails, but we still try to remove it
-	// on all exit paths, including early returns from run errors.
-	defer func() { _ = h.Exec(fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName)) }()
 	run := fmt.Sprintf(`schtasks /run /tn "%s"`, taskName)
 	if err := h.Exec(run); err != nil {
 		// Tolerate connection-level errors; the OS may kill WinRM as it starts
-		// rebooting before the run command returns.
+		// rebooting before the run command returns. Leave the task in place so it
+		// fires at its scheduled time if /run did not actually trigger it.
 		errMsg := err.Error()
 		if !strings.Contains(errMsg, "connection") && !strings.Contains(errMsg, "closed") && !strings.Contains(errMsg, "EOF") {
+			// Non-connection error: delete the task to prevent an unexpected reboot.
+			_ = h.Exec(fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName))
 			return fmt.Errorf("failed to run reboot task: %w", err)
 		}
 	}

--- a/os/windows.go
+++ b/os/windows.go
@@ -190,7 +190,7 @@ func (c Windows) CommandExist(h Host, cmd string) bool {
 // past-start-time warning; the task is triggered immediately via schtasks /run
 // regardless of the scheduled time.
 func (c Windows) Reboot(h Host) error {
-	taskName := fmt.Sprintf("RigReboot%d", time.Now().Unix())
+	taskName := fmt.Sprintf("RigReboot%d", time.Now().UnixNano())
 	const shutdownDelay = 5
 	startTime := time.Now().Add(time.Minute).Format("15:04")
 	create := fmt.Sprintf(
@@ -200,6 +200,10 @@ func (c Windows) Reboot(h Host) error {
 	if err := h.Exec(create, exec.AllowWinStderr()); err != nil {
 		return fmt.Errorf("failed to create reboot task: %w", err)
 	}
+	// Best-effort cleanup deferred immediately after create; /sc once guarantees
+	// the task won't re-fire even if delete fails, but we still try to remove it
+	// on all exit paths, including early returns from run errors.
+	defer func() { _ = h.Exec(fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName)) }()
 	run := fmt.Sprintf(`schtasks /run /tn "%s"`, taskName)
 	if err := h.Exec(run); err != nil {
 		// Tolerate connection-level errors; the OS may kill WinRM as it starts
@@ -209,8 +213,6 @@ func (c Windows) Reboot(h Host) error {
 			return fmt.Errorf("failed to run reboot task: %w", err)
 		}
 	}
-	// Best-effort cleanup; /sc once guarantees the task won't re-fire even if delete fails.
-	_ = h.Exec(fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName)) //nolint:errcheck
 	// Wait for the shutdown timer plus a buffer before the caller begins polling.
 	time.Sleep(time.Duration(shutdownDelay+10) * time.Second)
 	return nil

--- a/os/windows.go
+++ b/os/windows.go
@@ -183,6 +183,9 @@ func (c Windows) CommandExist(h Host, cmd string) bool {
 // disconnection rather than a logical failure. WinRM errors are not always
 // typed, so we check known sentinels first and fall back to string matching.
 func isWinRMConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
 	if errors.Is(err, io.EOF) {
 		return true
 	}
@@ -196,25 +199,25 @@ func isWinRMConnectionError(err error) bool {
 
 // Reboot triggers a forced restart via a SYSTEM-context one-shot scheduled
 // task that runs shutdown, then immediately triggers it with schtasks /run.
+// Returns as soon as the trigger is sent; the caller is responsible for
+// polling until the host goes down and comes back.
 //
 // Running via a scheduled task bypasses the filtered Administrator token used
 // by WinRM sessions (e.g. AWS EC2) which lacks SeShutdownPrivilege. Issuing
 // 'shutdown /r' directly in the WinRM session is silently ignored in that
 // context.
 //
-// The task is scheduled one hour ahead to avoid past-start-time warnings while
-// keeping the fallback window large enough that transient /run errors (not
-// caused by an actual reboot) do not trigger an unexpected restart. After the
-// shutdown delay elapses, a best-effort delete is attempted; if the machine is
-// already rebooting the delete will fail silently and the /z flag ensures the
-// task is removed once it eventually fires.
+// The task is scheduled for a fixed far-future date to avoid past-start-time
+// warnings without depending on the controller's clock or timezone. The /z
+// flag auto-deletes the task after it fires. A best-effort delete is also
+// attempted immediately after /run; if the machine is already rebooting the
+// delete will fail silently.
 func (c Windows) Reboot(h Host) error {
 	taskName := fmt.Sprintf("RigReboot%d", time.Now().UnixNano())
 	const shutdownDelay = 5
-	scheduled := time.Now().Add(time.Hour)
 	create := fmt.Sprintf(
-		`schtasks /create /tn "%s" /tr "shutdown /r /f /t %d" /sc once /sd %s /st %s /z /f /ru SYSTEM`,
-		taskName, shutdownDelay, scheduled.Format("01/02/2006"), scheduled.Format("15:04"),
+		`schtasks /create /tn "%s" /tr "shutdown /r /f /t %d" /sc once /sd 12/31/2099 /st 23:59 /z /f /ru SYSTEM`,
+		taskName, shutdownDelay,
 	)
 	if err := h.Exec(create, exec.AllowWinStderr()); err != nil {
 		return fmt.Errorf("failed to create reboot task: %w", err)
@@ -229,11 +232,10 @@ func (c Windows) Reboot(h Host) error {
 		// Connection-level error: the OS may have killed WinRM as it started
 		// rebooting. Leave the task in place so it fires at its scheduled time
 		// if /run did not actually trigger it.
+		return nil
 	}
-	// Wait for the shutdown timer plus a buffer before the caller begins polling.
-	time.Sleep(time.Duration(shutdownDelay+10) * time.Second)
-	// Best-effort cleanup: if the machine is still reachable here the reboot did
-	// not start, so remove the task to prevent it firing at its scheduled time.
+	// Best-effort cleanup: deleting the task entry does not cancel the already-
+	// started shutdown process; it only prevents the far-future scheduled fire.
 	_ = h.Exec(fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName))
 	return nil
 }

--- a/os/windows.go
+++ b/os/windows.go
@@ -178,26 +178,26 @@ func (c Windows) CommandExist(h Host, cmd string) bool {
 }
 
 // Reboot triggers an immediate forced restart by scheduling a SYSTEM-context
-// one-shot task that runs 'shutdown /r /f /t 5', then immediately triggering
-// and deleting it within the 5-second countdown window.
+// one-shot task that runs shutdown, then immediately triggering it.
 //
 // Running via a scheduled task bypasses the filtered Administrator token used
 // by WinRM sessions (e.g. AWS EC2) which lacks SeShutdownPrivilege. Issuing
 // 'shutdown /r' directly in the WinRM session is silently ignored in that
 // context.
 //
-// /sc onstart is used instead of /sc once to avoid schtasks writing a
-// stderr warning about the start time being in the past, which rig treats
-// as an error. The task is deleted immediately after triggering (while the
-// 5-second timer counts down) so it does not re-fire on subsequent startups.
+// A unique task name is used per invocation to prevent conflicts with concurrent
+// callers. The start time is set one minute ahead so schtasks does not emit a
+// past-start-time warning; the task is triggered immediately via schtasks /run
+// regardless of the scheduled time.
 func (c Windows) Reboot(h Host) error {
-	const taskName = "RigReboot"
-	// Create a SYSTEM-context ONSTART task that runs 'shutdown /r /f /t 5'.
-	// The 5-second delay gives us time to delete the task before the OS
-	// actually executes the reboot, preventing it from firing again on the
-	// next startup.
-	create := fmt.Sprintf(`schtasks /create /tn "%s" /tr "shutdown /r /f /t 5" /sc onstart /f /ru SYSTEM`, taskName)
-	if err := h.Exec(create); err != nil {
+	taskName := fmt.Sprintf("RigReboot%d", time.Now().Unix())
+	const shutdownDelay = 5
+	startTime := time.Now().Add(time.Minute).Format("15:04")
+	create := fmt.Sprintf(
+		`schtasks /create /tn "%s" /tr "shutdown /r /f /t %d" /sc once /st %s /f /ru SYSTEM`,
+		taskName, shutdownDelay, startTime,
+	)
+	if err := h.Exec(create, exec.AllowWinStderr()); err != nil {
 		return fmt.Errorf("failed to create reboot task: %w", err)
 	}
 	run := fmt.Sprintf(`schtasks /run /tn "%s"`, taskName)
@@ -209,14 +209,10 @@ func (c Windows) Reboot(h Host) error {
 			return fmt.Errorf("failed to run reboot task: %w", err)
 		}
 	}
-	// Delete the task immediately while the 5-second shutdown timer is still
-	// counting down. This prevents it from re-firing on subsequent startups.
-	del := fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName)
-	// Best-effort: ignore delete errors — if the task fires before we can
-	// delete it, the caller is expected to delete it after reconnecting.
-	_ = h.Exec(del)
-	// Allow Windows time to complete shutdown before waitForHost begins polling.
-	time.Sleep(15 * time.Second)
+	// Best-effort cleanup; /sc once guarantees the task won't re-fire even if delete fails.
+	_ = h.Exec(fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName)) //nolint:errcheck
+	// Wait for the shutdown timer plus a buffer before the caller begins polling.
+	time.Sleep(time.Duration(shutdownDelay+10) * time.Second)
 	return nil
 }
 

--- a/os/windows.go
+++ b/os/windows.go
@@ -193,8 +193,8 @@ func isWinRMConnectionError(err error) bool {
 	if errors.As(err, &netErr) {
 		return true
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "connection") || strings.Contains(msg, "closed") || strings.Contains(msg, "EOF")
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "connection") || strings.Contains(msg, "closed") || strings.Contains(msg, "eof")
 }
 
 // Reboot triggers a forced restart via a SYSTEM-context one-shot scheduled
@@ -210,8 +210,8 @@ func isWinRMConnectionError(err error) bool {
 // The task omits /sd to avoid locale-sensitive date parsing; /st 23:59 is
 // accepted universally. The task is immediately triggered via /run so the
 // scheduled time is irrelevant. The /z flag auto-deletes the task after it
-// fires. A best-effort delete is also attempted immediately after /run; if
-// the machine is already rebooting the delete will fail silently.
+// fires. A best-effort delete is attempted in all cases after /run; this
+// prevents a delayed fallback fire if /run never triggered the shutdown.
 func (c Windows) Reboot(h Host) error {
 	taskName := fmt.Sprintf("RigReboot%d", time.Now().UnixNano())
 	const shutdownDelay = 5
@@ -230,8 +230,9 @@ func (c Windows) Reboot(h Host) error {
 			return fmt.Errorf("failed to run reboot task: %w", err)
 		}
 		// Connection-level error: the OS may have killed WinRM as it started
-		// rebooting. Leave the task in place so it fires at its scheduled time
-		// if /run did not actually trigger it.
+		// rebooting. Attempt best-effort deletion to prevent a delayed fallback
+		// fire if /run never actually triggered the shutdown.
+		_ = h.Exec(fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName))
 		return nil
 	}
 	// Best-effort cleanup: deleting the task entry does not cancel the already-

--- a/os/windows.go
+++ b/os/windows.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -177,22 +179,39 @@ func (c Windows) CommandExist(h Host, cmd string) bool {
 	return h.Execf("where /q %s", cmd) == nil
 }
 
-// Reboot triggers an immediate forced restart by scheduling a SYSTEM-context
-// one-shot task that runs shutdown, then immediately triggering it.
+// isWinRMConnectionError reports whether err looks like a transport-level
+// disconnection rather than a logical failure. WinRM errors are not always
+// typed, so we check known sentinels first and fall back to string matching.
+func isWinRMConnectionError(err error) bool {
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "connection") || strings.Contains(msg, "closed") || strings.Contains(msg, "EOF")
+}
+
+// Reboot triggers a forced restart via a SYSTEM-context one-shot scheduled
+// task that runs shutdown, then immediately triggers it with schtasks /run.
 //
 // Running via a scheduled task bypasses the filtered Administrator token used
 // by WinRM sessions (e.g. AWS EC2) which lacks SeShutdownPrivilege. Issuing
 // 'shutdown /r' directly in the WinRM session is silently ignored in that
 // context.
 //
-// A unique task name is used per invocation to prevent conflicts with concurrent
-// callers. The start time is set one minute ahead so schtasks does not emit a
-// past-start-time warning; the task is triggered immediately via schtasks /run
-// regardless of the scheduled time.
+// The task is scheduled one hour ahead to avoid past-start-time warnings while
+// keeping the fallback window large enough that transient /run errors (not
+// caused by an actual reboot) do not trigger an unexpected restart. After the
+// shutdown delay elapses, a best-effort delete is attempted; if the machine is
+// already rebooting the delete will fail silently and the /z flag ensures the
+// task is removed once it eventually fires.
 func (c Windows) Reboot(h Host) error {
 	taskName := fmt.Sprintf("RigReboot%d", time.Now().UnixNano())
 	const shutdownDelay = 5
-	scheduled := time.Now().Add(time.Minute)
+	scheduled := time.Now().Add(time.Hour)
 	create := fmt.Sprintf(
 		`schtasks /create /tn "%s" /tr "shutdown /r /f /t %d" /sc once /sd %s /st %s /z /f /ru SYSTEM`,
 		taskName, shutdownDelay, scheduled.Format("01/02/2006"), scheduled.Format("15:04"),
@@ -202,18 +221,20 @@ func (c Windows) Reboot(h Host) error {
 	}
 	run := fmt.Sprintf(`schtasks /run /tn "%s"`, taskName)
 	if err := h.Exec(run); err != nil {
-		// Tolerate connection-level errors; the OS may kill WinRM as it starts
-		// rebooting before the run command returns. Leave the task in place so it
-		// fires at its scheduled time if /run did not actually trigger it.
-		errMsg := err.Error()
-		if !strings.Contains(errMsg, "connection") && !strings.Contains(errMsg, "closed") && !strings.Contains(errMsg, "EOF") {
+		if !isWinRMConnectionError(err) {
 			// Non-connection error: delete the task to prevent an unexpected reboot.
 			_ = h.Exec(fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName))
 			return fmt.Errorf("failed to run reboot task: %w", err)
 		}
+		// Connection-level error: the OS may have killed WinRM as it started
+		// rebooting. Leave the task in place so it fires at its scheduled time
+		// if /run did not actually trigger it.
 	}
 	// Wait for the shutdown timer plus a buffer before the caller begins polling.
 	time.Sleep(time.Duration(shutdownDelay+10) * time.Second)
+	// Best-effort cleanup: if the machine is still reachable here the reboot did
+	// not start, so remove the task to prevent it firing at its scheduled time.
+	_ = h.Exec(fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName))
 	return nil
 }
 

--- a/winrm.go
+++ b/winrm.go
@@ -197,17 +197,8 @@ type Command struct {
 }
 
 // Wait blocks until the command finishes
-func (c *Command) Wait() (err error) { //nolint:nonamedreturns // needed for panic recovery
-	defer func() {
-		if r := recover(); err == nil && r != nil {
-			if strings.Contains(fmt.Sprint(r), "close of closed channel") {
-				log.Debugf("recovered from a panic in Command.Wait: %v", r)
-			} else {
-				panic(r)
-			}
-		}
-	}()
-
+// Wait blocks until the command finishes
+func (c *Command) Wait() error {
 	defer c.sh.Close()
 	defer c.cmd.Close()
 
@@ -215,9 +206,9 @@ func (c *Command) Wait() (err error) { //nolint:nonamedreturns // needed for pan
 	c.cmd.Wait()
 	log.Debugf("command finished")
 	if c.cmd.ExitCode() != 0 {
-		err = fmt.Errorf("%w: exit code %d", ErrCommandFailed, c.cmd.ExitCode())
+		return fmt.Errorf("%w: exit code %d", ErrCommandFailed, c.cmd.ExitCode())
 	}
-	return err
+	return nil
 }
 
 // Close terminates the command
@@ -319,26 +310,19 @@ func (c *WinRM) Exec(cmd string, opts ...exec.Option) error { //nolint:cyclop
 		}()
 	}
 
+	var errors []string
+
 	wg.Add(1)
 	go func() {
-		// ignore channel close panics
-		defer func() {
-			if r := recover(); r != nil {
-				log.Debugf("recovered from a panic while reading stderr: %v", r)
-			}
-		}()
 		defer wg.Done()
 		if execOpts.Writer == nil {
 			outputScanner := bufio.NewScanner(command.Stdout)
-
 			for outputScanner.Scan() {
 				execOpts.AddOutput(c.String(), outputScanner.Text()+"\n", "")
 			}
-
 			if err := outputScanner.Err(); err != nil {
 				execOpts.LogErrorf("%s: %s", c, err.Error())
 			}
-			command.Stdout.Close()
 		} else {
 			if _, err := io.Copy(execOpts.Writer, command.Stdout); err != nil {
 				execOpts.LogErrorf("%s: failed to stream stdout: %v", c, err)
@@ -346,19 +330,10 @@ func (c *WinRM) Exec(cmd string, opts ...exec.Option) error { //nolint:cyclop
 		}
 	}()
 
-	var errors []string
-
 	wg.Add(1)
 	go func() {
-		// ignore channel close panics
-		defer func() {
-			if r := recover(); r != nil {
-				log.Debugf("recovered from a panic while reading stderr: %v", r)
-			}
-		}()
 		defer wg.Done()
 		outputScanner := bufio.NewScanner(command.Stderr)
-
 		for outputScanner.Scan() {
 			msg := outputScanner.Text()
 			if msg != "" {
@@ -366,11 +341,9 @@ func (c *WinRM) Exec(cmd string, opts ...exec.Option) error { //nolint:cyclop
 				execOpts.LogErrorf("%s: %s", c, msg)
 			}
 		}
-
 		if err := outputScanner.Err(); err != nil {
 			execOpts.LogErrorf("%s: %s", c, err.Error())
 		}
-		command.Stderr.Close()
 	}()
 
 	wg.Wait()

--- a/winrm.go
+++ b/winrm.go
@@ -309,7 +309,7 @@ func (c *WinRM) Exec(cmd string, opts ...exec.Option) error { //nolint:cyclop
 		}()
 	}
 
-	var errors []string
+	var stderrLines []string
 
 	wg.Add(1)
 	go func() {
@@ -336,7 +336,7 @@ func (c *WinRM) Exec(cmd string, opts ...exec.Option) error { //nolint:cyclop
 		for outputScanner.Scan() {
 			msg := outputScanner.Text()
 			if msg != "" {
-				errors = append(errors, msg)
+				stderrLines = append(stderrLines, msg)
 				execOpts.LogErrorf("%s: %s", c, msg)
 			}
 		}
@@ -351,8 +351,8 @@ func (c *WinRM) Exec(cmd string, opts ...exec.Option) error { //nolint:cyclop
 	if ec := command.ExitCode(); ec > 0 {
 		return fmt.Errorf("%w: non-zero exit code: %d", ErrCommandFailed, ec)
 	}
-	if !execOpts.AllowWinStderr && len(errors) > 0 {
-		return fmt.Errorf("%w: received data in stderr: %s", ErrCommandFailed, strings.Join(errors, "\n"))
+	if !execOpts.AllowWinStderr && len(stderrLines) > 0 {
+		return fmt.Errorf("%w: received data in stderr: %s", ErrCommandFailed, strings.Join(stderrLines, "\n"))
 	}
 
 	return nil

--- a/winrm.go
+++ b/winrm.go
@@ -196,8 +196,7 @@ type Command struct {
 	wg     sync.WaitGroup
 }
 
-// Wait blocks until the command finishes
-// Wait blocks until the command finishes
+// Wait blocks until the command finishes.
 func (c *Command) Wait() error {
 	defer c.sh.Close()
 	defer c.cmd.Close()


### PR DESCRIPTION
Hey K0s team.  I have been battling some windows/winrm issues in Launchpad, and with some Claude help have discovered:

1. windows 2019 (in particular) doesn't like the windows Reboot() function, which doesn't always work.
2. the winrm close panic still needs a different approach to resolve a race condition.

In this PR are two fixes:

1. The new reboot switches a flat "shutdown" Exec() to using "schtasks" to run a shutdown. The effort get's more complicated after CoPilot pointed out that you have to be careful with the schtask removal, as you may end up in a persistant reboot. I will take another stab at simplifying it (I think that there is a `--once` flag for schtasks.)

2. Drops the panic recover() and focuses on race resolution in closing the command Stdout/Stderr in two different places.