### PR TITLE
Add cmd.Proc and rename Formatter.Command to Formatter.Format

### DIFF
--- a/cmd/errorexec.go
+++ b/cmd/errorexec.go
@@ -26,8 +26,13 @@ func NewErrorExecutor(err error) *ErrorExecutor {
 	return &ErrorExecutor{Err: err}
 }
 
-// Command returns the command string as is.
-func (r *ErrorExecutor) Command(cmd string) string { return cmd }
+// Format returns the command string as is.
+func (r *ErrorExecutor) Format(cmd string) string { return cmd }
+
+// Proc returns a Proc bound to this executor for the given command.
+func (r *ErrorExecutor) Proc(cmd string) *Proc {
+	return &Proc{runner: r, command: cmd}
+}
 
 // IsWindows returns false.
 func (r *ErrorExecutor) IsWindows() bool { return false }

--- a/cmd/execoptions.go
+++ b/cmd/execoptions.go
@@ -48,8 +48,8 @@ type ExecOptions struct {
 	redactMask    string
 }
 
-// Command returns the command string with all decorators applied.
-func (o *ExecOptions) Command(cmd string) string {
+// Format returns the command string with all per-call decorators applied.
+func (o *ExecOptions) Format(cmd string) string {
 	for _, decorator := range o.decorateFuncs {
 		cmd = decorator(cmd)
 	}

--- a/cmd/executor.go
+++ b/cmd/executor.go
@@ -60,12 +60,18 @@ func NewExecutor(conn protocol.ProcessStarter, decorators ...DecorateFunc) *Exec
 	}
 }
 
-// Command returns the command string decorated with the runner's decorators.
-func (r *Executor) Command(cmd string) string {
+// Format returns the command string decorated with the runner's global decorators.
+func (r *Executor) Format(cmd string) string {
 	for _, decorator := range r.decorators {
 		cmd = decorator(cmd)
 	}
 	return cmd
+}
+
+// Proc returns a Proc bound to this runner for the given command.
+// Set Stdin, Stdout, Stderr on the returned Proc before calling Start or Run.
+func (r *Executor) Proc(cmd string) *Proc {
+	return &Proc{runner: r, command: cmd}
 }
 
 // IsWindows returns true if the host is running Windows.
@@ -196,7 +202,7 @@ func (r *Executor) Start(ctx context.Context, command string, opts ...ExecOption
 	execOpts := Build(opts...)
 	r.InjectLoggerTo(execOpts) //nolint:contextcheck // uses trace logger which takes context
 
-	cmd := r.Command(execOpts.Command(command))
+	cmd := r.Format(execOpts.Format(command))
 	if r.IsWindows() {
 		// we don't know if the default shell is cmd or powershell, so to make sure commands
 		// without a shell prefix go consistently go through the same shell, we default to running
@@ -321,7 +327,7 @@ func (r *Executor) ExecScanner(command string, opts ...ExecOption) *bufio.Scanne
 // StartProcess calls the connection's StartProcess method. This is done to satisfy the
 // connection interface and thus allow chaining of runners.
 func (r *Executor) StartProcess(ctx context.Context, command string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (protocol.Waiter, error) {
-	waiter, err := r.connection.StartProcess(ctx, r.Command(command), stdin, stdout, stderr)
+	waiter, err := r.connection.StartProcess(ctx, r.Format(command), stdin, stdout, stderr)
 	if err != nil {
 		return nil, fmt.Errorf("runner start process: %w", err)
 	}

--- a/cmd/proc.go
+++ b/cmd/proc.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"context"
+	"io"
+
+	"github.com/k0sproject/rig/v2/protocol"
+)
+
+// Proc is a command bound to a runner. Set Stdin, Stdout, and Stderr as needed,
+// then call Start or Run. Modeled after os/exec.Cmd.
+type Proc struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	runner  ContextRunner
+	command string
+}
+
+func (p *Proc) ioOpts(extra []ExecOption) []ExecOption {
+	opts := make([]ExecOption, 0, 3+len(extra))
+	if p.Stdin != nil {
+		opts = append(opts, Stdin(p.Stdin))
+	}
+	if p.Stdout != nil {
+		opts = append(opts, Stdout(p.Stdout))
+	}
+	if p.Stderr != nil {
+		opts = append(opts, Stderr(p.Stderr))
+	}
+	return append(opts, extra...)
+}
+
+// Start starts the command and returns a Waiter.
+func (p *Proc) Start(ctx context.Context, opts ...ExecOption) (protocol.Waiter, error) {
+	return p.runner.Start(ctx, p.command, p.ioOpts(opts)...) //nolint:wrapcheck // transparent delegation
+}
+
+// Run starts the command and waits for it to complete.
+func (p *Proc) Run(ctx context.Context, opts ...ExecOption) error {
+	return p.runner.ExecContext(ctx, p.command, p.ioOpts(opts)...) //nolint:wrapcheck // transparent delegation
+}

--- a/cmd/proc_test.go
+++ b/cmd/proc_test.go
@@ -1,0 +1,93 @@
+package cmd_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/cmd"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcRun(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandSuccess(rigtest.Equal("true"))
+	mr.AddCommandFailure(rigtest.Equal("false"), errors.New("exit 1"))
+
+	require.NoError(t, mr.Proc("true").Run(context.Background()))
+	require.Error(t, mr.Proc("false").Run(context.Background()))
+}
+
+func TestProcStdout(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommand(rigtest.Equal("hello"), func(a *rigtest.A) error {
+		fmt.Fprint(a.Stdout, "world")
+		return nil
+	})
+
+	var buf bytes.Buffer
+	proc := mr.Proc("hello")
+	proc.Stdout = &buf
+	require.NoError(t, proc.Run(context.Background()))
+	require.Equal(t, "world", buf.String())
+}
+
+func TestProcStderr(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommand(rigtest.Equal("cmd"), func(a *rigtest.A) error {
+		fmt.Fprint(a.Stderr, "oops")
+		return errors.New("failed")
+	})
+
+	var errbuf bytes.Buffer
+	proc := mr.Proc("cmd")
+	proc.Stderr = &errbuf
+	require.Error(t, proc.Run(context.Background()))
+	require.Equal(t, "oops", errbuf.String())
+}
+
+func TestProcStdin(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommand(rigtest.Equal("cat"), func(a *rigtest.A) error {
+		_, err := io.Copy(a.Stdout, a.Stdin)
+		return err
+	})
+
+	var buf bytes.Buffer
+	proc := mr.Proc("cat")
+	proc.Stdin = strings.NewReader("ping")
+	proc.Stdout = &buf
+	require.NoError(t, proc.Run(context.Background()))
+	require.Equal(t, "ping", buf.String())
+}
+
+func TestProcStart(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandSuccess(rigtest.Equal("daemon"))
+
+	waiter, err := mr.Proc("daemon").Start(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, waiter.Wait())
+}
+
+func TestProcOptsPassedThrough(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandSuccess(rigtest.Equal("cmd"))
+
+	proc := mr.Proc("cmd")
+	require.NoError(t, proc.Run(context.Background(), cmd.HideOutput()))
+}
+
+func TestProcNilFieldsSkipped(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommand(rigtest.Equal("cmd"), func(a *rigtest.A) error {
+		require.Nil(t, a.Stdin, "nil Stdin should not be wired")
+		return nil
+	})
+	require.NoError(t, mr.Proc("cmd").Run(context.Background()))
+}

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -22,9 +22,9 @@ var (
 // DecorateFunc is a function that takes a string and returns a decorated string.
 type DecorateFunc func(string) string
 
-// Formatter is an interface that can format commands.
+// Formatter is an interface that can format commands by applying decorators.
 type Formatter interface {
-	Command(cmd string) string
+	Format(cmd string) string
 }
 
 // WindowsChecker is implemented by types that can check if the underlying host OS is Windows.
@@ -59,7 +59,7 @@ type Runner interface {
 	WindowsChecker
 	SimpleRunner
 	ContextRunner
-	Formatter
+	Proc(cmd string) *Proc
 	// ProcessStarter is included to allow runners to accept another runner as their connection for chaining.
 	protocol.ProcessStarter
 }


### PR DESCRIPTION
cmd.Proc is an os/exec.Cmd-style helper: bind a command to a runner, set Stdin/Stdout/Stderr fields, then call `Start(ctx, ...opts)` or `Run(ctx, ...opts)`. Replaces the `ExecStreams` pattern for k0sctl migration.

Formatter.Command renamed to Formatter.Format to match the interface name and free up Command as a concept. Duplicate Formatter embedding in Runner removed. cmd.Proc added to the Runner interface.

Part of the rig v2 last mile effort, breaking API is not a problem as rig v2 has not been released yet.