### PR TITLE
Add kv.Encoder: write-side complement to kv.Decoder

### DIFF
--- a/kv/decoder.go
+++ b/kv/decoder.go
@@ -446,6 +446,9 @@ func (d *Decoder) Decode(obj any) (err error) { //nolint:cyclop
 			return fmt.Errorf("read: %w", readErr)
 		}
 
+		if len(line) > 0 && line[len(line)-1] == d.rdelim {
+			line = line[:len(line)-1]
+		}
 		line = strings.TrimSpace(line)
 
 		if len(line) == 0 {

--- a/kv/encoder.go
+++ b/kv/encoder.go
@@ -1,0 +1,347 @@
+package kv
+
+import (
+	"encoding"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Encoder writes key-value pairs to an output stream. The field delimiter
+// defaults to '=' and the row delimiter to '\n'.
+//
+// Struct fields are encoded using the same kv struct tags as Decoder:
+//
+//	Field type `kv:"key_name,option1,option2"`
+//
+// Tag options:
+//   - omitempty: skip the field when its value is the zero value
+//   - delim=X: for slice fields, join elements with delimiter X (default ',')
+//   - '-': skip the field entirely
+//   - '*': encode a map[string]string field as additional key-value pairs
+//
+// Keys and values that contain the field delimiter, quotes, backslashes,
+// leading/trailing whitespace, or keys that start with the comment prefix
+// (default "#") are automatically double-quoted with backslash escaping.
+// Keys or values containing the row delimiter cannot be encoded and cause an error.
+// Note: slice elements that themselves contain the slice delimiter or
+// leading/trailing whitespace cannot be round-tripped through the Decoder.
+type Encoder struct {
+	w            io.Writer
+	rdelim       byte
+	fdelim       rune
+	commentStart string
+}
+
+// NewEncoder returns a new Encoder that writes to w.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{w: w, rdelim: '\n', fdelim: '=', commentStart: "#"}
+}
+
+// CommentStart sets the comment prefix. Keys starting with this prefix are
+// automatically quoted so they are not mistaken for comments by Decoder.
+// Default is "#" to match Decoder's default.
+func (e *Encoder) CommentStart(s string) { e.commentStart = s }
+
+// RowDelimiter sets the row delimiter. Default is newline.
+func (e *Encoder) RowDelimiter(delim byte) { e.rdelim = delim }
+
+// FieldDelimiter sets the field delimiter. Default is '='.
+func (e *Encoder) FieldDelimiter(delim rune) { e.fdelim = delim }
+
+type encFieldInfo struct {
+	key       string
+	ignore    bool
+	catchAll  bool
+	omitempty bool
+	delim     rune
+}
+
+func parseEncTag(sf reflect.StructField) encFieldInfo {
+	info := encFieldInfo{}
+	parts := strings.Split(sf.Tag.Get("kv"), ",")
+	switch parts[0] {
+	case "-":
+		info.ignore = true
+		return info
+	case "*":
+		info.catchAll = true
+	default:
+		info.key = parts[0]
+	}
+	for _, opt := range parts[1:] {
+		switch {
+		case opt == "omitempty":
+			info.omitempty = true
+		case strings.HasPrefix(opt, "delim:"), strings.HasPrefix(opt, "delim="):
+			if rs := []rune(opt[6:]); len(rs) > 0 {
+				info.delim = rs[0]
+			}
+		}
+	}
+	return info
+}
+
+func fieldToStringSlice(value reflect.Value, delim rune) (string, error) {
+	sep := ","
+	if delim != 0 {
+		sep = string(delim)
+	}
+	parts := make([]string, value.Len())
+	for i := range value.Len() {
+		s, err := fieldToString(value.Index(i), delim)
+		if err != nil {
+			return "", err
+		}
+		parts[i] = s
+	}
+	return strings.Join(parts, sep), nil
+}
+
+func fieldToStringNumeric(value reflect.Value) (string, error) {
+	switch value.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(value.Int(), 10), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(value.Uint(), 10), nil
+	case reflect.Float32:
+		return strconv.FormatFloat(value.Float(), 'g', -1, 32), nil
+	case reflect.Float64:
+		return strconv.FormatFloat(value.Float(), 'g', -1, 64), nil
+	default:
+		return "", fmt.Errorf("%w: unsupported type %v", ErrInvalidObject, value.Kind())
+	}
+}
+
+func marshalText(value reflect.Value) (string, bool, error) {
+	if value.Kind() == reflect.Pointer && value.IsNil() {
+		return "", false, nil
+	}
+	// Try value receiver first, then pointer receiver for addressable values.
+	for _, v := range []reflect.Value{value, addrOf(value)} {
+		if !v.IsValid() || !v.CanInterface() {
+			continue
+		}
+		m, ok := v.Interface().(encoding.TextMarshaler)
+		if !ok {
+			continue
+		}
+		b, err := m.MarshalText()
+		if err != nil {
+			return "", false, fmt.Errorf("marshal text: %w", err)
+		}
+		return string(b), true, nil
+	}
+	return "", false, nil
+}
+
+func addrOf(v reflect.Value) reflect.Value {
+	if v.CanAddr() {
+		return v.Addr()
+	}
+	// Allocate an addressable copy so pointer-receiver TextMarshaler
+	// implementations work for non-addressable values such as map entries.
+	ptr := reflect.New(v.Type())
+	ptr.Elem().Set(v)
+	return ptr
+}
+
+func fieldToString(value reflect.Value, delim rune) (string, error) {
+	if s, ok, err := marshalText(value); ok || err != nil {
+		return s, err
+	}
+	switch value.Kind() {
+	case reflect.Pointer:
+		if value.IsNil() {
+			return "", nil
+		}
+		return fieldToString(value.Elem(), delim)
+	case reflect.Slice:
+		return fieldToStringSlice(value, delim)
+	case reflect.String:
+		return value.String(), nil
+	case reflect.Bool:
+		if value.Bool() {
+			return "true", nil
+		}
+		return "false", nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return fieldToStringNumeric(value)
+	default:
+		return "", fmt.Errorf("%w: unsupported type %v", ErrInvalidObject, value.Kind())
+	}
+}
+
+func isZeroValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Slice, reflect.Map:
+		return v.IsNil()
+	default:
+		return v.IsZero()
+	}
+}
+
+func (e *Encoder) needsQuoting(s string) bool {
+	if strings.TrimSpace(s) != s {
+		return true
+	}
+	if e.commentStart != "" && strings.HasPrefix(s, e.commentStart) {
+		return true
+	}
+	for _, r := range s {
+		if r == '\\' || r == '"' || r == '\'' || r == e.fdelim {
+			return true
+		}
+	}
+	return false
+}
+
+// quoteIfNeeded wraps s in double quotes and escapes backslashes and double
+// quotes if s contains any character that would be misinterpreted by Decoder.
+func (e *Encoder) quoteIfNeeded(s string) string {
+	if !e.needsQuoting(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for _, c := range s {
+		if c == '\\' || c == '"' {
+			b.WriteByte('\\')
+		}
+		b.WriteRune(c)
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+func (e *Encoder) writePair(key, value string) error {
+	if key == "" {
+		return fmt.Errorf("%w: empty key", ErrInvalidObject)
+	}
+	if strings.IndexByte(key, e.rdelim) >= 0 || strings.IndexByte(value, e.rdelim) >= 0 {
+		return fmt.Errorf("%w: key or value contains the row delimiter", ErrInvalidObject)
+	}
+	_, err := fmt.Fprintf(e.w, "%s%c%s%c", e.quoteIfNeeded(key), e.fdelim, e.quoteIfNeeded(value), e.rdelim)
+	if err != nil {
+		return fmt.Errorf("write pair: %w", err)
+	}
+	return nil
+}
+
+type encodedPair struct{ key, val string }
+
+func (e *Encoder) encodeMap(v reflect.Value) error {
+	pairs := make([]encodedPair, 0, v.Len())
+	for _, k := range v.MapKeys() {
+		kStr, err := fieldToString(k, 0)
+		if err != nil {
+			return err
+		}
+		vStr, err := fieldToString(v.MapIndex(k), 0)
+		if err != nil {
+			return err
+		}
+		pairs = append(pairs, encodedPair{kStr, vStr})
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].key < pairs[j].key })
+	for _, p := range pairs {
+		if err := e.writePair(p.key, p.val); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *Encoder) encodeField(structField reflect.StructField, fieldValue reflect.Value, info encFieldInfo) error {
+	if info.catchAll {
+		m, ok := fieldValue.Interface().(map[string]string)
+		if !ok {
+			return fmt.Errorf("%w: field %q with kv tag * must be a map[string]string", ErrInvalidTags, structField.Name)
+		}
+		keys := make([]string, 0, len(m))
+		for k := range m {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if err := e.writePair(k, m[k]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if info.omitempty && isZeroValue(fieldValue) {
+		return nil
+	}
+	key := info.key
+	if key == "" {
+		key = structField.Name
+	}
+	val, err := fieldToString(fieldValue, info.delim)
+	if err != nil {
+		return fmt.Errorf("field %q: %w", key, err)
+	}
+	return e.writePair(key, val)
+}
+
+func (e *Encoder) encodeStruct(structVal reflect.Value) error {
+	t := structVal.Type()
+	catchAllSeen := false
+	for i := range t.NumField() {
+		structField := t.Field(i)
+		if !structField.IsExported() {
+			if tag := structField.Tag.Get("kv"); tag != "" && tag != "-" {
+				return fmt.Errorf("%w: unexported field %q has kv tag", ErrInvalidTags, structField.Name)
+			}
+			continue
+		}
+		fieldValue := structVal.Field(i)
+		info := parseEncTag(structField)
+		if info.ignore {
+			continue
+		}
+		if info.catchAll {
+			if catchAllSeen {
+				return fmt.Errorf("%w: multiple fields with kv tag *", ErrInvalidTags)
+			}
+			catchAllSeen = true
+		}
+		if err := e.encodeField(structField, fieldValue, info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Encode writes the key-value representation of obj to the stream.
+// obj may be a map with string-convertible keys, or a struct (or pointer to struct).
+func (e *Encoder) Encode(obj any) error {
+	value := reflect.ValueOf(obj)
+	for value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return fmt.Errorf("%w: nil pointer", ErrInvalidObject)
+		}
+		value = value.Elem()
+	}
+	switch value.Kind() {
+	case reflect.Map:
+		return e.encodeMap(value)
+	case reflect.Struct:
+		if !value.CanAddr() {
+			// Heap-allocate a copy so fields are addressable, enabling
+			// pointer-receiver TextMarshaler implementations on struct fields.
+			ptr := reflect.New(value.Type())
+			ptr.Elem().Set(value)
+			value = ptr.Elem()
+		}
+		return e.encodeStruct(value)
+	default:
+		return fmt.Errorf("%w: unsupported type %T", ErrInvalidObject, obj)
+	}
+}

--- a/kv/encoder_test.go
+++ b/kv/encoder_test.go
@@ -1,0 +1,350 @@
+package kv_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/kv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncoderWithMap(t *testing.T) {
+	t.Run("StringMap", func(t *testing.T) {
+		var buf strings.Builder
+		enc := kv.NewEncoder(&buf)
+		input := map[string]string{"key1": "value1", "key2": "value2"}
+		require.NoError(t, enc.Encode(input))
+		// Map iteration order is random; decode back and compare
+		result := make(map[string]string)
+		require.NoError(t, kv.NewDecoder(strings.NewReader(buf.String())).Decode(result))
+		assert.Equal(t, input, result)
+	})
+
+	t.Run("CustomDelimiters", func(t *testing.T) {
+		var buf strings.Builder
+		enc := kv.NewEncoder(&buf)
+		enc.FieldDelimiter(':')
+		enc.RowDelimiter(';')
+		require.NoError(t, enc.Encode(map[string]string{"k": "v"}))
+		assert.Equal(t, "k:v;", buf.String())
+		// round-trip: decoder must also use matching delimiters
+		result := make(map[string]string)
+		dec := kv.NewDecoder(strings.NewReader(buf.String()))
+		dec.FieldDelimiter(':')
+		dec.RowDelimiter(';')
+		require.NoError(t, dec.Decode(result))
+		assert.Equal(t, map[string]string{"k": "v"}, result)
+	})
+}
+
+func TestEncoderWithStruct(t *testing.T) {
+	t.Run("WithTags", func(t *testing.T) {
+		type testStruct struct {
+			Key1 string `kv:"key1"`
+			Key2 int    `kv:"key2"`
+			Key3 bool   `kv:"key3"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Key1: "hello", Key2: 42, Key3: true}))
+		assert.Equal(t, "key1=hello\nkey2=42\nkey3=true\n", buf.String())
+	})
+
+	t.Run("WithoutTags", func(t *testing.T) {
+		type testStruct struct {
+			Alpha string
+			Beta  int
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Alpha: "a", Beta: 1}))
+		assert.Equal(t, "Alpha=a\nBeta=1\n", buf.String())
+	})
+
+	t.Run("IgnoreTag", func(t *testing.T) {
+		type testStruct struct {
+			Keep   string `kv:"keep"`
+			Hidden string `kv:"-"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Keep: "yes", Hidden: "no"}))
+		assert.Equal(t, "keep=yes\n", buf.String())
+	})
+
+	t.Run("Omitempty", func(t *testing.T) {
+		type testStruct struct {
+			Present string  `kv:"present"`
+			Empty   string  `kv:"empty,omitempty"`
+			NilPtr  *string `kv:"nilptr,omitempty"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Present: "here"}))
+		assert.Equal(t, "present=here\n", buf.String())
+	})
+
+	t.Run("SliceWithDelim", func(t *testing.T) {
+		type testStruct struct {
+			Items []string `kv:"items,delim:/"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Items: []string{"a", "b", "c"}}))
+		assert.Equal(t, "items=a/b/c\n", buf.String())
+	})
+
+	t.Run("SliceDefaultDelim", func(t *testing.T) {
+		type testStruct struct {
+			Tags []string `kv:"tags"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Tags: []string{"x", "y"}}))
+		assert.Equal(t, "tags=x,y\n", buf.String())
+	})
+
+	t.Run("Pointer", func(t *testing.T) {
+		type testStruct struct {
+			Val    *string `kv:"val"`
+			Absent *string `kv:"absent"`
+		}
+		s := "pointed"
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Val: &s}))
+		assert.Equal(t, "val=pointed\nabsent=\n", buf.String())
+	})
+
+	t.Run("CatchAll", func(t *testing.T) {
+		type testStruct struct {
+			Name  string            `kv:"name"`
+			Extra map[string]string `kv:"*"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{
+			Name:  "foo",
+			Extra: map[string]string{"x": "1"},
+		}))
+		result := make(map[string]string)
+		require.NoError(t, kv.NewDecoder(strings.NewReader(buf.String())).Decode(result))
+		assert.Equal(t, map[string]string{"name": "foo", "x": "1"}, result)
+	})
+
+	t.Run("PointerToStruct", func(t *testing.T) {
+		type testStruct struct {
+			Val string `kv:"val"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(&testStruct{Val: "ptr"}))
+		assert.Equal(t, "val=ptr\n", buf.String())
+	})
+}
+
+func TestEncoderFloatPrecision(t *testing.T) {
+	type testStruct struct {
+		F64 float64 `kv:"f64"`
+		F32 float32 `kv:"f32"`
+	}
+	original := testStruct{F64: 1.0000000000000002, F32: 1.0000001}
+	var buf strings.Builder
+	require.NoError(t, kv.NewEncoder(&buf).Encode(original))
+	var decoded testStruct
+	require.NoError(t, kv.NewDecoder(strings.NewReader(buf.String())).Decode(&decoded))
+	assert.Equal(t, original.F64, decoded.F64)
+	assert.Equal(t, original.F32, decoded.F32)
+}
+
+func TestEncoderRoundtrip(t *testing.T) {
+	type config struct {
+		Host    string            `kv:"host"`
+		Port    int               `kv:"port"`
+		Enabled bool              `kv:"enabled"`
+		Tags    []string          `kv:"tags,delim:/"`
+		Extra   map[string]string `kv:"*"`
+	}
+	original := config{
+		Host:    "10.0.0.1",
+		Port:    8080,
+		Enabled: true,
+		Tags:    []string{"a", "b"},
+		Extra:   map[string]string{"region": "eu"},
+	}
+
+	var buf strings.Builder
+	require.NoError(t, kv.NewEncoder(&buf).Encode(original))
+
+	var decoded config
+	require.NoError(t, kv.NewDecoder(strings.NewReader(buf.String())).Decode(&decoded))
+	assert.Equal(t, original, decoded)
+}
+
+func TestEncoderQuoting(t *testing.T) {
+	t.Run("ValueWithWhitespace", func(t *testing.T) {
+		type testStruct struct {
+			Val string `kv:"val"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Val: "  hello  "}))
+		var decoded testStruct
+		require.NoError(t, kv.NewDecoder(strings.NewReader(buf.String())).Decode(&decoded))
+		assert.Equal(t, "  hello  ", decoded.Val)
+	})
+
+	t.Run("KeyWithCommentPrefix", func(t *testing.T) {
+		type testStruct struct {
+			Val string `kv:"#commented"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Val: "x"}))
+		// key must be quoted so decoder doesn't skip it as a comment
+		var decoded testStruct
+		require.NoError(t, kv.NewDecoder(strings.NewReader(buf.String())).Decode(&decoded))
+		assert.Equal(t, "x", decoded.Val)
+	})
+
+	t.Run("ValueWithRowDelimiterErrors", func(t *testing.T) {
+		type testStruct struct {
+			Val string `kv:"val"`
+		}
+		var buf strings.Builder
+		err := kv.NewEncoder(&buf).Encode(testStruct{Val: "line1\nline2"})
+		require.Error(t, err)
+	})
+
+	t.Run("ValueWithDelimiter", func(t *testing.T) {
+		type testStruct struct {
+			Val string `kv:"val"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Val: "a=b"}))
+		assert.Equal(t, "val=\"a=b\"\n", buf.String())
+		// round-trip
+		var decoded testStruct
+		require.NoError(t, kv.NewDecoder(strings.NewReader(buf.String())).Decode(&decoded))
+		assert.Equal(t, "a=b", decoded.Val)
+	})
+
+	t.Run("ValueWithSingleQuote", func(t *testing.T) {
+		type testStruct struct {
+			Val string `kv:"val"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Val: "it's"}))
+		var decoded testStruct
+		require.NoError(t, kv.NewDecoder(strings.NewReader(buf.String())).Decode(&decoded))
+		assert.Equal(t, "it's", decoded.Val)
+	})
+
+	t.Run("ValueWithBackslash", func(t *testing.T) {
+		type testStruct struct {
+			Val string `kv:"val"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(testStruct{Val: `a\b`}))
+		var decoded testStruct
+		require.NoError(t, kv.NewDecoder(strings.NewReader(buf.String())).Decode(&decoded))
+		assert.Equal(t, `a\b`, decoded.Val)
+	})
+}
+
+func TestEncoderErrors(t *testing.T) {
+	t.Run("NilPointer", func(t *testing.T) {
+		var buf strings.Builder
+		var p *struct{ V string }
+		err := kv.NewEncoder(&buf).Encode(p)
+		require.Error(t, err)
+	})
+
+	t.Run("UnsupportedType", func(t *testing.T) {
+		var buf strings.Builder
+		err := kv.NewEncoder(&buf).Encode(42)
+		require.Error(t, err)
+	})
+
+	t.Run("EmptyKey", func(t *testing.T) {
+		var buf strings.Builder
+		err := kv.NewEncoder(&buf).Encode(map[string]string{"": "value"})
+		require.Error(t, err)
+	})
+
+	t.Run("MultipleCatchAll", func(t *testing.T) {
+		type testStruct struct {
+			A map[string]string `kv:"*"`
+			B map[string]string `kv:"*"`
+		}
+		var buf strings.Builder
+		err := kv.NewEncoder(&buf).Encode(testStruct{
+			A: map[string]string{"a": "1"},
+			B: map[string]string{"b": "2"},
+		})
+		require.ErrorIs(t, err, kv.ErrInvalidTags)
+	})
+
+	t.Run("NonMapCatchAll", func(t *testing.T) {
+		type testStruct struct {
+			A string `kv:"*"`
+		}
+		var buf strings.Builder
+		err := kv.NewEncoder(&buf).Encode(testStruct{A: "foo"})
+		require.ErrorIs(t, err, kv.ErrInvalidTags)
+	})
+
+	t.Run("UnexportedFieldWithTag", func(t *testing.T) {
+		type testStruct struct {
+			Exported   string `kv:"ok"`
+			unexported string `kv:"bad"` //nolint:govet
+		}
+		var buf strings.Builder
+		err := kv.NewEncoder(&buf).Encode(testStruct{Exported: "x"})
+		require.ErrorIs(t, err, kv.ErrInvalidTags)
+	})
+}
+
+func TestEncoderTextMarshaler(t *testing.T) {
+	t.Run("ValueReceiver", func(t *testing.T) {
+		type withMarshaler struct {
+			Val encodingTextValue `kv:"val"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(withMarshaler{Val: encodingTextValue("hello")}))
+		assert.Equal(t, "val=HELLO\n", buf.String())
+	})
+
+	t.Run("PointerReceiver", func(t *testing.T) {
+		type withMarshaler struct {
+			Val ptrReceiverValue `kv:"val"`
+		}
+		var buf strings.Builder
+		require.NoError(t, kv.NewEncoder(&buf).Encode(withMarshaler{Val: ptrReceiverValue("hello")}))
+		assert.Equal(t, "val=HELLO\n", buf.String())
+	})
+}
+
+// encodingTextValue uppercases its content when marshaled (value receiver).
+type encodingTextValue string
+
+func (v encodingTextValue) MarshalText() ([]byte, error) {
+	return []byte(strings.ToUpper(string(v))), nil
+}
+
+// ptrReceiverValue uppercases its content when marshaled (pointer receiver).
+type ptrReceiverValue string
+
+func (v *ptrReceiverValue) MarshalText() ([]byte, error) {
+	return []byte(strings.ToUpper(string(*v))), nil
+}
+
+func ExampleEncoder() {
+	type Config struct {
+		Host    string   `kv:"host"`
+		Port    int      `kv:"port"`
+		Tags    []string `kv:"tags,delim:/"`
+		Comment string   `kv:"-"`
+	}
+	cfg := Config{Host: "localhost", Port: 9000, Tags: []string{"a", "b"}, Comment: "ignored"}
+	var buf strings.Builder
+	if err := kv.NewEncoder(&buf).Encode(cfg); err != nil {
+		panic(err)
+	}
+	fmt.Print(buf.String())
+	// Output:
+	// host=localhost
+	// port=9000
+	// tags=a/b
+}

--- a/kv/split.go
+++ b/kv/split.go
@@ -24,7 +24,7 @@ var (
 // The separator is not included in the key or value.
 // If the input string has a syntax error such as mismatched quotes or no delimiter, the error will be of type kv.ErrSyntax.
 func SplitRune(s string, separator rune) (key string, value string, err error) { //nolint:cyclop
-	var inSingleQuotes, inDoubleQuotes, isEscaped bool
+	var inSingleQuotes, inDoubleQuotes, isEscaped, separatorSeen bool
 
 	sb, ok := builderPool.Get().(*strings.Builder)
 	if !ok {
@@ -61,10 +61,13 @@ func SplitRune(s string, separator rune) (key string, value string, err error) {
 				isEscaped = false
 			}
 		case separator:
-			if !inSingleQuotes && !inDoubleQuotes && !isEscaped {
+			if !inSingleQuotes && !inDoubleQuotes && !isEscaped && !separatorSeen {
+				separatorSeen = true
 				key = sb.String()
 				sb.Reset()
 				sb.Grow(len(s) - len(key))
+			} else {
+				sb.WriteRune(currentChar)
 			}
 			isEscaped = false
 		default:
@@ -77,7 +80,7 @@ func SplitRune(s string, separator rune) (key string, value string, err error) {
 		return "", "", fmt.Errorf("%w: mismatched quotes in %q", ErrSyntax, s)
 	}
 
-	if len(key) == 0 {
+	if !separatorSeen {
 		return "", "", fmt.Errorf("%w: no separator found in %q", ErrSyntax, s)
 	}
 	return key, sb.String(), nil

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -66,10 +66,42 @@ func TestSplitS(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "Separator in quoted value",
+			input:     `key="a=b"`,
+			separator: '=',
+			wantKey:   "key",
+			wantValue: "a=b",
+			wantErr:   false,
+		},
+		{
+			name:      "Separator in single-quoted value",
+			input:     `key='a=b'`,
+			separator: '=',
+			wantKey:   "key",
+			wantValue: "a=b",
+			wantErr:   false,
+		},
+		{
+			name:      "Multiple separators",
+			input:     "key=a=b=c",
+			separator: '=',
+			wantKey:   "key",
+			wantValue: "a=b=c",
+			wantErr:   false,
+		},
+		{
 			name:      "No separator",
 			input:     "justakey",
 			separator: '=',
 			wantErr:   true,
+		},
+		{
+			name:      "Empty key with multiple separators",
+			input:     "=a=b",
+			separator: '=',
+			wantKey:   "",
+			wantValue: "a=b",
+			wantErr:   false,
 		},
 	}
 


### PR DESCRIPTION
Implements the missing write half of the kv package. Mirrors the decoder's tag system (key name, -, *, omitempty, delim), supports structs, maps, pointers, slices, and encoding.TextMarshaler.