### PR TITLE
Fix golangci-lint failures from new linter version

### DIFF
--- a/cmd/executor.go
+++ b/cmd/executor.go
@@ -24,11 +24,14 @@ var (
 	_ ContextRunner = (*Executor)(nil)
 	_ Formatter     = (*Executor)(nil)
 	_ fmt.Stringer  = (*Executor)(nil)
+)
 
-	// DisableRedact will disable all redaction of sensitive data.
-	DisableRedact = false
+// DisableRedact will disable all redaction of sensitive data.
+var DisableRedact = false
 
-	errInternal = errors.New("internal error")
+var (
+	errInternal       = errors.New("internal error")
+	errOddUTF16Length = errors.New("odd byte length in UTF-16LE payload")
 )
 
 // Executor is an Runner that runs commands on a host.
@@ -176,10 +179,10 @@ func isExe(cmd string) bool {
 func decodeUTF16LE(encoded string) (string, error) {
 	raw, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("decode base64: %w", err)
 	}
 	if len(raw)%2 != 0 {
-		return "", fmt.Errorf("odd byte length in UTF-16LE payload")
+		return "", errOddUTF16Length
 	}
 	words := make([]uint16, len(raw)/2)
 	for i := range words {

--- a/kv/decoder.go
+++ b/kv/decoder.go
@@ -122,13 +122,13 @@ func getSupportedKinds() []reflect.Kind {
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 		reflect.Float32, reflect.Float64,
 		reflect.Slice,
-		reflect.Ptr,
+		reflect.Pointer,
 	}
 }
 
 func (ra *reflectAssigner) setup() error {
 	val := reflect.ValueOf(ra.obj)
-	if val.Kind() != reflect.Ptr || val.IsNil() {
+	if val.Kind() != reflect.Pointer || val.IsNil() {
 		return fmt.Errorf("%w: object must be a non-nil pointer", ErrInvalidObject)
 	}
 
@@ -274,7 +274,7 @@ func (ra *reflectAssigner) assignField(info fieldInfo, value string) error { //n
 			return fmt.Errorf("parse float: %w", err)
 		}
 		field.SetFloat(f)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if err := ra.assignPtr(info, value); err != nil {
 			return fmt.Errorf("assign ptr: %w", err)
 		}

--- a/os/release.go
+++ b/os/release.go
@@ -12,31 +12,38 @@ var ErrArchNotDetected = errors.New("architecture not detected")
 // ErrUnrecognizedArch is returned by Arch when the raw architecture string is not a known value.
 var ErrUnrecognizedArch = errors.New("unrecognized architecture")
 
+const (
+	archAmd64 = "amd64"
+	archArm64 = "arm64"
+	archArm   = "arm"
+	arch386   = "386"
+)
+
 // archNormalize maps raw uname -m / PROCESSOR_ARCHITECTURE values to GOARCH
 // strings matching the architecture tokens used in k0s release binaries.
 var archNormalize = map[string]string{
 	// Linux / macOS uname -m outputs
-	"x86_64":   "amd64",
-	"aarch64":  "arm64",
-	"arm64":    "arm64", // macOS Apple Silicon
-	"armv8l":   "arm",
-	"armv7l":   "arm",
-	"armv6l":   "arm",
-	"armv5tel": "arm",
-	"aarch32":  "arm",
-	"arm32":    "arm",
-	"armhfp":   "arm",
-	"arm-32":   "arm",
-	"i386":     "386",
-	"i686":     "386",
+	"x86_64":   archAmd64,
+	"aarch64":  archArm64,
+	"arm64":    archArm64, // macOS Apple Silicon
+	"armv8l":   archArm,
+	"armv7l":   archArm,
+	"armv6l":   archArm,
+	"armv5tel": archArm,
+	"aarch32":  archArm,
+	"arm32":    archArm,
+	"armhfp":   archArm,
+	"arm-32":   archArm,
+	"i386":     arch386,
+	"i686":     arch386,
 	// Windows PROCESSOR_ARCHITECTURE values
-	"AMD64":   "amd64",
-	"X86_64":  "amd64",
-	"ARM64":   "arm64",
-	"AARCH64": "arm64",
-	"x86":     "386",
-	"X86":     "386",
-	"I386":    "386",
+	"AMD64":   archAmd64,
+	"X86_64":  archAmd64,
+	"ARM64":   archArm64,
+	"AARCH64": archArm64,
+	"x86":     arch386,
+	"X86":     arch386,
+	"I386":    arch386,
 }
 
 // Release describes host operating system version information.

--- a/passphrase.go
+++ b/passphrase.go
@@ -10,7 +10,7 @@ import (
 // DefaultPasswordCallback is a default implementation for PasswordCallback.
 func DefaultPasswordCallback() (string, error) {
 	fmt.Print("Enter passphrase: ")
-	pass, err := term.ReadPassword(int(os.Stdin.Fd())) //nolint:gosec // G115: os.Stdin.Fd() always returns valid int
+	pass, err := term.ReadPassword(int(os.Stdin.Fd()))
 	fmt.Println()
 	if err != nil {
 		return "", fmt.Errorf("failed to read password: %w", err)

--- a/powershell/powershell.go
+++ b/powershell/powershell.go
@@ -32,8 +32,8 @@ func CompressedCmd(psCmd string) string {
 	if err != nil {
 		panic(err) // BestCompression level is always valid
 	}
-	_, _ = w.Write([]byte(cmd))   //nolint:errcheck // write to bytes.Buffer never fails
-	_ = w.Close()                  //nolint:errcheck // close on memory buffer never fails
+	_, _ = w.Write([]byte(cmd))
+	_ = w.Close()
 	scriptlet := `$z="` + base64.StdEncoding.EncodeToString(b.Bytes()) + `"
 $d=[Convert]::FromBase64String($z)
 Set-Alias NO New-Object
@@ -67,7 +67,7 @@ func EncodeCmd(psCmd string) string {
 	words := utf16.Encode([]rune(psCmd))
 	buf := make([]byte, len(words)*2)
 	for i, w := range words {
-		buf[i*2] = byte(w)
+		buf[i*2] = byte(w) //nolint:gosec // G115: intentional low-8-bits extraction for little-endian encoding
 		buf[i*2+1] = byte(w >> 8)
 	}
 	return base64.StdEncoding.EncodeToString(buf)
@@ -77,7 +77,7 @@ func EncodeCmd(psCmd string) string {
 // Scripts that contain newlines, double-quotes, or cmd.exe metacharacters
 // are passed via -EncodedCommand to avoid shell expansion; simple one-liners
 // are passed via -Command so they remain readable in logs.
-// cmd.exe metacharacters guarded: " % ! ^ & | < >
+// cmd.exe metacharacters guarded: " % ! ^ & | < >.
 func Cmd(psCmd string) string {
 	if strings.ContainsAny(psCmd, "\n\r\"%!^&|<>") {
 		return "powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -E " + EncodeCmd(psCmd)

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -635,7 +635,7 @@ func (c *Connection) ExecInteractive(cmd string, stdin io.Reader, stdout, stderr
 	var input io.Reader
 
 	if inF, ok := stdin.(*os.File); ok {
-		fd := int(os.Stdin.Fd()) //nolint:gosec // G115: os.Stdin.Fd() always returns valid int
+		fd := int(os.Stdin.Fd())
 		old, err := term.MakeRaw(fd)
 		if err != nil {
 			return fmt.Errorf("make local terminal raw: %w", err)
@@ -718,7 +718,7 @@ func ParseSSHPrivateKey(key []byte, callback PasswordCallback) ([]ssh.AuthMethod
 // DefaultPasswordCallback is a default implementation for PasswordCallback.
 func DefaultPasswordCallback() (string, error) {
 	fmt.Print("Enter passphrase: ")
-	pass, err := term.ReadPassword(int(os.Stdin.Fd())) //nolint:gosec // G115: os.Stdin.Fd() always returns valid int
+	pass, err := term.ReadPassword(int(os.Stdin.Fd()))
 	fmt.Println()
 	if err != nil {
 		return "", fmt.Errorf("failed to read password: %w", err)

--- a/protocol/ssh/signals.go
+++ b/protocol/ssh/signals.go
@@ -50,7 +50,7 @@ func captureSignals(stdin io.Writer, session *ssh.Session) func() {
 
 func termSizeWNCH() []byte {
 	size := make([]byte, 16)
-	fd := int(os.Stdin.Fd()) //nolint:gosec // G115: os.Stdin.Fd() always returns valid int
+	fd := int(os.Stdin.Fd())
 	rows, cols, err := term.GetSize(fd)
 	if err != nil {
 		binary.BigEndian.PutUint32(size, 40)

--- a/sshconfig/keys.go
+++ b/sshconfig/keys.go
@@ -36,6 +36,13 @@ const (
 	// these are here for making the list below easier to read.
 	noTilde = false
 	noEnv   = false
+
+	keyHostCanonical      = "Host"
+	keyMatchCanonical     = "Match"
+	keyIncludeCanonical   = "Include"
+	keyKbdInteractiveAuth = "KbdInteractiveAuthentication"
+	keyMatchLower         = "match"
+	keyIncludeLower       = "include"
 )
 
 var knownKeys = map[string]keyInfo{
@@ -61,9 +68,9 @@ var knownKeys = map[string]keyInfo{
 	"rsaauthentication":       {"", (*Setter).ignore, nil, noTokens, noTilde, noEnv},
 
 	// config structuring keys
-	fkHost:    {"Host", (*Setter).setHost, (*printer).stringer, noTokens, noTilde, noEnv},
-	"match":   {"Match", nil, nil, noTokens, noTilde, noEnv},
-	"include": {"Include", nil, nil, noTokens, noTilde, noEnv},
+	fkHost:          {keyHostCanonical, (*Setter).setHost, (*printer).stringer, noTokens, noTilde, noEnv},
+	keyMatchLower:   {keyMatchCanonical, nil, nil, noTokens, noTilde, noEnv},
+	keyIncludeLower: {keyIncludeCanonical, nil, nil, noTokens, noTilde, noEnv},
 
 	"addkeystoagent":                   {"AddKeysToAgent", (*Setter).setAddKeysToAgentOption, (*printer).stringer, noTokens, noTilde, noEnv},
 	"addressfamily":                    {"AddressFamily", enum("any", "inet", "inet6"), (*printer).stringer, noTokens, noTilde, noEnv},
@@ -115,10 +122,10 @@ var knownKeys = map[string]keyInfo{
 	"identityfile":                     {"IdentityFile", (*Setter).appendPathList, (*printer).stringerslice, tokenset1, true, noEnv},
 	"ignoreunknown":                    {"IgnoreUnknown", (*Setter).setStringSlice, (*printer).stringerslice, noTokens, noTilde, noEnv},
 	"ipqos":                            {"IPQoS", (*Setter).setIPQoSOption, (*printer).stringerslice, noTokens, noTilde, noEnv},
-	"challengeresponseauthentication":  {"KbdInteractiveAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv}, // alias
-	"skeyauthentication":               {"KbdInteractiveAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv}, // alias
-	"tisauthentication":                {"KbdInteractiveAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv}, // alias
-	"kbdinteractiveauthentication":     {"KbdInteractiveAuthentication", (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
+	"challengeresponseauthentication":  {keyKbdInteractiveAuth, (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv}, // alias
+	"skeyauthentication":               {keyKbdInteractiveAuth, (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv}, // alias
+	"tisauthentication":                {keyKbdInteractiveAuth, (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv}, // alias
+	"kbdinteractiveauthentication":     {keyKbdInteractiveAuth, (*Setter).setBool, (*printer).boolean, noTokens, noTilde, noEnv},
 	"kbdinteractivedevices":            {"KbdInteractiveDevices", (*Setter).setStringSliceCSV, (*printer).stringercsv, noTokens, noTilde, noEnv},
 	"kexalgorithms":                    {"KexAlgorithms", preloadedDefaultsSetter(defaultList("KexAlgorithms")), (*printer).stringercsv, noTokens, noTilde, noEnv},
 	"knownhostscommand":                {"KnownHostsCommand", (*Setter).setString, (*printer).stringer, tokenset2, noTilde, noEnv},

--- a/sshconfig/parser.go
+++ b/sshconfig/parser.go
@@ -291,7 +291,7 @@ func (p *Parser) apply(setter *Setter) error {
 		setter.applyingDefaults(path == "__default__")
 
 		switch key {
-		case "include":
+		case keyIncludeLower:
 			// just keep on iterating, the tree parser has already included the file as just another beanch
 			continue
 		case fkHost:
@@ -303,7 +303,7 @@ func (p *Parser) apply(setter *Setter) error {
 				// Not for this host, skip the block.
 				p.iter.Skip()
 			}
-		case "match":
+		case keyMatchLower:
 			match, err := setter.matchesMatch(values...)
 			if err != nil {
 				return fmt.Errorf("can't process Match directive %q in %s:%d: %w", values, path, row, err)

--- a/sshconfig/printer.go
+++ b/sshconfig/printer.go
@@ -66,7 +66,7 @@ func (p *printer) stringify(field reflect.Value) (string, bool) {
 	if field.Kind() == reflect.String {
 		return quote(field.String()), true
 	}
-	if field.Kind() == reflect.Ptr && field.Elem().Kind() == reflect.String {
+	if field.Kind() == reflect.Pointer && field.Elem().Kind() == reflect.String {
 		return quote(field.Elem().String()), true
 	}
 	if field.CanInterface() {
@@ -251,7 +251,7 @@ func (p *printer) dump() string { //nolint:cyclop
 		sb.WriteRune('\n')
 	}
 	for _, key := range keys {
-		if key == "Host" {
+		if key == keyHostCanonical {
 			continue
 		}
 		keyinfo, ok := knownKeys[key]

--- a/sshconfig/set.go
+++ b/sshconfig/set.go
@@ -119,7 +119,7 @@ func (s *Setter) initHost() {
 func getElem(obj any) (reflect.Value, error) {
 	objVal := reflect.ValueOf(obj)
 
-	if objVal.Kind() != reflect.Ptr {
+	if objVal.Kind() != reflect.Pointer {
 		return reflect.Value{}, fmt.Errorf("%w: object is not a pointer", errInvalidObject)
 	}
 
@@ -199,8 +199,8 @@ func (s *Setter) get(key string, expectedKinds ...reflect.Kind) (reflect.Value, 
 		return reflect.Value{}, fmt.Errorf("%w: field %q is not settable", errInvalidObject, key)
 	}
 
-	isPtr := field.Kind() == reflect.Ptr
-	expectsPtr := len(expectedKinds) > 0 && expectedKinds[0] == reflect.Ptr
+	isPtr := field.Kind() == reflect.Pointer
+	expectsPtr := len(expectedKinds) > 0 && expectedKinds[0] == reflect.Pointer
 
 	if isPtr && !expectsPtr {
 		if field.IsNil() {
@@ -283,7 +283,7 @@ func (s *Setter) setBool(key string, values ...string) error {
 	value := reflect.ValueOf(bval)
 	field, err := s.get(key, value.Kind())
 	if err != nil {
-		if field, err := s.get(key, reflect.Ptr, reflect.Bool); err == nil {
+		if field, err := s.get(key, reflect.Pointer, reflect.Bool); err == nil {
 			if !field.IsNil() {
 				return nil
 			}
@@ -323,7 +323,7 @@ func (s *Setter) setInt(key string, values ...string) error {
 	if err != nil {
 		return err
 	}
-	if field.Kind() == reflect.Ptr {
+	if field.Kind() == reflect.Pointer {
 		if !field.IsNil() {
 			return nil
 		}
@@ -367,7 +367,7 @@ func (s *Setter) setUint(key string, values ...string) error {
 	if err != nil {
 		return err
 	}
-	if field.Kind() == reflect.Ptr {
+	if field.Kind() == reflect.Pointer {
 		if !field.IsNil() {
 			return nil
 		}
@@ -406,7 +406,7 @@ func (s *Setter) setDuration(key string, values ...string) error { //nolint:cycl
 		}
 	}
 
-	field, err := s.get(key, reflect.Ptr, reflect.Int64)
+	field, err := s.get(key, reflect.Pointer, reflect.Int64)
 	if err != nil {
 		if f, err := s.get(key, reflect.Int64); err == nil {
 			field = f
@@ -419,7 +419,7 @@ func (s *Setter) setDuration(key string, values ...string) error { //nolint:cycl
 
 	durationType := reflect.TypeFor[time.Duration]()
 	switch {
-	case field.Kind() == reflect.Ptr:
+	case field.Kind() == reflect.Pointer:
 		if field.Type().Elem() != durationType {
 			return fmt.Errorf("%w: field must be a pointer to a duration", errInvalidField)
 		}
@@ -432,7 +432,7 @@ func (s *Setter) setDuration(key string, values ...string) error { //nolint:cycl
 		return nil
 	}
 
-	if field.Kind() == reflect.Ptr {
+	if field.Kind() == reflect.Pointer {
 		durPtr := reflect.New(durationType)
 		durPtr.Elem().Set(reflect.ValueOf(dur))
 		field.Set(durPtr)
@@ -984,7 +984,7 @@ func (s *Setter) Reset(key string) error {
 		return fmt.Errorf("%w: field %q is not found", errFieldNotFound, key)
 	}
 	// Set a pointer to nil and a non-pointer to zero value.
-	if field.Kind() == reflect.Ptr {
+	if field.Kind() == reflect.Pointer {
 		field.Set(reflect.New(field.Type().Elem()))
 	} else {
 		field.Set(reflect.Zero(field.Type()))
@@ -1146,7 +1146,7 @@ func (s *Setter) expandToken(token string) (string, error) { //nolint:cyclop
 		}
 		return username(), nil
 	case "%H":
-		for _, field := range []string{"HostkeyAlias", "Hostname", "Host"} {
+		for _, field := range []string{"HostkeyAlias", "Hostname", keyHostCanonical} {
 			if f, err := s.get(field, reflect.String); err == nil && f.Len() > 0 {
 				return f.String(), nil
 			}
@@ -1239,7 +1239,7 @@ func (s *Setter) ExpandString(key string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("%w: field %q is not found", errFieldNotFound, key)
 	}
-	if field.Kind() == reflect.Ptr {
+	if field.Kind() == reflect.Pointer {
 		if field.IsNil() {
 			return "", fmt.Errorf("%w: field %q is nil", errInvalidField, key)
 		}

--- a/sshconfig/tree.go
+++ b/sshconfig/tree.go
@@ -365,11 +365,11 @@ func (p *treeParser) parseTree(reader io.Reader, root *node, includes map[string
 			continue
 		}
 		switch key {
-		case "host", "match":
+		case "host", keyMatchLower:
 			newNode := newNode(key, values, currNode.Path(), row)
 			root.AddChild(newNode)
 			currNode = newNode
-		case "include":
+		case keyIncludeLower:
 			for _, value := range values {
 				value = filepath.Clean(value)
 				if slices.Contains(strings.Split(value, string(os.PathSeparator)), "..") {


### PR DESCRIPTION
- reflect.Ptr → reflect.Pointer (govet inline, 15 sites in kv and sshconfig)
- Extract repeated string constants for goconst (os/release.go arch strings, sshconfig Host/match/include/KbdInteractiveAuthentication keys)
- Remove stale //nolint:gosec G115 directives on os.Stdin.Fd() conversions (passphrase.go, protocol/ssh/connection.go, protocol/ssh/signals.go)
- Remove stale //nolint:errcheck on gzip w.Close() in powershell.go
- Add sentinel errOddUTF16Length and wrap base64 error in cmd/executor.go decodeUTF16LE (err113, wrapcheck)
- Add //nolint:gosec G115 on intentional uint16→byte truncation in powershell EncodeCmd UTF-16LE encoder
- Fix godot: period at end of metacharacter guard comment
- Fix gci: import/variable group formatting in cmd/executor.go