### PR TITLE
Fix Service.Restart double-restart and waitState busy loop

### DIFF
--- a/service.go
+++ b/service.go
@@ -78,11 +78,15 @@ func (m *Service) Restart(ctx context.Context) error {
 	return nil
 }
 
-const serviceStatePollInterval = 500 * time.Millisecond
+const (
+	serviceStatePollMinInterval = 100 * time.Millisecond
+	serviceStatePollMaxInterval = 1000 * time.Millisecond
+)
 
 func (m *Service) waitState(ctx context.Context, state serviceState) error {
-	ticker := time.NewTicker(serviceStatePollInterval)
-	defer ticker.Stop()
+	delay := serviceStatePollMinInterval
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
 	for {
 		running := m.initsys.ServiceIsRunning(ctx, m.runner, m.name)
 		wantRunning := state == serviceStateStarted
@@ -92,7 +96,12 @@ func (m *Service) waitState(ctx context.Context, state serviceState) error {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("service '%s' did not reach the desired state: %w", m.name, ctx.Err())
-		case <-ticker.C:
+		case <-timer.C:
+			delay *= 2
+			if delay > serviceStatePollMaxInterval {
+				delay = serviceStatePollMaxInterval
+			}
+			timer.Reset(delay)
 		}
 	}
 }

--- a/service.go
+++ b/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path"
+	"time"
 
 	"github.com/k0sproject/rig/v2/cmd"
 	"github.com/k0sproject/rig/v2/initsystem"
@@ -66,25 +67,32 @@ func (m *Service) Restart(ctx context.Context) error {
 		if err := restarter.RestartService(ctx, m.runner, m.name); err != nil {
 			return fmt.Errorf("failed to restart service '%s': %w", m.name, err)
 		}
+		return m.waitState(ctx, serviceStateStarted)
 	}
 	if err := m.Stop(ctx); err != nil {
 		return fmt.Errorf("failed to stop service '%s' for restart: %w", m.name, err)
 	}
 	if err := m.Start(ctx); err != nil {
-		return fmt.Errorf("failed to restart service '%s: %w", m.name, err)
+		return fmt.Errorf("failed to restart service '%s': %w", m.name, err)
 	}
 	return nil
 }
 
+const serviceStatePollInterval = 500 * time.Millisecond
+
 func (m *Service) waitState(ctx context.Context, state serviceState) error {
+	ticker := time.NewTicker(serviceStatePollInterval)
+	defer ticker.Stop()
 	for {
+		running := m.initsys.ServiceIsRunning(ctx, m.runner, m.name)
+		wantRunning := state == serviceStateStarted
+		if running == wantRunning {
+			return nil
+		}
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("service '%s' did not reach the desired state: %w", m.name, ctx.Err())
-		default:
-			if m.initsys.ServiceIsRunning(ctx, m.runner, m.name) == (state == serviceStateStarted) {
-				return nil
-			}
+		case <-ticker.C:
 		}
 	}
 }

--- a/service_test.go
+++ b/service_test.go
@@ -2,6 +2,7 @@ package rig
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"testing"
 
@@ -196,7 +197,133 @@ func TestServiceDaemonReload(t *testing.T) {
 	})
 }
 
+// mockLifecycleManager tracks Start/Stop calls and maintains isRunning state.
+type mockLifecycleManager struct {
+	isRunning   bool
+	neverReady  bool // when true, ServiceIsRunning always returns false
+	startCalled int
+	stopCalled  int
+}
+
+func (m *mockLifecycleManager) StartService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	m.startCalled++
+	if !m.neverReady {
+		m.isRunning = true
+	}
+	return nil
+}
+
+func (m *mockLifecycleManager) StopService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	m.stopCalled++
+	m.isRunning = false
+	return nil
+}
+
+func (m *mockLifecycleManager) ServiceIsRunning(_ context.Context, _ cmd.ContextRunner, _ string) bool {
+	if m.neverReady {
+		return false
+	}
+	return m.isRunning
+}
+
+func (m *mockLifecycleManager) ServiceScriptPath(_ context.Context, _ cmd.ContextRunner, _ string) (string, error) {
+	return "", nil
+}
+
+func (m *mockLifecycleManager) EnableService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockLifecycleManager) DisableService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+// mockNativeRestarter extends mockLifecycleManager with RestartService.
+type mockNativeRestarter struct {
+	mockLifecycleManager
+	restartCalled int
+	restartErr    error
+}
+
+func (m *mockNativeRestarter) RestartService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	m.restartCalled++
+	if m.restartErr != nil {
+		return m.restartErr
+	}
+	if !m.neverReady {
+		m.isRunning = true
+	}
+	return nil
+}
+
+func TestServiceStart(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("starts and reaches running state", func(t *testing.T) {
+		mgr := &mockLifecycleManager{}
+		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: mgr}
+		require.NoError(t, svc.Start(ctx))
+		require.Equal(t, 1, mgr.startCalled)
+		require.True(t, mgr.isRunning)
+	})
+
+	t.Run("pre-cancelled context returns error", func(t *testing.T) {
+		mgr := &mockLifecycleManager{neverReady: true}
+		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: mgr}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := svc.Start(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestServiceStop(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("stops and reaches stopped state", func(t *testing.T) {
+		mgr := &mockLifecycleManager{isRunning: true}
+		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: mgr}
+		require.NoError(t, svc.Stop(ctx))
+		require.Equal(t, 1, mgr.stopCalled)
+		require.False(t, mgr.isRunning)
+	})
+}
+
+func TestServiceRestart(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("uses native restart when available", func(t *testing.T) {
+		mgr := &mockNativeRestarter{}
+		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: mgr}
+		require.NoError(t, svc.Restart(ctx))
+		require.Equal(t, 1, mgr.restartCalled)
+		require.Equal(t, 0, mgr.startCalled, "Start must not be called after native restart")
+		require.Equal(t, 0, mgr.stopCalled, "Stop must not be called after native restart")
+	})
+
+	t.Run("falls back to stop+start without native restart", func(t *testing.T) {
+		mgr := &mockLifecycleManager{isRunning: true}
+		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: mgr}
+		require.NoError(t, svc.Restart(ctx))
+		require.Equal(t, 1, mgr.stopCalled)
+		require.Equal(t, 1, mgr.startCalled)
+	})
+
+	t.Run("native restart error does not fall through to stop+start", func(t *testing.T) {
+		restartErr := errors.New("restart failed")
+		mgr := &mockNativeRestarter{restartErr: restartErr}
+		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: mgr}
+		err := svc.Restart(ctx)
+		require.Error(t, err)
+		require.ErrorIs(t, err, restartErr)
+		require.Equal(t, 0, mgr.startCalled, "Start must not be called after failed native restart")
+		require.Equal(t, 0, mgr.stopCalled, "Stop must not be called after failed native restart")
+	})
+}
+
 // Ensure initsystem.ServiceEnvironmentManager is satisfied by types implementing it.
 var _ initsystem.ServiceEnvironmentManager = (*mockEnvManager)(nil)
 var _ initsystem.ServiceManagerReloader = (*mockReloadEnvManager)(nil)
 var _ initsystem.ServiceManager = (*mockBasicManager)(nil)
+var _ initsystem.ServiceManager = (*mockLifecycleManager)(nil)
+var _ initsystem.ServiceManagerRestarter = (*mockNativeRestarter)(nil)


### PR DESCRIPTION
Service.Restart fell through to Stop+Start even when RestartService succeeded, causing the service to be restarted twice. Add return after waitState to stop the fallthrough.

Service.waitState spun in a tight busy loop with no delay between ServiceIsRunning checks. Add a 100..1000ms (backoff) poll interval so the loop yields between probes; context cancellation is still immediate via select.

Also adds tests for Start, Stop, and Restart lifecycle methods, which previously had no coverage.