### PR TITLE
feat: add fix for uutils for newer ubuntu

### DIFF
--- a/pkg/rigfs/posixfsys.go
+++ b/pkg/rigfs/posixfsys.go
@@ -287,7 +287,7 @@ func (fsys *PosixFsys) initStat() error {
 		if err != nil {
 			return fmt.Errorf("can't access stat command: %w", err)
 		}
-		if strings.Contains(out, "BusyBox") || strings.Contains(out, "--format=") {
+		if strings.Contains(out, "BusyBox") || strings.Contains(out, "--format") {
 			fsys.statCmd = &statCmdGNU
 		} else {
 			fsys.statCmd = &statCmdBSD


### PR DESCRIPTION
This fixes #328

After digging it more, I discovered that issue is that when we checking if we should use the BSD or GNU stat command string:

https://github.com/k0sproject/rig/blob/789ccd0c3a37b171db9ce20b7ba9c44bcc7a1612/pkg/rigfs/posixfsys.go#L290-L294

I have tested that once removing the `=` from the `--format`, we now default to the correct stat command format.