### PR TITLE
Fix Windows sudo detection to use IsInRole for effective elevation check

### DIFF
--- a/sudo/windows.go
+++ b/sudo/windows.go
@@ -19,6 +19,6 @@ func RegisterWindowsNoop(repository *Registry) {
 		if runner.Exec(isAdminCmd, cmd.PS()) != nil {
 			return nil, false
 		}
-		return runner, true
+		return cmd.NewExecutor(runner, Noop), true
 	})
 }

--- a/sudo/windows.go
+++ b/sudo/windows.go
@@ -1,36 +1,24 @@
 package sudo
 
 import (
-	"strings"
-
 	"github.com/k0sproject/rig/v2/cmd"
 )
 
-// RegisterWindowsNoop registers a noop DecorateFunc with the given repository if the user is
-// the built-in Administrator or a member of the Administrators group with UAC disabled.
+// RegisterWindowsNoop registers a noop DecorateFunc with the given repository if the current
+// session has effective administrator privileges. IsInRole uses CheckTokenMembership, which
+// returns true only when the Administrators SID is present and not marked deny-only — the
+// correct signal for an effectively elevated token. SSH sessions on Windows always provide a
+// full elevated token for Administrators group members regardless of UAC; WinRM does too for
+// domain accounts or when LocalAccountTokenFilterPolicy=1 is set.
 func RegisterWindowsNoop(repository *Registry) {
 	repository.Register(func(runner cmd.Runner) (cmd.Runner, bool) {
 		if !runner.IsWindows() {
 			return nil, false
 		}
-		out, err := runner.ExecOutput(`whoami.exe`)
-		if err != nil {
+		const isAdminCmd = `if (-not (New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { exit 1 }`
+		if runner.Exec(isAdminCmd, cmd.PS()) != nil {
 			return nil, false
 		}
-		parts := strings.Split(out, `\`)
-		if strings.ToLower(parts[len(parts)-1]) == "administrator" {
-			// user is already the administrator
-			return runner, true
-		}
-
-		// Check if the current token includes the Administrators group SID.
-		// When UAC is enabled and the session is not elevated, the token is filtered
-		// and will not contain this SID even if the user is a group member.
-		adminSID := `[Security.Principal.SecurityIdentifier]::new([Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid, $null)`
-		if runner.Exec(`if (-not ([Security.Principal.WindowsIdentity]::GetCurrent().Groups -contains `+adminSID+`)) { exit 1 }`, cmd.PS()) != nil {
-			return nil, false
-		}
-
 		return runner, true
 	})
 }

--- a/sudo/windows_test.go
+++ b/sudo/windows_test.go
@@ -13,6 +13,7 @@ func TestRegisterWindowsNoop(t *testing.T) {
 	t.Run("elevated session registers noop runner", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
 		mr.Windows = true
+		mr.ErrDefault = errors.New("unexpected command")
 		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
 
 		registry := sudo.NewRegistry()
@@ -21,6 +22,7 @@ func TestRegisterWindowsNoop(t *testing.T) {
 		runner, err := registry.Get(mr)
 		require.NoError(t, err)
 		require.NotNil(t, runner)
+		require.NoError(t, mr.NotReceived(rigtest.Contains("whoami")))
 	})
 
 	t.Run("non-elevated session skips registration", func(t *testing.T) {

--- a/sudo/windows_test.go
+++ b/sudo/windows_test.go
@@ -1,0 +1,47 @@
+package sudo_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/k0sproject/rig/v2/sudo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterWindowsNoop(t *testing.T) {
+	t.Run("elevated session registers noop runner", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+
+		registry := sudo.NewRegistry()
+		sudo.RegisterWindowsNoop(registry)
+
+		runner, err := registry.Get(mr)
+		require.NoError(t, err)
+		require.NotNil(t, runner)
+	})
+
+	t.Run("non-elevated session skips registration", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("access denied"))
+
+		registry := sudo.NewRegistry()
+		sudo.RegisterWindowsNoop(registry)
+
+		_, err := registry.Get(mr)
+		require.ErrorIs(t, err, sudo.ErrNoSudo)
+	})
+
+	t.Run("non-windows host skips registration", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+
+		registry := sudo.NewRegistry()
+		sudo.RegisterWindowsNoop(registry)
+
+		_, err := registry.Get(mr)
+		require.ErrorIs(t, err, sudo.ErrNoSudo)
+	})
+}


### PR DESCRIPTION
Replace the raw token Groups SID check with WindowsPrincipal.IsInRole, which calls CheckTokenMembership and returns true only when the Administrators SID is present and not marked deny-only. This correctly handles SSH sessions (Windows OpenSSH always provides a full elevated token for Administrators group members, regardless of UAC) as well as WinRM domain accounts and local accounts with LocalAccountTokenFilterPolicy=1. The previous Groups check could also produce false positives for WinRM local accounts with filtered tokens, where the Administrators SID is present but deny-only.

Fixes #332