### PR TITLE
WriteFileAtomic

### DIFF
--- a/remotefs/hostinfo_test.go
+++ b/remotefs/hostinfo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io/fs"
 	"testing"
 	"time"
@@ -608,6 +609,35 @@ func TestPosixCreateTemp(t *testing.T) {
 		f := remotefs.NewPosixFS(mr)
 		_, err := f.CreateTemp("/srv", "rig-")
 		require.Error(t, err)
+	})
+}
+
+func TestWindowsRename(t *testing.T) {
+	const src = `C:\src\file.txt`
+	const dst = `C:\dst\file.txt`
+	// Move-Item uses double-quoted paths, which forces powershell.Cmd into
+	// -EncodedCommand mode. Build the expected command the same way WinFS.Rename does.
+	renameCmd := powershell.Cmd(fmt.Sprintf("Move-Item -Force -LiteralPath %s -Destination %s",
+		powershell.DoubleQuotePath(src), powershell.DoubleQuotePath(dst)))
+
+	t.Run("uses Force and LiteralPath", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandSuccess(rigtest.Equal(renameCmd))
+		f := remotefs.NewWindowsFS(mr)
+		require.NoError(t, f.Rename(src, dst))
+		require.NoError(t, mr.Received(rigtest.Equal(renameCmd)))
+	})
+
+	t.Run("error includes both paths", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("access denied"))
+		f := remotefs.NewWindowsFS(mr)
+		err := f.Rename(src, dst)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), src)
+		require.Contains(t, err.Error(), dst)
 	})
 }
 

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -647,10 +647,10 @@ func (s *WinFS) LongHostname() (string, error) {
 	return out, nil
 }
 
-// Rename renames (moves) oldpath to newpath.
+// Rename renames (moves) oldpath to newpath, overwriting newpath if it exists.
 func (s *WinFS) Rename(oldpath, newpath string) error {
-	if err := s.Exec(fmt.Sprintf("Move-Item -Path %s -Destination %s", ps.DoubleQuotePath(oldpath), ps.DoubleQuotePath(newpath)), cmd.PS()); err != nil {
-		return fmt.Errorf("rename %s: %w", oldpath, err)
+	if err := s.Exec(fmt.Sprintf("Move-Item -Force -LiteralPath %s -Destination %s", ps.DoubleQuotePath(oldpath), ps.DoubleQuotePath(newpath)), cmd.PS()); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", oldpath, newpath, err)
 	}
 	return nil
 }

--- a/remotefs/writefileatomic.go
+++ b/remotefs/writefileatomic.go
@@ -1,0 +1,32 @@
+package remotefs
+
+import (
+	"fmt"
+	"io/fs"
+)
+
+// WriteFileAtomic writes data to path atomically: a temp file is created in the
+// same directory, written with restricted permissions, chmod'd to perm, then
+// renamed into place. Parent directories are created as needed. Cleanup of the
+// temp file is always attempted; if Remove fails the error is ignored.
+func WriteFileAtomic(host OS, path string, data []byte, perm fs.FileMode) error {
+	dir := host.Dir(path)
+	if err := host.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("write-file-atomic %s: %w", path, err)
+	}
+	tmp, err := host.CreateTemp(dir, ".tmp-")
+	if err != nil {
+		return fmt.Errorf("write-file-atomic %s: %w", path, err)
+	}
+	defer func() { _ = host.Remove(tmp) }()
+	if err := host.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write-file-atomic %s: %w", path, err)
+	}
+	if err := host.Chmod(tmp, perm); err != nil {
+		return fmt.Errorf("write-file-atomic %s: %w", path, err)
+	}
+	if err := host.Rename(tmp, path); err != nil {
+		return fmt.Errorf("write-file-atomic %s: %w", path, err)
+	}
+	return nil
+}

--- a/remotefs/writefileatomic_test.go
+++ b/remotefs/writefileatomic_test.go
@@ -1,0 +1,150 @@
+package remotefs_test
+
+import (
+	"errors"
+	"io/fs"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/rig/v2/remotefs"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+// atomicOS is a minimal OS stub for WriteFileAtomic tests.
+// Only the seven methods called by WriteFileAtomic are implemented;
+// everything else panics so a mistaken call surfaces immediately.
+type atomicOS struct {
+	mkdirAllErr    error
+	createTempPath string
+	createTempErr  error
+	writeFileErr   error
+	chmodErr       error
+	renameErr      error
+
+	removedPaths []string
+}
+
+func (o *atomicOS) Dir(p string) string                               { return path.Dir(p) }
+func (o *atomicOS) MkdirAll(_ string, _ fs.FileMode) error            { return o.mkdirAllErr }
+func (o *atomicOS) CreateTemp(_, _ string) (string, error)            { return o.createTempPath, o.createTempErr }
+func (o *atomicOS) WriteFile(_ string, _ []byte, _ fs.FileMode) error { return o.writeFileErr }
+func (o *atomicOS) Chmod(_ string, _ fs.FileMode) error               { return o.chmodErr }
+func (o *atomicOS) Rename(_, _ string) error                          { return o.renameErr }
+func (o *atomicOS) Remove(p string) error                             { o.removedPaths = append(o.removedPaths, p); return nil }
+
+// Unused methods — panic on call so misuse is caught immediately.
+func (o *atomicOS) RemoveAll(_ string) error               { panic("not implemented") }
+func (o *atomicOS) Mkdir(_ string, _ fs.FileMode) error    { panic("not implemented") }
+func (o *atomicOS) MkdirTemp(_, _ string) (string, error)  { panic("not implemented") }
+func (o *atomicOS) FileExist(_ string) bool                { panic("not implemented") }
+func (o *atomicOS) LookPath(_ string) (string, error)      { panic("not implemented") }
+func (o *atomicOS) Join(_ ...string) string                { panic("not implemented") }
+func (o *atomicOS) Chown(_ string, _ string) error         { panic("not implemented") }
+func (o *atomicOS) ChownInt(_ string, _, _ int) error      { panic("not implemented") }
+func (o *atomicOS) ChownTree(_ string, _ string) error     { panic("not implemented") }
+func (o *atomicOS) ChownTreeInt(_ string, _, _ int) error  { panic("not implemented") }
+func (o *atomicOS) Chtimes(_ string, _, _ int64) error     { panic("not implemented") }
+func (o *atomicOS) Touch(_ string, _ ...time.Time) error   { panic("not implemented") }
+func (o *atomicOS) Truncate(_ string, _ int64) error       { panic("not implemented") }
+func (o *atomicOS) Getenv(_ string) string                 { panic("not implemented") }
+func (o *atomicOS) FileContains(_, _ string) (bool, error) { panic("not implemented") }
+func (o *atomicOS) IsContainer() (bool, error)             { panic("not implemented") }
+func (o *atomicOS) Hostname() (string, error)              { panic("not implemented") }
+func (o *atomicOS) LongHostname() (string, error)          { panic("not implemented") }
+func (o *atomicOS) MachineID() (string, error)             { panic("not implemented") }
+func (o *atomicOS) SystemTime() (time.Time, error)         { panic("not implemented") }
+func (o *atomicOS) TempDir() string                        { panic("not implemented") }
+func (o *atomicOS) UserCacheDir() string                   { panic("not implemented") }
+func (o *atomicOS) UserConfigDir() string                  { panic("not implemented") }
+func (o *atomicOS) UserHomeDir() string                    { panic("not implemented") }
+func (o *atomicOS) Base(_ string) string                   { panic("not implemented") }
+func (o *atomicOS) CommandExist(_ string) bool             { panic("not implemented") }
+
+// Compile-time check that atomicOS satisfies remotefs.OS.
+var _ remotefs.OS = (*atomicOS)(nil)
+
+func TestWriteFileAtomic(t *testing.T) {
+	const target = "/srv/k0s"
+	const tmp = "/srv/.tmp-abc123"
+	data := []byte("binary content")
+
+	t.Run("success", func(t *testing.T) {
+		o := &atomicOS{createTempPath: tmp}
+		err := remotefs.WriteFileAtomic(o, target, data, 0o755)
+		require.NoError(t, err)
+		// After a successful rename the temp path no longer exists; Remove is
+		// still called by defer but the error is ignored.
+		require.Contains(t, o.removedPaths, tmp, "deferred Remove must be called")
+	})
+
+	t.Run("write failure cleans up temp", func(t *testing.T) {
+		o := &atomicOS{
+			createTempPath: tmp,
+			writeFileErr:   errors.New("no space left on device"),
+		}
+		err := remotefs.WriteFileAtomic(o, target, data, 0o755)
+		require.Error(t, err)
+		require.Contains(t, o.removedPaths, tmp, "temp file must be removed after write failure")
+	})
+
+	t.Run("chmod failure cleans up temp", func(t *testing.T) {
+		o := &atomicOS{
+			createTempPath: tmp,
+			chmodErr:       errors.New("operation not permitted"),
+		}
+		err := remotefs.WriteFileAtomic(o, target, data, 0o755)
+		require.Error(t, err)
+		require.Contains(t, o.removedPaths, tmp, "temp file must be removed after chmod failure")
+	})
+
+	t.Run("rename failure cleans up temp", func(t *testing.T) {
+		o := &atomicOS{
+			createTempPath: tmp,
+			renameErr:      errors.New("cross-device link"),
+		}
+		err := remotefs.WriteFileAtomic(o, target, data, 0o755)
+		require.Error(t, err)
+		require.Contains(t, o.removedPaths, tmp, "temp file must be removed after rename failure")
+	})
+
+	t.Run("mkdirall failure propagates", func(t *testing.T) {
+		o := &atomicOS{mkdirAllErr: errors.New("permission denied")}
+		err := remotefs.WriteFileAtomic(o, target, data, 0o755)
+		require.Error(t, err)
+		require.Empty(t, o.removedPaths, "no temp file created, nothing to remove")
+	})
+
+	t.Run("createtemp failure propagates", func(t *testing.T) {
+		o := &atomicOS{createTempErr: errors.New("no space left on device")}
+		err := remotefs.WriteFileAtomic(o, target, data, 0o755)
+		require.Error(t, err)
+		require.Empty(t, o.removedPaths)
+	})
+}
+
+// TestWriteFileAtomicPosix verifies WriteFileAtomic works end-to-end via PosixFS.
+func TestWriteFileAtomicPosix(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	// initStat probe
+	mr.AddCommandOutput(rigtest.Equal("stat --help 2>&1"), "Usage: stat --format=FORMAT")
+	// MkdirAll: Stat probe returns empty (dir not found), then install -d
+	mr.AddCommandSuccess(rigtest.Contains("stat -c"))
+	mr.AddCommandSuccess(rigtest.Contains("install -d"))
+	// CreateTemp
+	mr.AddCommandOutput(rigtest.Contains("mktemp"), "/srv/.tmp-abc123")
+	// WriteFile via install + stdin
+	mr.AddCommandSuccess(rigtest.Contains("install"))
+	// Chmod
+	mr.AddCommandSuccess(rigtest.Contains("chmod"))
+	// Rename
+	mr.AddCommandSuccess(rigtest.Contains("mv -f"))
+
+	f := remotefs.NewPosixFS(mr)
+	err := remotefs.WriteFileAtomic(f, "/srv/k0s", []byte("binary"), 0o755)
+	require.NoError(t, err)
+	require.NoError(t, mr.Received(rigtest.Contains("mktemp")))
+	require.NoError(t, mr.Received(rigtest.Contains("chmod")))
+	require.NoError(t, mr.Received(rigtest.Contains("mv -f")))
+}


### PR DESCRIPTION
Add WriteFileAtomic and fix WinFS.Rename

Add remotefs.WriteFileAtomic, a package-level function that writes data
to a path atomically via a temp-then-rename sequence: creates a temp
file in the same directory, writes with restricted permissions (0o600),
chmod's to the final perm, then renames into place. Parent directories
are created as needed. Deferred Remove cleans up the temp file on any
failure before the rename.

Also fix WinFS.Rename: add -Force to Move-Item so it overwrites an
existing destination (matching POSIX mv -f semantics), and fix the
error format string to include newpath.

Part of the rig v2 last mile effort, breaking API is not a problem as rig v2 has not been released yet.