### PR TITLE
[release-0.x] Fix Windows sudo detection to use IsInRole for effective elevation check

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -16,6 +16,7 @@ import (
 	"github.com/k0sproject/rig/exec"
 	"github.com/k0sproject/rig/log"
 	rigos "github.com/k0sproject/rig/os"
+	ps "github.com/k0sproject/rig/pkg/powershell"
 	"github.com/k0sproject/rig/pkg/rigfs"
 	"github.com/mattn/go-shellwords"
 )
@@ -317,7 +318,7 @@ func (c *Connection) discoverSudo() {
 	// present and not deny-only, which correctly identifies an effectively elevated session.
 	// SSH sessions always give Administrators group members a full elevated token regardless
 	// of UAC; WinRM does too for domain accounts or when LocalAccountTokenFilterPolicy=1.
-	isAdmin := `powershell -NoProfile -Command "if (-not (New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { exit 1 }"`
+	isAdmin := ps.Cmd(`if (-not (New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { exit 1 }`)
 	if c.Exec(isAdmin) == nil {
 		c.sudofunc = sudoWindows
 	}

--- a/connection.go
+++ b/connection.go
@@ -289,9 +289,7 @@ func sudoDoas(cmd string) string {
 	return `doas -n -- "${SHELL-sh}" -c ` + shellescape.Quote(cmd)
 }
 
-// sudoWindows is a no-op on windows - the user must already be an admin or UAC must be disabled
-// and the user must belong to Administrators. if that is the case, the user should be able to
-// do anything.
+// sudoWindows is a no-op: the session already has effective administrator privileges.
 func sudoWindows(cmd string) string {
 	return cmd
 }
@@ -315,30 +313,13 @@ func (c *Connection) discoverSudo() {
 		return
 	}
 
-	out, err := c.ExecOutput(`whoami`)
-	if err != nil {
-		return
-	}
-	parts := strings.Split(out, `\`)
-	if strings.ToLower(parts[len(parts)-1]) == "administrator" {
-		// user is already the administrator
+	// IsInRole uses CheckTokenMembership: returns true only when the Administrators SID is
+	// present and not deny-only, which correctly identifies an effectively elevated session.
+	// SSH sessions always give Administrators group members a full elevated token regardless
+	// of UAC; WinRM does too for domain accounts or when LocalAccountTokenFilterPolicy=1.
+	isAdmin := `powershell -NoProfile -Command "if (-not (New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { exit 1 }"`
+	if c.Exec(isAdmin) == nil {
 		c.sudofunc = sudoWindows
-		return
-	}
-
-	if c.Exec(`net user "%USERNAME%" | findstr /B /C:"Local Group Memberships" | findstr /C:"*Administrators"`) != nil {
-		// user is not in the Administrators group
-		return
-	}
-
-	out, err = c.ExecOutput(`reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v "EnableLUA"`)
-	if err != nil {
-		return
-	}
-	if strings.Contains(out, "0x0") {
-		// UAC is disabled and the user is in the Administrators group - expect sudo to work
-		c.sudofunc = sudoWindows
-		return
 	}
 }
 
@@ -346,7 +327,7 @@ func (c *Connection) discoverSudo() {
 func (c Connection) Sudo(cmd string) (string, error) {
 	if c.sudofunc == nil {
 		if c.IsWindows() {
-			return "", fmt.Errorf("%w: UAC is enabled and user is not 'Administrator'", ErrSudoRequired)
+			return "", fmt.Errorf("%w: current session does not have administrator privileges", ErrSudoRequired)
 		}
 		return "", fmt.Errorf("%w: user is not root and passwordless access elevation (sudo, doas) has not been configured", ErrSudoRequired)
 	}

--- a/connection.go
+++ b/connection.go
@@ -320,7 +320,7 @@ func (c *Connection) discoverSudo() {
 	// of UAC; WinRM does too for domain accounts or when LocalAccountTokenFilterPolicy=1.
 	isAdmin := ps.Cmd(`if (-not (New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { exit 1 }`)
 	if c.Exec(isAdmin) == nil {
-		c.sudofunc = sudoWindows
+		c.SetSudofn(sudoWindows)
 	}
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -49,6 +49,23 @@ var stubSudofunc = func(in string) string {
 	return "sudo-goes-here " + in
 }
 
+type windowsMockClient struct {
+	execErr error
+}
+
+func (m *windowsMockClient) Connect() error      { return nil }
+func (m *windowsMockClient) Disconnect()         {}
+func (m *windowsMockClient) IsWindows() bool     { return true }
+func (m *windowsMockClient) ExecInteractive(_ string) error { return nil }
+func (m *windowsMockClient) String() string      { return "windows-mock" }
+func (m *windowsMockClient) Protocol() string    { return "winrm" }
+func (m *windowsMockClient) IPAddress() string   { return "192.0.2.1" }
+func (m *windowsMockClient) IsConnected() bool   { return true }
+func (m *windowsMockClient) Exec(_ string, _ ...exec.Option) error { return m.execErr }
+func (m *windowsMockClient) ExecStreams(_ string, _ io.ReadCloser, _, _ io.Writer, _ ...exec.Option) (exec.Waiter, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func TestHostFunctions(t *testing.T) {
 	h := Host{
 		Connection: Connection{
@@ -110,6 +127,26 @@ func TestGrouping(t *testing.T) {
 	opts, args := GroupParams(h, "ls", 1, exec.HideOutput(), exec.Sudo(h))
 	require.Len(t, opts, 2)
 	require.Len(t, args, 3)
+}
+
+func TestDiscoverSudoWindows(t *testing.T) {
+	t.Run("elevated session sets sudofunc", func(t *testing.T) {
+		mc := &windowsMockClient{}
+		h := Host{Connection: Connection{client: mc}}
+		h.discoverSudo()
+		result, err := h.Sudo("whoami")
+		require.NoError(t, err)
+		require.Equal(t, "whoami", result)
+	})
+
+	t.Run("non-elevated session returns ErrSudoRequired", func(t *testing.T) {
+		mc := &windowsMockClient{execErr: fmt.Errorf("access denied")}
+		h := Host{Connection: Connection{client: mc}}
+		h.discoverSudo()
+		_, err := h.Sudo("whoami")
+		require.ErrorIs(t, err, ErrSudoRequired)
+		require.ErrorContains(t, err, "administrator privileges")
+	})
 }
 
 func TestSudo(t *testing.T) {


### PR DESCRIPTION
Replace the three-step heuristic (whoami username check, net user Administrators group check, EnableLUA registry query) with a single PowerShell IsInRole call. WindowsPrincipal.IsInRole uses CheckTokenMembership and returns true only when the Administrators SID is present and not marked deny-only — the correct signal for an effectively elevated session. This handles SSH sessions (Windows OpenSSH always provides a full elevated token for Administrators group members, regardless of UAC), WinRM domain accounts, and local accounts with LocalAccountTokenFilterPolicy=1. Also updates the error message to accurately reflect what was detected.

Fixes #332