### PR TITLE
Improve PowerShell EncodedCommand usage

### DIFF
--- a/cmd/executor.go
+++ b/cmd/executor.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"unicode/utf16"
 
 	"github.com/k0sproject/rig/v2/log"
 	"github.com/k0sproject/rig/v2/protocol"
@@ -172,6 +173,21 @@ func isExe(cmd string) bool {
 	return strings.HasSuffix(firstWord, ".exe")
 }
 
+func decodeUTF16LE(encoded string) (string, error) {
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", err
+	}
+	if len(raw)%2 != 0 {
+		return "", fmt.Errorf("odd byte length in UTF-16LE payload")
+	}
+	words := make([]uint16, len(raw)/2)
+	for i := range words {
+		words[i] = uint16(raw[i*2]) | uint16(raw[i*2+1])<<8
+	}
+	return string(utf16.Decode(words)), nil
+}
+
 func decodeEncoded(cmd string) string {
 	if !strings.Contains(cmd, "powershell") {
 		return cmd
@@ -179,10 +195,9 @@ func decodeEncoded(cmd string) string {
 
 	parts := strings.Split(cmd, " ")
 	for i, p := range parts {
-		if p == "-E" || p == "-EncodedCommand" && len(parts) > i+1 {
-			decoded, err := base64.StdEncoding.DecodeString(parts[i+1])
-			if err == nil {
-				parts[i+1] = strings.ReplaceAll(string(decoded), "\x00", "")
+		if (p == "-E" || p == "-EncodedCommand") && i+1 < len(parts) {
+			if plain, err := decodeUTF16LE(parts[i+1]); err == nil {
+				parts[i+1] = plain
 			}
 		}
 	}

--- a/powershell/powershell.go
+++ b/powershell/powershell.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"strings"
+	"unicode/utf16"
 )
 
 // PipeHasEnded string is used during the base64+sha265 upload process.
@@ -27,9 +28,12 @@ func CompressedCmd(psCmd string) string {
 	}
 	cmd := strings.Join(trimmed, "\n")
 	var b bytes.Buffer
-	w, _ := gzip.NewWriterLevel(&b, gzip.BestCompression)
-	_, _ = w.Write([]byte(cmd))
-	_ = w.Close()
+	w, err := gzip.NewWriterLevel(&b, gzip.BestCompression)
+	if err != nil {
+		panic(err) // BestCompression level is always valid
+	}
+	_, _ = w.Write([]byte(cmd))   //nolint:errcheck // write to bytes.Buffer never fails
+	_ = w.Close()                  //nolint:errcheck // close on memory buffer never fails
 	scriptlet := `$z="` + base64.StdEncoding.EncodeToString(b.Bytes()) + `"
 $d=[Convert]::FromBase64String($z)
 Set-Alias NO New-Object
@@ -44,28 +48,41 @@ Invoke-Expression "function s(){$u}"; s`
 	return Cmd(scriptlet)
 }
 
-// EncodeCmd base64-encodes a string in a way that is accepted by PowerShell -EncodedCommand.
-func EncodeCmd(psCmd string) string {
-	if !strings.Contains(psCmd, "begin {") {
-		psCmd = "$ProgressPreference='SilentlyContinue'; " + psCmd
+// withProgressPreference prepends the $ProgressPreference suppressor unless the
+// script already uses a begin block (handles it itself). The check is
+// case-insensitive ("Begin {", "BEGIN{", etc.) to match PowerShell's own
+// keyword handling.
+func withProgressPreference(psCmd string) string {
+	lower := strings.ToLower(psCmd)
+	if strings.Contains(lower, "begin{") || strings.Contains(lower, "begin {") {
+		return psCmd
 	}
-	// 2 byte chars to make PowerShell happy
-	var wideCmd strings.Builder
-	for _, b := range []byte(psCmd) {
-		wideCmd.WriteString(string(b) + "\x00")
-	}
-
-	// Base64 encode the command
-	input := []uint8(wideCmd.String())
-	return base64.StdEncoding.EncodeToString(input)
+	return "$ProgressPreference='SilentlyContinue'; " + psCmd
 }
 
-// Cmd builds a command-line for executing a complex command or script as an EncodedCommand through powershell.
-func Cmd(psCmd string) string {
-	encodedCmd := EncodeCmd(psCmd)
+// EncodeCmd base64-encodes a string as UTF-16LE in a way that is accepted by
+// PowerShell -EncodedCommand.
+func EncodeCmd(psCmd string) string {
+	psCmd = withProgressPreference(psCmd)
+	words := utf16.Encode([]rune(psCmd))
+	buf := make([]byte, len(words)*2)
+	for i, w := range words {
+		buf[i*2] = byte(w)
+		buf[i*2+1] = byte(w >> 8)
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
 
-	// Create the powershell.exe command line to execute the script
-	return "powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -E " + encodedCmd
+// Cmd builds a command-line for executing a PowerShell command or script.
+// Scripts that contain newlines, double-quotes, or cmd.exe metacharacters
+// are passed via -EncodedCommand to avoid shell expansion; simple one-liners
+// are passed via -Command so they remain readable in logs.
+// cmd.exe metacharacters guarded: " % ! ^ & | < >
+func Cmd(psCmd string) string {
+	if strings.ContainsAny(psCmd, "\n\r\"%!^&|<>") {
+		return "powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -E " + EncodeCmd(psCmd)
+	}
+	return "powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -Command \"" + withProgressPreference(psCmd) + "\""
 }
 
 // SingleQuote quotes and escapes a string in a format that is accepted by powershell scriptlets
@@ -89,7 +106,7 @@ func SingleQuote(v string) string {
 
 // DoubleQuote adds double quotes around a string and escapes any double quotes inside.
 func DoubleQuote(v string) string {
-	if v[0] == '"' && v[len(v)-1] == '"' {
+	if len(v) > 0 && v[0] == '"' && v[len(v)-1] == '"' {
 		// already quoted
 		return v
 	}

--- a/powershell/powershell_test.go
+++ b/powershell/powershell_test.go
@@ -1,0 +1,131 @@
+package powershell_test
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	"github.com/k0sproject/rig/v2/powershell"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmdSimpleUsesCommand(t *testing.T) {
+	out := powershell.Cmd("$env:COMPUTERNAME")
+	require.Contains(t, out, "-Command")
+	require.NotContains(t, out, " -E ")
+	require.Contains(t, out, "$env:COMPUTERNAME")
+}
+
+func TestCmdNewlineUsesEncoded(t *testing.T) {
+	out := powershell.Cmd("$a=1\n$b=2")
+	require.Contains(t, out, " -E ")
+	require.NotContains(t, out, "-Command")
+}
+
+func TestCmdDoubleQuoteUsesEncoded(t *testing.T) {
+	out := powershell.Cmd(`New-Item -Path "C:\foo"`)
+	require.Contains(t, out, " -E ")
+	require.NotContains(t, out, "-Command")
+}
+
+func TestCmdSimpleInjectsProgressPreference(t *testing.T) {
+	out := powershell.Cmd("$env:COMPUTERNAME")
+	require.Contains(t, out, "$ProgressPreference='SilentlyContinue'")
+}
+
+func TestCmdSimpleReadableInLogs(t *testing.T) {
+	script := "[DateTimeOffset]::UtcNow.ToUnixTimeSeconds()"
+	out := powershell.Cmd(script)
+	require.True(t, strings.Contains(out, script), "simple script should be visible in the command string")
+}
+
+func TestCmdPercentUsesEncoded(t *testing.T) {
+	// % is expanded by cmd.exe before PowerShell sees the command.
+	out := powershell.Cmd("Write-Output %PATH%")
+	require.Contains(t, out, " -E ")
+	require.NotContains(t, out, "-Command")
+}
+
+func TestCmdExclamationUsesEncoded(t *testing.T) {
+	// ! triggers delayed expansion in cmd.exe.
+	out := powershell.Cmd("Write-Output !foo!")
+	require.Contains(t, out, " -E ")
+	require.NotContains(t, out, "-Command")
+}
+
+func TestCmdCmdExeMetacharsUseEncoded(t *testing.T) {
+	// These cmd.exe metacharacters can alter semantics when the command is
+	// executed via cmd.exe /c and must go through -EncodedCommand.
+	// Note: () are NOT included — they are protected inside the double-quoted
+	// -Command "..." argument and are ubiquitous in PowerShell method calls.
+	metacharScripts := []string{
+		`Write-Output ^escaped`,     // ^ escape character
+		`Get-Process & Get-Service`, // & command chaining
+		`Get-Process | Select Name`, // | pipe
+		`Get-Content < file.txt`,    // < redirect
+		`Get-Content > file.txt`,    // > redirect
+	}
+	for _, script := range metacharScripts {
+		out := powershell.Cmd(script)
+		require.Contains(t, out, " -E ", "expected -EncodedCommand for: %s", script)
+		require.NotContains(t, out, "-Command", "unexpected -Command for: %s", script)
+	}
+}
+
+func TestCmdBeginBlockSkipsProgressPrefix(t *testing.T) {
+	script := "begin { } process { Get-Date }"
+	out := powershell.Cmd(script)
+	require.NotContains(t, out, "$ProgressPreference")
+}
+
+// decodeEncodeCmd decodes a base64+UTF-16LE payload produced by EncodeCmd.
+func decodeEncodeCmd(t *testing.T, encoded string) string {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(raw)%2, "encoded payload must have even byte length (UTF-16LE)")
+	words := make([]uint16, len(raw)/2)
+	for i := range words {
+		words[i] = uint16(raw[i*2]) | uint16(raw[i*2+1])<<8
+	}
+	runes := utf16.Decode(words)
+	var sb strings.Builder
+	for _, r := range runes {
+		sb.WriteRune(r)
+	}
+	return sb.String()
+}
+
+func TestEncodeCmdBeginBlockSkipsProgressPrefix(t *testing.T) {
+	script := "begin { } process { Get-Date }"
+	decoded := decodeEncodeCmd(t, powershell.EncodeCmd(script))
+	require.NotContains(t, decoded, "ProgressPreference")
+}
+
+func TestCmdBeginBlockNoSpaceSkipsProgressPrefix(t *testing.T) {
+	// "begin{" without a space before the brace is also a valid begin block.
+	script := "begin{ } process { Get-Date }"
+	out := powershell.Cmd(script)
+	require.NotContains(t, out, "$ProgressPreference")
+}
+
+func TestCmdBeginBlockCaseInsensitiveSkipsProgressPrefix(t *testing.T) {
+	// PowerShell keywords are case-insensitive; Begin/BEGIN must also be exempt.
+	for _, script := range []string{
+		"Begin { } Process { Get-Date }",
+		"BEGIN { } PROCESS { Get-Date }",
+	} {
+		out := powershell.Cmd(script)
+		require.NotContains(t, out, "$ProgressPreference", "script: %s", script)
+	}
+}
+
+func TestEncodeCmdUnicode(t *testing.T) {
+	// Non-ASCII input must survive the UTF-16LE round-trip intact.
+	script := "Write-Output 'héllo wörld 日本語'"
+	require.False(t, utf8.ValidString(script) && len(script) == len([]rune(script)), "test must use multi-byte runes")
+	decoded := decodeEncodeCmd(t, powershell.EncodeCmd(script))
+	require.Contains(t, decoded, "héllo wörld 日本語")
+}

--- a/remotefs/hostinfo_test.go
+++ b/remotefs/hostinfo_test.go
@@ -239,7 +239,7 @@ func TestPosixTouch(t *testing.T) {
 	})
 }
 
-// WinFS — PS commands are base64-encoded so we match by powershell.exe prefix.
+// WinFS — PS commands match by powershell.exe prefix (simple scripts use -Command, complex ones use -EncodedCommand).
 
 func TestWindowsDownloadURL(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
@@ -533,7 +533,7 @@ func TestWindowsCreateTemp(t *testing.T) {
 		mr := rigtest.NewMockRunner()
 		mr.Windows = true
 		// Stub TempDir's TEMP lookup first (exact match), then the CreateTemp script (broad prefix).
-		// PS commands are base64-encoded so the exact match distinguishes the two calls.
+		// The exact match on powershell.Cmd(...) distinguishes the two calls regardless of encoding.
 		mr.AddCommandOutput(rigtest.Equal(powershell.Cmd("[System.Environment]::GetEnvironmentVariable('TEMP')")), `C:\Windows\Temp`)
 		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), `C:\Windows\Temp\rig-abc123.tmp`)
 		f := remotefs.NewWindowsFS(mr)


### PR DESCRIPTION
The powershell.Cmd now auto-detects if the script contains \n, \r, or " and uses -EncodedCommand (safe for cmd.exe), otherwise it uses -Command "..." so the script is visible in logs. Simple one-liners like $env:COMPUTERNAME, [DateTimeOffset]::UtcNow.ToUnixTimeSeconds(), registry reads, etc. are now human-readable.

Part of the rig v2 last-mile effort, breaking API is not a problem as rig v2 has not been released.