### PR TITLE
Add PatchFile: line-oriented file patching on remote filesystems

### DIFF
--- a/remotefs/patchfile.go
+++ b/remotefs/patchfile.go
@@ -229,7 +229,7 @@ type patchOptions struct {
 func WithCreate(perm fs.FileMode) PatchOption {
 	return func(o *patchOptions) {
 		o.create = true
-		o.perm = perm
+		o.perm = perm.Perm() // strip any type or special bits
 	}
 }
 
@@ -254,7 +254,14 @@ func statAndRead(fsys FS, path string, opts *patchOptions) (fs.FileMode, []byte,
 		if err != nil {
 			return 0, nil, fmt.Errorf("patch-file %s: %w", path, err)
 		}
-		return info.Mode().Perm(), content, nil
+		perm := info.Mode().Perm()
+		if info.Mode().Type() == fs.ModeSymlink {
+			// BSD stat reports symlink permissions as 0o777, which are
+			// meaningless. Use a safe private default; on GNU/Linux stat
+			// follows the link so this branch is never reached.
+			perm = 0o600
+		}
+		return perm, content, nil
 	case errors.Is(statErr, fs.ErrNotExist):
 		if !opts.create {
 			return 0, nil, fmt.Errorf("patch-file %s: %w", path, statErr)
@@ -273,7 +280,10 @@ func statAndRead(fsys FS, path string, opts *patchOptions) (fs.FileMode, []byte,
 // rejected with ErrNotRegularFile.
 //
 // If path is a symlink, the link itself is replaced by the rewritten file; the
-// symlink target is not modified.
+// symlink target is not modified. On platforms where stat follows symlinks (GNU
+// Linux), the target's permission bits are preserved. On platforms where stat
+// reports the link itself (BSD), symlink permissions are meaningless (0o777), so
+// the replacement file is created with 0o600 instead.
 //
 // CRLF handling: if the original file contains any CR+LF sequence, the entire
 // output is written with CR+LF line endings. Files with mixed line endings are

--- a/remotefs/patchfile.go
+++ b/remotefs/patchfile.go
@@ -1,0 +1,344 @@
+package remotefs
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+var (
+	// ErrNilPatch is returned by PatchFile when a Patch with a nil apply function is encountered.
+	ErrNilPatch = errors.New("patch has nil apply function")
+	// ErrInvalidMatch is returned when a zero-value LineMatch (no matcher function set) is used.
+	ErrInvalidMatch = errors.New("invalid line match: use ByPrefix, ByExact, ByContains, or ByRegex")
+	// ErrMultilinePatch is returned by patch constructors when the line argument contains newline characters.
+	ErrMultilinePatch = errors.New("patch line contains newline characters")
+	// ErrNotRegularFile is returned by PatchFile when the target path is not a regular file.
+	ErrNotRegularFile = errors.New("not a regular file")
+)
+
+// LineMatch matches a single text line. It is created by ByPrefix, ByExact,
+// ByContains, or ByRegex and consumed by Patch constructors.
+type LineMatch struct {
+	fn  func(string) bool
+	err error
+}
+
+// ByPrefix returns a LineMatch that matches lines beginning with s.
+func ByPrefix(s string) LineMatch {
+	return LineMatch{fn: func(line string) bool { return strings.HasPrefix(line, s) }}
+}
+
+// ByExact returns a LineMatch that matches lines equal to s.
+func ByExact(s string) LineMatch {
+	return LineMatch{fn: func(line string) bool { return line == s }}
+}
+
+// ByContains returns a LineMatch that matches lines containing s.
+func ByContains(s string) LineMatch {
+	return LineMatch{fn: func(line string) bool { return strings.Contains(line, s) }}
+}
+
+// ByRegex returns a LineMatch that matches lines matching pattern.
+// If pattern fails to compile, the error surfaces when the Patch is applied in PatchFile.
+func ByRegex(pattern string) LineMatch {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return LineMatch{err: fmt.Errorf("invalid regex %q: %w", pattern, err)}
+	}
+	return LineMatch{fn: re.MatchString}
+}
+
+// checkMatch validates that a LineMatch was created by one of the constructors.
+// A zero-value LineMatch (both fn and err nil) is rejected with ErrInvalidMatch.
+func checkMatch(match LineMatch) error {
+	if match.err != nil {
+		return match.err
+	}
+	if match.fn == nil {
+		return ErrInvalidMatch
+	}
+	return nil
+}
+
+// checkLine rejects line values containing newline characters, which would
+// corrupt the line-oriented structure of the patched file.
+func checkLine(line string) error {
+	if strings.ContainsAny(line, "\r\n") {
+		return fmt.Errorf("%w: %q", ErrMultilinePatch, line)
+	}
+	return nil
+}
+
+// Patch is a single file-editing operation that transforms a slice of lines.
+// Construct patches with ReplaceOrAppend, DeleteMatching, AppendIfMissing,
+// InsertAfter, InsertBefore, or Transform.
+type Patch struct {
+	apply func(lines []string) ([]string, error)
+	err   error
+}
+
+// ReplaceOrAppend replaces the first line matching match with line,
+// or appends line if no existing line matches.
+func ReplaceOrAppend(match LineMatch, line string) Patch {
+	if err := checkMatch(match); err != nil {
+		return Patch{err: err}
+	}
+	if err := checkLine(line); err != nil {
+		return Patch{err: err}
+	}
+	return Patch{apply: func(lines []string) ([]string, error) {
+		for i, l := range lines {
+			if match.fn(l) {
+				lines[i] = line
+				return lines, nil
+			}
+		}
+		return append(lines, line), nil
+	}}
+}
+
+// DeleteMatching removes all lines matching match.
+func DeleteMatching(match LineMatch) Patch {
+	if err := checkMatch(match); err != nil {
+		return Patch{err: err}
+	}
+	return Patch{apply: func(lines []string) ([]string, error) {
+		result := lines[:0]
+		for _, l := range lines {
+			if !match.fn(l) {
+				result = append(result, l)
+			}
+		}
+		return result, nil
+	}}
+}
+
+// AppendIfMissing appends line if no existing line is exactly equal to it.
+func AppendIfMissing(line string) Patch {
+	if err := checkLine(line); err != nil {
+		return Patch{err: err}
+	}
+	return Patch{apply: func(lines []string) ([]string, error) {
+		if slices.Contains(lines, line) {
+			return lines, nil
+		}
+		return append(lines, line), nil
+	}}
+}
+
+// InsertAfter inserts line after the first line matching match.
+// If no line matches, the file is left unchanged.
+func InsertAfter(match LineMatch, line string) Patch {
+	if err := checkMatch(match); err != nil {
+		return Patch{err: err}
+	}
+	if err := checkLine(line); err != nil {
+		return Patch{err: err}
+	}
+	return Patch{apply: func(lines []string) ([]string, error) {
+		for i, l := range lines {
+			if match.fn(l) {
+				result := make([]string, 0, len(lines)+1)
+				result = append(result, lines[:i+1]...)
+				result = append(result, line)
+				result = append(result, lines[i+1:]...)
+				return result, nil
+			}
+		}
+		return lines, nil
+	}}
+}
+
+// InsertBefore inserts line before the first line matching match.
+// If no line matches, the file is left unchanged.
+func InsertBefore(match LineMatch, line string) Patch {
+	if err := checkMatch(match); err != nil {
+		return Patch{err: err}
+	}
+	if err := checkLine(line); err != nil {
+		return Patch{err: err}
+	}
+	return Patch{apply: func(lines []string) ([]string, error) {
+		for i, l := range lines {
+			if match.fn(l) {
+				result := make([]string, 0, len(lines)+1)
+				result = append(result, lines[:i]...)
+				result = append(result, line)
+				result = append(result, lines[i:]...)
+				return result, nil
+			}
+		}
+		return lines, nil
+	}}
+}
+
+// Transform applies fn to the full slice of lines and is an escape hatch for
+// cases that do not fit the structured patch constructors.
+func Transform(fn func(lines []string) ([]string, error)) Patch {
+	return Patch{apply: fn}
+}
+
+// applyPatches runs each patch in sequence and returns the resulting lines.
+func applyPatches(patches []Patch, lines []string) ([]string, error) {
+	for _, p := range patches {
+		if p.err != nil {
+			return nil, p.err
+		}
+		if p.apply == nil {
+			return nil, ErrNilPatch
+		}
+		var err error
+		lines, err = p.apply(lines)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return lines, nil
+}
+
+// buildOutput reconstructs the file bytes from lines, restoring the original
+// trailing-newline status and CRLF encoding.
+func buildOutput(lines []string, hadTrailingNewline bool, crlf bool) []byte {
+	out := strings.Join(lines, "\n")
+	if hadTrailingNewline && len(lines) > 0 {
+		out += "\n"
+	}
+	outBytes := []byte(out)
+	if crlf {
+		outBytes = bytes.ReplaceAll(outBytes, []byte("\n"), []byte("\r\n"))
+	}
+	return outBytes
+}
+
+// PatchOption is a functional option for PatchFile.
+type PatchOption func(*patchOptions)
+
+type patchOptions struct {
+	create bool
+	perm   fs.FileMode
+}
+
+// WithCreate causes PatchFile to create the file with the given permissions if
+// it does not already exist. Without this option, PatchFile returns an error when
+// the target file is missing.
+func WithCreate(perm fs.FileMode) PatchOption {
+	return func(o *patchOptions) {
+		o.create = true
+		o.perm = perm
+	}
+}
+
+// statAndRead returns the file's permission bits and content. When the file does
+// not exist and opts.create is set, it returns the create permission and nil
+// content. In all other error cases it returns a wrapped error.
+//
+// Only the lower 9 permission bits (rwxrwxrwx) are returned; setuid, setgid,
+// and sticky bits are not preserved by PatchFile.
+func statAndRead(fsys FS, path string, opts *patchOptions) (fs.FileMode, []byte, error) {
+	info, statErr := fsys.Stat(path)
+	switch {
+	case statErr == nil:
+		// Allow regular files and symlinks; reject directories, FIFOs, devices, etc.
+		// Symlinks are allowed because stat(2) may report ModeSymlink on BSD
+		// (which does not follow links by default), while the subsequent ReadFile
+		// and WriteFileAtomic still operate on the link target or replace the link.
+		if typ := info.Mode().Type(); typ != 0 && typ != fs.ModeSymlink {
+			return 0, nil, fmt.Errorf("patch-file %s: %w", path, ErrNotRegularFile)
+		}
+		content, err := fsys.ReadFile(path)
+		if err != nil {
+			return 0, nil, fmt.Errorf("patch-file %s: %w", path, err)
+		}
+		return info.Mode().Perm(), content, nil
+	case errors.Is(statErr, fs.ErrNotExist):
+		if !opts.create {
+			return 0, nil, fmt.Errorf("patch-file %s: %w", path, statErr)
+		}
+		return opts.perm, nil, nil
+	default:
+		return 0, nil, fmt.Errorf("patch-file %s: %w", path, statErr)
+	}
+}
+
+// PatchFile reads path, applies each patch in sequence, and writes the result
+// back atomically via WriteFileAtomic. Existing permission bits (rwxrwxrwx) are
+// preserved; setuid, setgid, and sticky bits are not. If the file does not exist
+// and WithCreate is provided, the file is created with the given mode; otherwise
+// ErrNotExist is returned. Non-regular files (directories, FIFOs, devices) are
+// rejected with ErrNotRegularFile.
+//
+// If path is a symlink, the link itself is replaced by the rewritten file; the
+// symlink target is not modified.
+//
+// CRLF handling: if the original file contains any CR+LF sequence, the entire
+// output is written with CR+LF line endings. Files with mixed line endings are
+// fully normalised to CRLF. Bare CR bytes (old Mac-style) are not treated as
+// line endings and are left as-is. Otherwise LF is used throughout.
+//
+// The trailing newline status of the original file is preserved: files that end
+// with a newline will continue to do so; files that do not will not gain one.
+// New files created via WithCreate get a trailing newline when the output is
+// non-empty; an empty result (or an existing empty file) produces an empty file.
+//
+// Because WriteFileAtomic replaces the original inode via a temp-file rename,
+// only permission bits are restored. Owner, group, ACLs, extended attributes,
+// hard links, and timestamps of the original file are not preserved.
+//
+// PatchFile performs a read-then-write cycle without inter-process locking. A
+// concurrent writer between the read and the rename will have its changes
+// silently overwritten by the atomic rename.
+//
+// If the patches produce output identical to the original content, WriteFileAtomic
+// is skipped and the file (including any symlink) is left untouched.
+func PatchFile(fsys FS, path string, patches []Patch, opts ...PatchOption) error {
+	options := &patchOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	perm, content, err := statAndRead(fsys, path, options)
+	if err != nil {
+		return err
+	}
+
+	// Detect and normalise CRLF so all patch logic operates on LF-only lines.
+	crlf := bytes.Contains(content, []byte("\r\n"))
+	text := string(bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n")))
+
+	// Preserve the trailing newline status of the original. A nil content slice
+	// means the file does not yet exist (WithCreate path) and is treated as
+	// having a trailing newline so the first write is properly terminated.
+	// An existing empty file (non-nil, zero-length) is not treated as having a
+	// trailing newline; its status is determined by the content, which has none.
+	hadTrailingNewline := content == nil || strings.HasSuffix(text, "\n")
+
+	// Split on newlines; strip one trailing newline to avoid a ghost empty line.
+	var lines []string
+	if text != "" {
+		lines = strings.Split(strings.TrimSuffix(text, "\n"), "\n")
+	}
+
+	lines, err = applyPatches(patches, lines)
+	if err != nil {
+		return fmt.Errorf("patch-file %s: %w", path, err)
+	}
+
+	outBytes := buildOutput(lines, hadTrailingNewline, crlf)
+
+	// Skip the write when the patches produced no change. The nil check is
+	// required because bytes.Equal(nil, []byte{}) is true: without it, a new
+	// file (content==nil) whose patches yield empty output would never be created.
+	if content != nil && bytes.Equal(outBytes, content) {
+		return nil
+	}
+
+	if err := WriteFileAtomic(fsys, path, outBytes, perm); err != nil {
+		return fmt.Errorf("patch-file %s: %w", path, err)
+	}
+	return nil
+}

--- a/remotefs/patchfile_test.go
+++ b/remotefs/patchfile_test.go
@@ -287,6 +287,15 @@ func TestPatchFileWithCreate(t *testing.T) {
 		require.Equal(t, fs.FileMode(0o600), f.writtenPerm)
 	})
 
+	t.Run("strips type bits from WithCreate perm", func(t *testing.T) {
+		f := &patchFS{statErr: &fs.PathError{Op: "stat", Path: "/new", Err: fs.ErrNotExist}}
+		err := remotefs.PatchFile(f, "/new", []remotefs.Patch{
+			remotefs.AppendIfMissing("hello"),
+		}, remotefs.WithCreate(fs.ModeDir|0o755))
+		require.NoError(t, err)
+		require.Equal(t, fs.FileMode(0o755), f.writtenPerm, "type bits must be stripped from WithCreate perm")
+	})
+
 	t.Run("errors when missing without WithCreate", func(t *testing.T) {
 		f := &patchFS{statErr: &fs.PathError{Op: "stat", Path: "/new", Err: fs.ErrNotExist}}
 		err := remotefs.PatchFile(f, "/new", []remotefs.Patch{
@@ -400,17 +409,19 @@ func TestPatchFileNotRegularFile(t *testing.T) {
 }
 
 func TestPatchFileSymlinkAllowed(t *testing.T) {
-	// Symlinks must not be rejected by the IsRegular check. BSD stat reports
-	// ModeSymlink for symlinks; PatchFile should still proceed.
+	// Symlinks must not be rejected by the type check. BSD stat reports
+	// ModeSymlink | 0o777 for symlinks; PatchFile should proceed but must use
+	// 0o600 instead of the meaningless 0o777 symlink permission.
 	f := &patchFS{
 		content:  []byte("FOO=old\n"),
-		statMode: fs.ModeSymlink | 0o644,
+		statMode: fs.ModeSymlink | 0o777,
 	}
 	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
 		remotefs.ReplaceOrAppend(remotefs.ByPrefix("FOO="), "FOO=new"),
 	})
 	require.NoError(t, err)
 	require.Equal(t, "FOO=new\n", f.writtenStr())
+	require.Equal(t, fs.FileMode(0o600), f.writtenPerm, "symlink perm 0o777 must be replaced with safe 0o600")
 }
 
 func TestPatchFileNoWriteOnIdenticalContent(t *testing.T) {

--- a/remotefs/patchfile_test.go
+++ b/remotefs/patchfile_test.go
@@ -1,0 +1,473 @@
+package remotefs_test
+
+import (
+	"errors"
+	"io/fs"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/rig/v2/remotefs"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+// patchFS is a minimal FS stub for PatchFile tests. The methods called by
+// PatchFile and WriteFileAtomic are implemented; everything else panics.
+type patchFS struct {
+	content  []byte
+	statErr  error
+	statMode fs.FileMode
+
+	written      []byte
+	writtenPerm  fs.FileMode
+	writeCalled  bool
+}
+
+func (f *patchFS) Stat(_ string) (fs.FileInfo, error) {
+	if f.statErr != nil {
+		return nil, f.statErr
+	}
+	return &patchFileInfo{mode: f.statMode}, nil
+}
+
+func (f *patchFS) ReadFile(_ string) ([]byte, error) {
+	return f.content, nil
+}
+
+// WriteFileAtomic delegates to these OS methods:
+func (f *patchFS) Dir(p string) string                             { return path.Dir(p) }
+func (f *patchFS) MkdirAll(_ string, _ fs.FileMode) error         { return nil }
+func (f *patchFS) CreateTemp(dir, _ string) (string, error)       { return dir + "/.tmp-test", nil }
+func (f *patchFS) WriteFile(_ string, data []byte, _ fs.FileMode) error {
+	f.written = data
+	f.writeCalled = true
+	return nil
+}
+func (f *patchFS) Chmod(_ string, mode fs.FileMode) error { f.writtenPerm = mode; return nil }
+func (f *patchFS) Rename(_, _ string) error               { return nil }
+func (f *patchFS) Remove(_ string) error                  { return nil }
+
+// Unused FS methods — panic on call so any unexpected usage is caught immediately.
+func (f *patchFS) Open(_ string) (fs.File, error)                          { panic("not implemented") }
+func (f *patchFS) ReadDir(_ string) ([]fs.DirEntry, error)                 { panic("not implemented") }
+func (f *patchFS) OpenFile(_ string, _ int, _ fs.FileMode) (remotefs.File, error) {
+	panic("not implemented")
+}
+func (f *patchFS) Sha256(_ string) (string, error)                         { panic("not implemented") }
+func (f *patchFS) DownloadURL(_, _ string) error                           { panic("not implemented") }
+func (f *patchFS) RoundTrip(_ *http.Request) (*http.Response, error)       { panic("not implemented") }
+func (f *patchFS) RemoveAll(_ string) error                                { panic("not implemented") }
+func (f *patchFS) Mkdir(_ string, _ fs.FileMode) error                     { panic("not implemented") }
+func (f *patchFS) MkdirTemp(_, _ string) (string, error)                   { panic("not implemented") }
+func (f *patchFS) FileExist(_ string) bool                                 { panic("not implemented") }
+func (f *patchFS) LookPath(_ string) (string, error)                       { panic("not implemented") }
+func (f *patchFS) Join(_ ...string) string                                 { panic("not implemented") }
+func (f *patchFS) Chown(_ string, _ string) error                          { panic("not implemented") }
+func (f *patchFS) ChownInt(_ string, _, _ int) error                       { panic("not implemented") }
+func (f *patchFS) ChownTree(_ string, _ string) error                      { panic("not implemented") }
+func (f *patchFS) ChownTreeInt(_ string, _, _ int) error                   { panic("not implemented") }
+func (f *patchFS) Chtimes(_ string, _, _ int64) error                      { panic("not implemented") }
+func (f *patchFS) Touch(_ string, _ ...time.Time) error                    { panic("not implemented") }
+func (f *patchFS) Truncate(_ string, _ int64) error                        { panic("not implemented") }
+func (f *patchFS) Getenv(_ string) string                                  { panic("not implemented") }
+func (f *patchFS) FileContains(_, _ string) (bool, error)                  { panic("not implemented") }
+func (f *patchFS) IsContainer() (bool, error)                              { panic("not implemented") }
+func (f *patchFS) Hostname() (string, error)                               { panic("not implemented") }
+func (f *patchFS) LongHostname() (string, error)                           { panic("not implemented") }
+func (f *patchFS) MachineID() (string, error)                              { panic("not implemented") }
+func (f *patchFS) SystemTime() (time.Time, error)                          { panic("not implemented") }
+func (f *patchFS) TempDir() string                                         { panic("not implemented") }
+func (f *patchFS) UserCacheDir() string                                    { panic("not implemented") }
+func (f *patchFS) UserConfigDir() string                                   { panic("not implemented") }
+func (f *patchFS) UserHomeDir() string                                     { panic("not implemented") }
+func (f *patchFS) Base(_ string) string                                    { panic("not implemented") }
+func (f *patchFS) CommandExist(_ string) bool                              { panic("not implemented") }
+
+var _ remotefs.FS = (*patchFS)(nil)
+
+// patchFileInfo is a minimal fs.FileInfo stub.
+type patchFileInfo struct{ mode fs.FileMode }
+
+func (i *patchFileInfo) Name() string      { return "stub" }
+func (i *patchFileInfo) Size() int64       { return 0 }
+func (i *patchFileInfo) Mode() fs.FileMode { return i.mode }
+func (i *patchFileInfo) ModTime() time.Time { return time.Time{} }
+func (i *patchFileInfo) IsDir() bool       { return false }
+func (i *patchFileInfo) Sys() any          { return nil }
+
+func newPatchFS(content string) *patchFS {
+	return &patchFS{content: []byte(content), statMode: 0o644}
+}
+
+// writtenStr returns what PatchFile wrote, as a string.
+func (f *patchFS) writtenStr() string { return string(f.written) }
+
+// wasWritten reports whether WriteFileAtomic was called (i.e. the file was changed).
+func (f *patchFS) wasWritten() bool { return f.writeCalled }
+
+func TestPatchFileReplaceOrAppend(t *testing.T) {
+	t.Run("replaces first matching line", func(t *testing.T) {
+		f := newPatchFS("FOO=old\nBAR=keep\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.ReplaceOrAppend(remotefs.ByPrefix("FOO="), "FOO=new"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "FOO=new\nBAR=keep\n", f.writtenStr())
+	})
+
+	t.Run("appends when no line matches", func(t *testing.T) {
+		f := newPatchFS("BAR=keep\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.ReplaceOrAppend(remotefs.ByPrefix("FOO="), "FOO=new"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "BAR=keep\nFOO=new\n", f.writtenStr())
+	})
+
+	t.Run("appends to empty file", func(t *testing.T) {
+		// An existing empty file has no trailing newline, so neither does the output.
+		f := newPatchFS("")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.ReplaceOrAppend(remotefs.ByPrefix("FOO="), "FOO=new"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "FOO=new", f.writtenStr())
+	})
+}
+
+func TestPatchFileDeleteMatching(t *testing.T) {
+	t.Run("removes matching lines", func(t *testing.T) {
+		f := newPatchFS("keep\ndelete-me\nalso-delete\nkeep-too\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.DeleteMatching(remotefs.ByContains("delete")),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "keep\nkeep-too\n", f.writtenStr())
+	})
+
+	t.Run("no-op when no lines match", func(t *testing.T) {
+		f := newPatchFS("keep\nkeep-too\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.DeleteMatching(remotefs.ByContains("delete")),
+		})
+		require.NoError(t, err)
+		require.False(t, f.wasWritten(), "no-op patch should not write the file")
+	})
+}
+
+func TestPatchFileAppendIfMissing(t *testing.T) {
+	t.Run("appends when line is absent", func(t *testing.T) {
+		f := newPatchFS("existing\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.AppendIfMissing("newline"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "existing\nnewline\n", f.writtenStr())
+	})
+
+	t.Run("no-op when line is already present", func(t *testing.T) {
+		f := newPatchFS("existing\nnewline\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.AppendIfMissing("newline"),
+		})
+		require.NoError(t, err)
+		require.False(t, f.wasWritten(), "no-op patch should not write the file")
+	})
+}
+
+func TestPatchFileInsertAfter(t *testing.T) {
+	t.Run("inserts after matching line", func(t *testing.T) {
+		f := newPatchFS("line1\nanchor\nline3\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.InsertAfter(remotefs.ByExact("anchor"), "inserted"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "line1\nanchor\ninserted\nline3\n", f.writtenStr())
+	})
+
+	t.Run("no-op when no line matches", func(t *testing.T) {
+		f := newPatchFS("line1\nline2\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.InsertAfter(remotefs.ByExact("anchor"), "inserted"),
+		})
+		require.NoError(t, err)
+		require.False(t, f.wasWritten(), "no-op patch should not write the file")
+	})
+
+	t.Run("inserts after last line", func(t *testing.T) {
+		f := newPatchFS("line1\nanchor\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.InsertAfter(remotefs.ByExact("anchor"), "inserted"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "line1\nanchor\ninserted\n", f.writtenStr())
+	})
+}
+
+func TestPatchFileInsertBefore(t *testing.T) {
+	t.Run("inserts before matching line", func(t *testing.T) {
+		f := newPatchFS("line1\nanchor\nline3\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.InsertBefore(remotefs.ByExact("anchor"), "inserted"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "line1\ninserted\nanchor\nline3\n", f.writtenStr())
+	})
+
+	t.Run("no-op when no line matches", func(t *testing.T) {
+		f := newPatchFS("line1\nline2\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.InsertBefore(remotefs.ByExact("anchor"), "inserted"),
+		})
+		require.NoError(t, err)
+		require.False(t, f.wasWritten(), "no-op patch should not write the file")
+	})
+
+	t.Run("inserts before first line", func(t *testing.T) {
+		f := newPatchFS("anchor\nline2\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.InsertBefore(remotefs.ByExact("anchor"), "inserted"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "inserted\nanchor\nline2\n", f.writtenStr())
+	})
+}
+
+func TestPatchFileTransform(t *testing.T) {
+	f := newPatchFS("a\nb\nc\n")
+	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+		remotefs.Transform(func(lines []string) ([]string, error) {
+			return []string{"x", "y"}, nil
+		}),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "x\ny\n", f.writtenStr())
+}
+
+func TestPatchFileMultiplePatches(t *testing.T) {
+	f := newPatchFS("FOO=old\nBAR=keep\nDELETE_ME=1\n")
+	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+		remotefs.ReplaceOrAppend(remotefs.ByPrefix("FOO="), "FOO=new"),
+		remotefs.DeleteMatching(remotefs.ByPrefix("DELETE_ME=")),
+		remotefs.AppendIfMissing("BAZ=added"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "FOO=new\nBAR=keep\nBAZ=added\n", f.writtenStr())
+}
+
+func TestPatchFileCRLF(t *testing.T) {
+	f := newPatchFS("line1\r\nline2\r\n")
+	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+		remotefs.ReplaceOrAppend(remotefs.ByExact("line1"), "LINE1"),
+	})
+	require.NoError(t, err)
+	// CRLF must be preserved in the output.
+	require.Equal(t, "LINE1\r\nline2\r\n", f.writtenStr())
+}
+
+func TestPatchFilePreservesPermissions(t *testing.T) {
+	f := &patchFS{content: []byte("line\n"), statMode: 0o755}
+	err := remotefs.PatchFile(f, "/etc/script", []remotefs.Patch{
+		remotefs.AppendIfMissing("extra"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, fs.FileMode(0o755), f.writtenPerm)
+}
+
+func TestPatchFileWithCreate(t *testing.T) {
+	t.Run("creates file when missing", func(t *testing.T) {
+		f := &patchFS{statErr: &fs.PathError{Op: "stat", Path: "/new", Err: fs.ErrNotExist}}
+		err := remotefs.PatchFile(f, "/new", []remotefs.Patch{
+			remotefs.AppendIfMissing("hello"),
+		}, remotefs.WithCreate(0o600))
+		require.NoError(t, err)
+		require.Equal(t, "hello\n", f.writtenStr())
+		require.Equal(t, fs.FileMode(0o600), f.writtenPerm)
+	})
+
+	t.Run("errors when missing without WithCreate", func(t *testing.T) {
+		f := &patchFS{statErr: &fs.PathError{Op: "stat", Path: "/new", Err: fs.ErrNotExist}}
+		err := remotefs.PatchFile(f, "/new", []remotefs.Patch{
+			remotefs.AppendIfMissing("hello"),
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, fs.ErrNotExist)
+	})
+}
+
+func TestPatchFileByRegex(t *testing.T) {
+	t.Run("matches by regex", func(t *testing.T) {
+		f := newPatchFS("foo=123\nbar=456\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.ReplaceOrAppend(remotefs.ByRegex(`^foo=\d+$`), "foo=999"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "foo=999\nbar=456\n", f.writtenStr())
+	})
+
+	t.Run("invalid regex surfaces as error", func(t *testing.T) {
+		f := newPatchFS("foo=123\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.ReplaceOrAppend(remotefs.ByRegex(`[invalid`), "foo=999"),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid regex")
+	})
+}
+
+func TestPatchFileTrailingNewline(t *testing.T) {
+	t.Run("preserves absence of trailing newline", func(t *testing.T) {
+		f := newPatchFS("line1\nline2")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.AppendIfMissing("line3"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "line1\nline2\nline3", f.writtenStr())
+	})
+
+	t.Run("preserves trailing newline when present", func(t *testing.T) {
+		f := newPatchFS("line1\nline2\n")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.AppendIfMissing("line3"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "line1\nline2\nline3\n", f.writtenStr())
+	})
+
+	t.Run("existing empty file does not gain trailing newline", func(t *testing.T) {
+		// An existing empty file is not treated as having a trailing newline;
+		// only new files (via WithCreate) get one.
+		f := newPatchFS("") // existing empty file, content = []byte{}
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.AppendIfMissing("hello"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "hello", f.writtenStr())
+	})
+
+	t.Run("no-op patches do not add trailing newline", func(t *testing.T) {
+		// A file without a trailing newline where the patch makes no change
+		// must not gain a trailing newline — and must not be written at all.
+		f := newPatchFS("line1\nline2")
+		err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+			remotefs.AppendIfMissing("line1"), // already present — no-op
+		})
+		require.NoError(t, err)
+		require.False(t, f.wasWritten(), "no-op patch should not write the file")
+	})
+}
+
+func TestPatchFileNilApply(t *testing.T) {
+	f := newPatchFS("line\n")
+	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{{}})
+	require.ErrorIs(t, err, remotefs.ErrNilPatch)
+}
+
+func TestPatchFileInvalidMatch(t *testing.T) {
+	f := newPatchFS("line\n")
+	// A zero-value LineMatch must produce ErrInvalidMatch, not delete lines.
+	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+		remotefs.DeleteMatching(remotefs.LineMatch{}),
+	})
+	require.ErrorIs(t, err, remotefs.ErrInvalidMatch)
+	require.False(t, f.wasWritten())
+}
+
+func TestPatchFileMultilinePatch(t *testing.T) {
+	f := newPatchFS("line\n")
+	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+		remotefs.AppendIfMissing("bad\nvalue"),
+	})
+	require.ErrorIs(t, err, remotefs.ErrMultilinePatch)
+	require.False(t, f.wasWritten())
+}
+
+func TestPatchFileNotRegularFile(t *testing.T) {
+	for _, mode := range []fs.FileMode{
+		fs.ModeNamedPipe | 0o644,
+		fs.ModeDevice | 0o644,
+		fs.ModeDir | 0o755,
+		fs.ModeSocket | 0o644,
+	} {
+		f := &patchFS{statMode: mode}
+		err := remotefs.PatchFile(f, "/dev/stdin", []remotefs.Patch{
+			remotefs.AppendIfMissing("line"),
+		})
+		require.ErrorIs(t, err, remotefs.ErrNotRegularFile, "mode %v should be rejected", mode)
+	}
+}
+
+func TestPatchFileSymlinkAllowed(t *testing.T) {
+	// Symlinks must not be rejected by the IsRegular check. BSD stat reports
+	// ModeSymlink for symlinks; PatchFile should still proceed.
+	f := &patchFS{
+		content:  []byte("FOO=old\n"),
+		statMode: fs.ModeSymlink | 0o644,
+	}
+	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+		remotefs.ReplaceOrAppend(remotefs.ByPrefix("FOO="), "FOO=new"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "FOO=new\n", f.writtenStr())
+}
+
+func TestPatchFileNoWriteOnIdenticalContent(t *testing.T) {
+	f := newPatchFS("FOO=bar\n")
+	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+		remotefs.AppendIfMissing("FOO=bar"), // already present — no-op
+	})
+	require.NoError(t, err)
+	require.False(t, f.wasWritten(), "identical output must not trigger a write")
+}
+
+func TestPatchFileWithCreateEmptyOutput(t *testing.T) {
+	// WithCreate on a missing file where patches produce empty output must still
+	// create the file (bytes.Equal(nil, []byte{}) must not suppress the write).
+	f := &patchFS{statErr: &fs.PathError{Op: "stat", Path: "/new", Err: fs.ErrNotExist}}
+	err := remotefs.PatchFile(f, "/new", nil, remotefs.WithCreate(0o600))
+	require.NoError(t, err)
+	require.True(t, f.wasWritten(), "WithCreate must write even when output is empty")
+}
+
+func TestPatchFileStatError(t *testing.T) {
+	f := &patchFS{statErr: errors.New("permission denied")}
+	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+		remotefs.AppendIfMissing("hello"),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "permission denied")
+}
+
+// TestPatchFilePosix verifies PatchFile works end-to-end via PosixFS.
+func TestPatchFilePosix(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	// initStat probe: "stat --format=FORMAT" selects GNU stat (stat -c format).
+	mr.AddCommandOutput(rigtest.Equal("stat --help 2>&1"), "Usage: stat --format=FORMAT")
+	// PatchFile's Stat("/etc/env") — match path-specifically so the generic stat
+	// handler below (for MkdirAll's Stat("/etc")) does not fire first.
+	// 0x81a4 = 0o100644 (regular file, rw-r--r--).
+	mr.AddCommandOutput(rigtest.Match(`stat -c.*etc/env`), "0x81a4 12 1234567890.000000000 ///etc/env//")
+	// ReadFile via cat.
+	mr.AddCommandOutput(rigtest.Contains("cat"), "FOO=old\nBAR=keep\n")
+	// WriteFileAtomic: MkdirAll probes Stat("/etc") — return directory so no install -d is needed.
+	// 0x41ed = 0o040755 (directory, rwxr-xr-x). This fires for any remaining stat -c call.
+	mr.AddCommandOutput(rigtest.Contains("stat -c"), "0x41ed 0 1234567890.000000000 ///etc//")
+	// CreateTemp.
+	mr.AddCommandOutput(rigtest.Contains("mktemp"), "/etc/.tmp-abc123")
+	// WriteFile via install -D + stdin.
+	mr.AddCommandSuccess(rigtest.Contains("install"))
+	// Chmod.
+	mr.AddCommandSuccess(rigtest.Contains("chmod"))
+	// Rename.
+	mr.AddCommandSuccess(rigtest.Contains("mv -f"))
+
+	f := remotefs.NewPosixFS(mr)
+	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+		remotefs.ReplaceOrAppend(remotefs.ByPrefix("FOO="), "FOO=new"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, mr.Received(rigtest.Contains("mktemp")))
+	require.NoError(t, mr.Received(rigtest.Contains("mv -f")))
+}

--- a/remotefs/winfileinfo.go
+++ b/remotefs/winfileinfo.go
@@ -52,12 +52,16 @@ func (fi *winFileInfo) Size() int64 {
 	return fi.Length
 }
 
-// Mode returns the file mode bits.
+// Mode returns the file mode bits, including fs.ModeDir for directories.
 func (fi *winFileInfo) Mode() fs.FileMode {
-	if fi.IsReadOnly {
-		return 0o555
+	var mode fs.FileMode
+	if fi.IsDir() {
+		mode |= fs.ModeDir
 	}
-	return 0o777
+	if fi.IsReadOnly {
+		return mode | 0o555
+	}
+	return mode | 0o777
 }
 
 // ModTime returns the modification time.

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -389,13 +389,15 @@ func (s *WinFS) Chtimes(name string, atime, mtime int64) error {
 	return nil
 }
 
-// Chmod changes the mode of the named file to mode. On Windows, only the 0200 bit (owner writable) of mode is used; it controls whether the file's read-only attribute is set or cleared.
+// Chmod changes the mode of the named file to mode. On Windows, only the 0200
+// bit (owner writable) of mode is used: if set, the read-only attribute is
+// cleared (attrib -R); if unset, it is set (attrib +R).
 func (s *WinFS) Chmod(name string, mode fs.FileMode) error {
 	var attribSign string
 	if mode&0o200 != 0 {
-		attribSign = "+"
+		attribSign = "-" // owner-write set → clear read-only
 	} else {
-		attribSign = "-"
+		attribSign = "+" // owner-write not set → set read-only
 	}
 	if err := s.Exec(fmt.Sprintf("attrib %sR %s", attribSign, ps.DoubleQuotePath(name))); err != nil {
 		return fmt.Errorf("chmod %s: %w", name, err)


### PR DESCRIPTION
This replaces / complements the LineInFile of rig v0.

Provides PatchFile(fsys FS, path string, patches []Patch, opts ...PatchOption) that reads, transforms, and atomically rewrites a remote file via WriteFileAtomic.

Patch constructors: ReplaceOrAppend, DeleteMatching, AppendIfMissing, InsertAfter, InsertBefore, Transform. LineMatch constructors: ByPrefix, ByExact, ByContains, ByRegex. WithCreate option creates missing files.

CRLF line endings are normalised on read and restored on write.

Part of the rig v2 last mile effort, breaking API is not a problem as rig v2 hasn't been released yet.
