### PR TITLE
  Add real-time log streaming for services and file following

### DIFF
--- a/initsystem/defaultprovider.go
+++ b/initsystem/defaultprovider.go
@@ -4,6 +4,7 @@ package initsystem
 import (
 	"context"
 	"errors"
+	"io"
 	"sync"
 
 	"github.com/k0sproject/rig/v2/cmd"
@@ -23,6 +24,13 @@ type ServiceManager interface {
 // ServiceManagerLogReader is a servicemanager that supports reading service logs.
 type ServiceManagerLogReader interface {
 	ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, lines int) ([]string, error)
+}
+
+// ServiceManagerLogStreamer is an optional interface for init systems that can follow
+// service logs in real time. The method streams log output to w until ctx is cancelled
+// or an error occurs. Context cancellation is treated as a clean stop, not an error.
+type ServiceManagerLogStreamer interface {
+	StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error
 }
 
 // ServiceManagerRestarter is a servicemanager that supports direct restarts (instead of stop+start).

--- a/initsystem/launchd.go
+++ b/initsystem/launchd.go
@@ -66,7 +66,7 @@ func (i Launchd) DisableService(ctx context.Context, h cmd.ContextRunner, s stri
 
 // ServiceLogs returns the logs for a launchd service.
 func (i Launchd) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, lines int) ([]string, error) {
-	out, err := h.ExecOutputContext(ctx, fmt.Sprintf("log show --predicate 'subsystem contains %s' --debug --info --last 10m --style syslog", strconv.QuoteToASCII(s)))
+	out, err := h.ExecOutputContext(ctx, sh.Command("log", "show", "--predicate", "subsystem contains "+strconv.QuoteToASCII(s), "--debug", "--info", "--last", "10m", "--style", "syslog"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get logs for service %s: %w", s, err)
 	}
@@ -79,7 +79,7 @@ func (i Launchd) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string,
 
 // StreamServiceLogs streams service logs to w using the macOS log stream command, until ctx is cancelled.
 func (i Launchd) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
-	return streamToWriter(ctx, h, s, fmt.Sprintf("log stream --predicate 'subsystem contains %s'", strconv.QuoteToASCII(s)), w)
+	return streamToWriter(ctx, h, s, sh.Command("log", "stream", "--predicate", "subsystem contains "+strconv.QuoteToASCII(s)), w)
 }
 
 // RegisterLaunchd registers the launchd init system to a init system repository.

--- a/initsystem/launchd.go
+++ b/initsystem/launchd.go
@@ -3,6 +3,7 @@ package initsystem
 import (
 	"context"
 	"fmt"
+	"io"
 	"path"
 	"strconv"
 	"strings"
@@ -74,6 +75,19 @@ func (i Launchd) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string,
 		return rows[len(rows)-lines:], nil
 	}
 	return rows, nil
+}
+
+// StreamServiceLogs streams service logs to w using the macOS log stream command, until ctx is cancelled.
+func (i Launchd) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
+	err := h.ExecContext(ctx, fmt.Sprintf("log stream --predicate 'subsystem contains %s'", strconv.QuoteToASCII(s)), cmd.Stdout(w))
+	if err != nil {
+		if ctx.Err() != nil {
+			// Context was cancelled, which is expected. Don't return the error.
+			return nil //nolint:nilerr // context cancellation is not an error condition
+		}
+		return fmt.Errorf("stream logs: %w", err)
+	}
+	return nil
 }
 
 // RegisterLaunchd registers the launchd init system to a init system repository.

--- a/initsystem/launchd.go
+++ b/initsystem/launchd.go
@@ -79,15 +79,7 @@ func (i Launchd) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string,
 
 // StreamServiceLogs streams service logs to w using the macOS log stream command, until ctx is cancelled.
 func (i Launchd) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
-	err := h.ExecContext(ctx, fmt.Sprintf("log stream --predicate 'subsystem contains %s'", strconv.QuoteToASCII(s)), cmd.Stdout(w))
-	if err != nil {
-		if ctx.Err() != nil {
-			// Context was cancelled, which is expected. Don't return the error.
-			return nil //nolint:nilerr // context cancellation is not an error condition
-		}
-		return fmt.Errorf("stream logs: %w", err)
-	}
-	return nil
+	return streamToWriter(ctx, h, s, fmt.Sprintf("log stream --predicate 'subsystem contains %s'", strconv.QuoteToASCII(s)), w)
 }
 
 // RegisterLaunchd registers the launchd init system to a init system repository.

--- a/initsystem/runit.go
+++ b/initsystem/runit.go
@@ -87,7 +87,7 @@ func (i Runit) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, l
 // StreamServiceLogs streams service logs to w by following /var/log/<service>/current, until ctx is cancelled.
 // It's not guaranteed that the log file exists or that the service logs to this file.
 func (i Runit) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
-	return streamToWriter(ctx, h, s, sh.Command("tail", "-f", "/var/log/"+s+"/current"), w)
+	return streamToWriter(ctx, h, s, sh.Command("tail", "-n", "0", "-f", "--", "/var/log/"+s+"/current"), w)
 }
 
 // RegisterRunit register runit in a repository.

--- a/initsystem/runit.go
+++ b/initsystem/runit.go
@@ -3,6 +3,7 @@ package initsystem
 import (
 	"context"
 	"fmt"
+	"io"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -81,6 +82,20 @@ func (i Runit) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, l
 		return nil, fmt.Errorf("failed to get logs for service %s: %w", s, err)
 	}
 	return strings.Split(out, "\n"), nil
+}
+
+// StreamServiceLogs streams service logs to w by following /var/log/<service>/current, until ctx is cancelled.
+// It's not guaranteed that the log file exists or that the service logs to this file.
+func (i Runit) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
+	err := h.ExecContext(ctx, sh.Command("tail", "-f", "/var/log/"+s+"/current"), cmd.Stdout(w))
+	if err != nil {
+		if ctx.Err() != nil {
+			// Context was cancelled, which is expected. Don't return the error.
+			return nil //nolint:nilerr // context cancellation is not an error condition
+		}
+		return fmt.Errorf("stream logs: %w", err)
+	}
+	return nil
 }
 
 // RegisterRunit register runit in a repository.

--- a/initsystem/runit.go
+++ b/initsystem/runit.go
@@ -87,15 +87,7 @@ func (i Runit) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, l
 // StreamServiceLogs streams service logs to w by following /var/log/<service>/current, until ctx is cancelled.
 // It's not guaranteed that the log file exists or that the service logs to this file.
 func (i Runit) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
-	err := h.ExecContext(ctx, sh.Command("tail", "-f", "/var/log/"+s+"/current"), cmd.Stdout(w))
-	if err != nil {
-		if ctx.Err() != nil {
-			// Context was cancelled, which is expected. Don't return the error.
-			return nil //nolint:nilerr // context cancellation is not an error condition
-		}
-		return fmt.Errorf("stream logs: %w", err)
-	}
-	return nil
+	return streamToWriter(ctx, h, s, sh.Command("tail", "-f", "/var/log/"+s+"/current"), w)
 }
 
 // RegisterRunit register runit in a repository.

--- a/initsystem/stream.go
+++ b/initsystem/stream.go
@@ -11,7 +11,7 @@ import (
 // streamToWriter runs command with stdout piped to w. Context cancellation is treated as a
 // clean stop and returns nil — it is the expected way for callers to terminate streaming.
 func streamToWriter(ctx context.Context, h cmd.ContextRunner, s, command string, w io.Writer) error {
-	err := h.ExecContext(ctx, command, cmd.Stdout(w))
+	err := h.ExecContext(ctx, command, cmd.Stdout(w), cmd.HideOutput())
 	if err != nil && ctx.Err() != nil {
 		return nil //nolint:nilerr // context cancellation is the expected stop signal
 	}

--- a/initsystem/stream.go
+++ b/initsystem/stream.go
@@ -1,0 +1,22 @@
+package initsystem
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/k0sproject/rig/v2/cmd"
+)
+
+// streamToWriter runs command with stdout piped to w. Context cancellation is treated as a
+// clean stop and returns nil — it is the expected way for callers to terminate streaming.
+func streamToWriter(ctx context.Context, h cmd.ContextRunner, s, command string, w io.Writer) error {
+	err := h.ExecContext(ctx, command, cmd.Stdout(w))
+	if err != nil && ctx.Err() != nil {
+		return nil //nolint:nilerr // context cancellation is the expected stop signal
+	}
+	if err != nil {
+		return fmt.Errorf("failed to stream logs for service %s: %w", s, err)
+	}
+	return nil
+}

--- a/initsystem/stream_test.go
+++ b/initsystem/stream_test.go
@@ -90,40 +90,46 @@ func TestStreamServiceLogsError(t *testing.T) {
 	}
 }
 
-func TestSystemdStreamServiceLogsCommand(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.AddCommandSuccess(rigtest.Contains("journalctl"))
-
-	_ = initsystem.Systemd{}.StreamServiceLogs(context.Background(), mr, "mysvc", io.Discard)
-
-	require.NoError(t, mr.Received(rigtest.Contains("journalctl -f -u mysvc")))
-}
-
-func TestUpstartStreamServiceLogsCommand(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.AddCommandSuccess(rigtest.Contains("tail"))
-
-	_ = initsystem.Upstart{}.StreamServiceLogs(context.Background(), mr, "mysvc", io.Discard)
-
-	require.NoError(t, mr.Received(rigtest.Contains("/var/log/upstart/mysvc.log")))
-}
-
-func TestRunitStreamServiceLogsCommand(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.AddCommandSuccess(rigtest.Contains("tail"))
-
-	_ = initsystem.Runit{}.StreamServiceLogs(context.Background(), mr, "mysvc", io.Discard)
-
-	require.NoError(t, mr.Received(rigtest.Contains("/var/log/mysvc/current")))
-}
-
-func TestLaunchdStreamServiceLogsCommand(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.AddCommandSuccess(rigtest.Contains("log stream"))
-
-	_ = initsystem.Launchd{}.StreamServiceLogs(context.Background(), mr, "mysvc", io.Discard)
-
-	require.NoError(t, mr.Received(rigtest.Contains("mysvc")))
+func TestStreamServiceLogsCommand(t *testing.T) {
+	cases := []struct {
+		name     string
+		streamer initsystem.ServiceManagerLogStreamer
+		setup    rigtest.CommandMatcher
+		expect   rigtest.CommandMatcher
+	}{
+		{
+			name:     "Systemd",
+			streamer: initsystem.Systemd{},
+			setup:    rigtest.Contains("journalctl"),
+			expect:   rigtest.Contains("journalctl -f -u mysvc"),
+		},
+		{
+			name:     "Upstart",
+			streamer: initsystem.Upstart{},
+			setup:    rigtest.Contains("tail"),
+			expect:   rigtest.Contains("/var/log/upstart/mysvc.log"),
+		},
+		{
+			name:     "Runit",
+			streamer: initsystem.Runit{},
+			setup:    rigtest.Contains("tail"),
+			expect:   rigtest.Contains("/var/log/mysvc/current"),
+		},
+		{
+			name:     "Launchd",
+			streamer: initsystem.Launchd{},
+			setup:    rigtest.Contains("log stream"),
+			expect:   rigtest.Contains("mysvc"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := rigtest.NewMockRunner()
+			mr.AddCommandSuccess(tc.setup)
+			_ = tc.streamer.StreamServiceLogs(context.Background(), mr, "mysvc", io.Discard)
+			require.NoError(t, mr.Received(tc.expect))
+		})
+	}
 }
 
 // Compile-time checks.

--- a/initsystem/stream_test.go
+++ b/initsystem/stream_test.go
@@ -1,0 +1,135 @@
+package initsystem_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/initsystem"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+// streamCase groups parameters for a generic stream test.
+type streamCase struct {
+	name      string
+	streamer  initsystem.ServiceManagerLogStreamer
+	cmdSubstr string
+}
+
+func streamCases() []streamCase {
+	return []streamCase{
+		{
+			name:      "Systemd",
+			streamer:  initsystem.Systemd{},
+			cmdSubstr: "journalctl",
+		},
+		{
+			name:      "Upstart",
+			streamer:  initsystem.Upstart{},
+			cmdSubstr: "tail",
+		},
+		{
+			name:      "Runit",
+			streamer:  initsystem.Runit{},
+			cmdSubstr: "tail",
+		},
+		{
+			name:      "Launchd",
+			streamer:  initsystem.Launchd{},
+			cmdSubstr: "log stream",
+		},
+	}
+}
+
+func TestStreamServiceLogsOutput(t *testing.T) {
+	for _, tc := range streamCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := rigtest.NewMockRunner()
+			mr.AddCommand(rigtest.Contains(tc.cmdSubstr), func(a *rigtest.A) error {
+				_, _ = a.Stdout.Write([]byte("line1\nline2\n"))
+				return nil
+			})
+
+			var buf bytes.Buffer
+			err := tc.streamer.StreamServiceLogs(context.Background(), mr, "svc", &buf)
+			require.NoError(t, err)
+			require.Equal(t, "line1\nline2\n", buf.String())
+		})
+	}
+}
+
+func TestStreamServiceLogsContextCancel(t *testing.T) {
+	for _, tc := range streamCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := rigtest.NewMockRunner()
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			mr.AddCommand(rigtest.Contains(tc.cmdSubstr), func(a *rigtest.A) error {
+				return a.Ctx.Err()
+			})
+
+			err := tc.streamer.StreamServiceLogs(ctx, mr, "svc", io.Discard)
+			require.NoError(t, err, "context cancellation should not return an error")
+		})
+	}
+}
+
+func TestStreamServiceLogsError(t *testing.T) {
+	for _, tc := range streamCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := rigtest.NewMockRunner()
+			execErr := errors.New("exec failed")
+			mr.AddCommandFailure(rigtest.Contains(tc.cmdSubstr), execErr)
+
+			err := tc.streamer.StreamServiceLogs(context.Background(), mr, "svc", io.Discard)
+			require.ErrorIs(t, err, execErr)
+		})
+	}
+}
+
+func TestSystemdStreamServiceLogsCommand(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandSuccess(rigtest.Contains("journalctl"))
+
+	_ = initsystem.Systemd{}.StreamServiceLogs(context.Background(), mr, "mysvc", io.Discard)
+
+	require.NoError(t, mr.Received(rigtest.Contains("journalctl -f -u mysvc")))
+}
+
+func TestUpstartStreamServiceLogsCommand(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandSuccess(rigtest.Contains("tail"))
+
+	_ = initsystem.Upstart{}.StreamServiceLogs(context.Background(), mr, "mysvc", io.Discard)
+
+	require.NoError(t, mr.Received(rigtest.Contains("/var/log/upstart/mysvc.log")))
+}
+
+func TestRunitStreamServiceLogsCommand(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandSuccess(rigtest.Contains("tail"))
+
+	_ = initsystem.Runit{}.StreamServiceLogs(context.Background(), mr, "mysvc", io.Discard)
+
+	require.NoError(t, mr.Received(rigtest.Contains("/var/log/mysvc/current")))
+}
+
+func TestLaunchdStreamServiceLogsCommand(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandSuccess(rigtest.Contains("log stream"))
+
+	_ = initsystem.Launchd{}.StreamServiceLogs(context.Background(), mr, "mysvc", io.Discard)
+
+	require.NoError(t, mr.Received(rigtest.Contains("mysvc")))
+}
+
+// Compile-time checks.
+var (
+	_ initsystem.ServiceManagerLogStreamer = initsystem.Systemd{}
+	_ initsystem.ServiceManagerLogStreamer = initsystem.Upstart{}
+	_ initsystem.ServiceManagerLogStreamer = initsystem.Runit{}
+	_ initsystem.ServiceManagerLogStreamer = initsystem.Launchd{}
+)

--- a/initsystem/stream_test.go
+++ b/initsystem/stream_test.go
@@ -101,7 +101,7 @@ func TestStreamServiceLogsCommand(t *testing.T) {
 			name:     "Systemd",
 			streamer: initsystem.Systemd{},
 			setup:    rigtest.Contains("journalctl"),
-			expect:   rigtest.Contains("journalctl -f -u mysvc"),
+			expect:   rigtest.Contains("journalctl -n 0 -f -u mysvc"),
 		},
 		{
 			name:     "Upstart",

--- a/initsystem/systemd.go
+++ b/initsystem/systemd.go
@@ -120,15 +120,7 @@ func (i Systemd) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string,
 
 // StreamServiceLogs streams service logs to w using journalctl -f, until ctx is cancelled.
 func (i Systemd) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
-	err := h.ExecContext(ctx, sh.Command("journalctl", "-f", "-u", s), cmd.Stdout(w))
-	if err != nil {
-		if ctx.Err() != nil {
-			// Context was cancelled, which is expected. Don't return the error.
-			return nil //nolint:nilerr // context cancellation is not an error condition
-		}
-		return fmt.Errorf("stream logs: %w", err)
-	}
-	return nil
+	return streamToWriter(ctx, h, s, sh.Command("journalctl", "-f", "-u", s), w)
 }
 
 // RegisterSystemd registers systemd into a repository.

--- a/initsystem/systemd.go
+++ b/initsystem/systemd.go
@@ -3,6 +3,7 @@ package initsystem
 import (
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"strconv"
 	"strings"
@@ -115,6 +116,19 @@ func (i Systemd) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string,
 	}
 
 	return strings.Split(out, "\n"), nil
+}
+
+// StreamServiceLogs streams service logs to w using journalctl -f, until ctx is cancelled.
+func (i Systemd) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
+	err := h.ExecContext(ctx, sh.Command("journalctl", "-f", "-u", s), cmd.Stdout(w))
+	if err != nil {
+		if ctx.Err() != nil {
+			// Context was cancelled, which is expected. Don't return the error.
+			return nil //nolint:nilerr // context cancellation is not an error condition
+		}
+		return fmt.Errorf("stream logs: %w", err)
+	}
+	return nil
 }
 
 // RegisterSystemd registers systemd into a repository.

--- a/initsystem/systemd.go
+++ b/initsystem/systemd.go
@@ -120,7 +120,7 @@ func (i Systemd) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string,
 
 // StreamServiceLogs streams service logs to w using journalctl -f, until ctx is cancelled.
 func (i Systemd) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
-	return streamToWriter(ctx, h, s, sh.Command("journalctl", "-f", "-u", s), w)
+	return streamToWriter(ctx, h, s, sh.Command("journalctl", "-n", "0", "-f", "-u", s), w)
 }
 
 // RegisterSystemd registers systemd into a repository.

--- a/initsystem/upstart.go
+++ b/initsystem/upstart.go
@@ -3,6 +3,7 @@ package initsystem
 import (
 	"context"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 
@@ -78,6 +79,20 @@ func (i Upstart) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string,
 		return nil, fmt.Errorf("failed to get logs for service %s: %w", s, err)
 	}
 	return strings.Split(out, "\n"), nil
+}
+
+// StreamServiceLogs streams service logs to w by following /var/log/upstart/<service>.log, until ctx is cancelled.
+// It's not guaranteed that the log file exists or that the service logs to this file.
+func (i Upstart) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
+	err := h.ExecContext(ctx, sh.Command("tail", "-f", "/var/log/upstart/"+s+".log"), cmd.Stdout(w))
+	if err != nil {
+		if ctx.Err() != nil {
+			// Context was cancelled, which is expected. Don't return the error.
+			return nil //nolint:nilerr // context cancellation is not an error condition
+		}
+		return fmt.Errorf("stream logs: %w", err)
+	}
+	return nil
 }
 
 // RegisterUpstart registers Upstart in a repository.

--- a/initsystem/upstart.go
+++ b/initsystem/upstart.go
@@ -84,7 +84,7 @@ func (i Upstart) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string,
 // StreamServiceLogs streams service logs to w by following /var/log/upstart/<service>.log, until ctx is cancelled.
 // It's not guaranteed that the log file exists or that the service logs to this file.
 func (i Upstart) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
-	return streamToWriter(ctx, h, s, sh.Command("tail", "-f", "/var/log/upstart/"+s+".log"), w)
+	return streamToWriter(ctx, h, s, sh.Command("tail", "-n", "0", "-f", "--", "/var/log/upstart/"+s+".log"), w)
 }
 
 // RegisterUpstart registers Upstart in a repository.

--- a/initsystem/upstart.go
+++ b/initsystem/upstart.go
@@ -84,15 +84,7 @@ func (i Upstart) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string,
 // StreamServiceLogs streams service logs to w by following /var/log/upstart/<service>.log, until ctx is cancelled.
 // It's not guaranteed that the log file exists or that the service logs to this file.
 func (i Upstart) StreamServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, w io.Writer) error {
-	err := h.ExecContext(ctx, sh.Command("tail", "-f", "/var/log/upstart/"+s+".log"), cmd.Stdout(w))
-	if err != nil {
-		if ctx.Err() != nil {
-			// Context was cancelled, which is expected. Don't return the error.
-			return nil //nolint:nilerr // context cancellation is not an error condition
-		}
-		return fmt.Errorf("stream logs: %w", err)
-	}
-	return nil
+	return streamToWriter(ctx, h, s, sh.Command("tail", "-f", "/var/log/upstart/"+s+".log"), w)
 }
 
 // RegisterUpstart registers Upstart in a repository.

--- a/initsystem/winscm.go
+++ b/initsystem/winscm.go
@@ -54,6 +54,9 @@ func (c WinSCM) EnableService(ctx context.Context, h cmd.ContextRunner, s string
 }
 
 // ServiceLogs returns the logs for a service.
+// ServiceLogs returns Service Control Manager lifecycle events for the service from the System
+// event log (start, stop, crash). This reflects SCM control events only, not the service's own
+// application output. Services that write to a file or a separate event log source are not covered.
 func (c WinSCM) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, lines int) ([]string, error) {
 	command := fmt.Sprintf(`Get-EventLog -LogName System -Source "Service Control Manager" -Newest %[1]d | Where-Object {$_.Message -like "*%s*"} | Select-Object -Property TimeGenerated, Message -First %[1]d`, lines, s)
 	out, err := h.ExecOutputContext(ctx, command, cmd.PS())

--- a/initsystem/winscm.go
+++ b/initsystem/winscm.go
@@ -53,12 +53,11 @@ func (c WinSCM) EnableService(ctx context.Context, h cmd.ContextRunner, s string
 	return nil
 }
 
-// ServiceLogs returns the logs for a service.
 // ServiceLogs returns Service Control Manager lifecycle events for the service from the System
 // event log (start, stop, crash). This reflects SCM control events only, not the service's own
 // application output. Services that write to a file or a separate event log source are not covered.
 func (c WinSCM) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, lines int) ([]string, error) {
-	command := fmt.Sprintf(`Get-EventLog -LogName System -Source "Service Control Manager" -Newest %[1]d | Where-Object {$_.Message -like "*%s*"} | Select-Object -Property TimeGenerated, Message -First %[1]d`, lines, s)
+	command := fmt.Sprintf(`Get-EventLog -LogName System -Source "Service Control Manager" -Newest %[1]d | Where-Object {$_.Message -match [regex]::Escape(%s)} | Select-Object -Property TimeGenerated, Message -First %[1]d`, lines, ps.SingleQuote(s))
 	out, err := h.ExecOutputContext(ctx, command, cmd.PS())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get logs for service %s: %w", s, err)

--- a/remotefs/hostinfo_test.go
+++ b/remotefs/hostinfo_test.go
@@ -1,10 +1,12 @@
 package remotefs_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"testing"
 	"time"
@@ -641,3 +643,45 @@ func TestWindowsRename(t *testing.T) {
 	})
 }
 
+
+func TestPosixFSFollow(t *testing.T) {
+	const path = "/var/log/app.log"
+
+	t.Run("output flows to writer", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommand(rigtest.Contains("tail"), func(a *rigtest.A) error {
+			_, _ = a.Stdout.Write([]byte("new line\n"))
+			return nil
+		})
+		fs := remotefs.NewPosixFS(mr)
+		var buf bytes.Buffer
+		require.NoError(t, fs.Follow(context.Background(), path, &buf))
+		require.Equal(t, "new line\n", buf.String())
+	})
+
+	t.Run("starts from EOF", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandSuccess(rigtest.Contains("tail"))
+		fs := remotefs.NewPosixFS(mr)
+		_ = fs.Follow(context.Background(), path, io.Discard)
+		require.NoError(t, mr.Received(rigtest.Contains("-n 0")))
+	})
+
+	t.Run("context cancellation returns nil", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		mr.AddCommand(rigtest.Contains("tail"), func(a *rigtest.A) error {
+			return a.Ctx.Err()
+		})
+		fs := remotefs.NewPosixFS(mr)
+		require.NoError(t, fs.Follow(ctx, path, io.Discard), "context cancellation should not return an error")
+	})
+
+	t.Run("command error propagates", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Contains("tail"), errors.New("permission denied"))
+		fs := remotefs.NewPosixFS(mr)
+		require.Error(t, fs.Follow(context.Background(), path, io.Discard))
+	})
+}

--- a/remotefs/patchfile_test.go
+++ b/remotefs/patchfile_test.go
@@ -1,7 +1,9 @@
 package remotefs_test
 
 import (
+	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"net/http"
 	"path"
@@ -73,6 +75,7 @@ func (f *patchFS) Touch(_ string, _ ...time.Time) error                    { pan
 func (f *patchFS) Truncate(_ string, _ int64) error                        { panic("not implemented") }
 func (f *patchFS) Getenv(_ string) string                                  { panic("not implemented") }
 func (f *patchFS) FileContains(_, _ string) (bool, error)                  { panic("not implemented") }
+func (f *patchFS) Follow(_ context.Context, _ string, _ io.Writer) error   { panic("not implemented") }
 func (f *patchFS) IsContainer() (bool, error)                              { panic("not implemented") }
 func (f *patchFS) Hostname() (string, error)                               { panic("not implemented") }
 func (f *patchFS) LongHostname() (string, error)                           { panic("not implemented") }

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -3,6 +3,7 @@ package remotefs
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -590,6 +591,19 @@ func (s *PosixFS) FileContains(name, substr string) (bool, error) {
 			return false, fmt.Errorf("file-contains %s: %w (exit %d)", name, errTestFailed, testStatus)
 		}
 	}
+}
+
+// Follow streams new content appended to path to w until ctx is cancelled.
+// Cancelling ctx is the expected way to stop following and does not return an error.
+func (s *PosixFS) Follow(ctx context.Context, path string, w io.Writer) error {
+	err := s.ExecContext(ctx, sh.Command("tail", "-f", path), cmd.Stdout(w))
+	if err != nil && ctx.Err() != nil {
+		return nil //nolint:nilerr // context cancellation is the expected stop signal
+	}
+	if err != nil {
+		return fmt.Errorf("follow %s: %w", path, err)
+	}
+	return nil
 }
 
 // IsContainer reports whether the remote host is running inside a container

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -596,7 +596,7 @@ func (s *PosixFS) FileContains(name, substr string) (bool, error) {
 // Follow streams new content appended to path to w until ctx is cancelled.
 // Cancelling ctx is the expected way to stop following and does not return an error.
 func (s *PosixFS) Follow(ctx context.Context, path string, w io.Writer) error {
-	err := s.ExecContext(ctx, sh.Command("tail", "-n", "0", "-f", "--", path), cmd.Stdout(w))
+	err := s.ExecContext(ctx, sh.Command("tail", "-n", "0", "-f", "--", path), cmd.Stdout(w), cmd.HideOutput())
 	if err != nil && ctx.Err() != nil {
 		return nil //nolint:nilerr // context cancellation is the expected stop signal
 	}

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -596,7 +596,7 @@ func (s *PosixFS) FileContains(name, substr string) (bool, error) {
 // Follow streams new content appended to path to w until ctx is cancelled.
 // Cancelling ctx is the expected way to stop following and does not return an error.
 func (s *PosixFS) Follow(ctx context.Context, path string, w io.Writer) error {
-	err := s.ExecContext(ctx, sh.Command("tail", "-f", path), cmd.Stdout(w))
+	err := s.ExecContext(ctx, sh.Command("tail", "-n", "0", "-f", "--", path), cmd.Stdout(w))
 	if err != nil && ctx.Err() != nil {
 		return nil //nolint:nilerr // context cancellation is the expected stop signal
 	}

--- a/remotefs/types.go
+++ b/remotefs/types.go
@@ -1,6 +1,7 @@
 package remotefs
 
 import (
+	"context"
 	"errors"
 	"io"
 	"io/fs"
@@ -55,6 +56,7 @@ type OS interface { //nolint:interfacebloat // intentionally large interface
 	Getenv(key string) string
 	Rename(oldpath, newpath string) error
 	FileContains(path, substr string) (bool, error)
+	Follow(ctx context.Context, path string, w io.Writer) error
 	IsContainer() (bool, error)
 	Hostname() (string, error)
 	LongHostname() (string, error)

--- a/remotefs/upload_test.go
+++ b/remotefs/upload_test.go
@@ -1,6 +1,7 @@
 package remotefs_test
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
@@ -67,6 +68,7 @@ func (f *uploadFS) Rename(_, _ string) error                                { pa
 func (f *uploadFS) DownloadURL(_ string, _ string) error                    { panic("not implemented") }
 func (f *uploadFS) RoundTrip(_ *http.Request) (*http.Response, error)       { panic("not implemented") }
 func (f *uploadFS) FileContains(_ string, _ string) (bool, error)           { panic("not implemented") }
+func (f *uploadFS) Follow(_ context.Context, _ string, _ io.Writer) error   { panic("not implemented") }
 func (f *uploadFS) IsContainer() (bool, error)                              { panic("not implemented") }
 func (f *uploadFS) Hostname() (string, error)                               { panic("not implemented") }
 func (f *uploadFS) LongHostname() (string, error)                           { panic("not implemented") }

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -587,7 +587,7 @@ try {
 // Follow streams new content appended to path to w until ctx is cancelled.
 // Cancelling ctx is the expected way to stop following and does not return an error.
 func (s *WinFS) Follow(ctx context.Context, path string, w io.Writer) error {
-	err := s.ExecContext(ctx, fmt.Sprintf("Get-Content -LiteralPath %s -Tail 0 -Wait", ps.SingleQuote(ps.ToWindowsPath(path))), cmd.Stdout(w), cmd.PS())
+	err := s.ExecContext(ctx, fmt.Sprintf("Get-Content -LiteralPath %s -Tail 0 -Wait", ps.SingleQuote(ps.ToWindowsPath(path))), cmd.Stdout(w), cmd.HideOutput(), cmd.PS())
 	if err != nil && ctx.Err() != nil {
 		return nil //nolint:nilerr // context cancellation is the expected stop signal
 	}

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -587,7 +587,7 @@ try {
 // Follow streams new content appended to path to w until ctx is cancelled.
 // Cancelling ctx is the expected way to stop following and does not return an error.
 func (s *WinFS) Follow(ctx context.Context, path string, w io.Writer) error {
-	err := s.ExecContext(ctx, fmt.Sprintf("Get-Content -LiteralPath %s -Wait", ps.DoubleQuotePath(path)), cmd.Stdout(w), cmd.PS())
+	err := s.ExecContext(ctx, fmt.Sprintf("Get-Content -LiteralPath %s -Tail 0 -Wait", ps.DoubleQuotePath(path)), cmd.Stdout(w), cmd.PS())
 	if err != nil && ctx.Err() != nil {
 		return nil //nolint:nilerr // context cancellation is the expected stop signal
 	}

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -587,7 +587,7 @@ try {
 // Follow streams new content appended to path to w until ctx is cancelled.
 // Cancelling ctx is the expected way to stop following and does not return an error.
 func (s *WinFS) Follow(ctx context.Context, path string, w io.Writer) error {
-	err := s.ExecContext(ctx, fmt.Sprintf("Get-Content -LiteralPath %s -Tail 0 -Wait", ps.DoubleQuotePath(path)), cmd.Stdout(w), cmd.PS())
+	err := s.ExecContext(ctx, fmt.Sprintf("Get-Content -LiteralPath %s -Tail 0 -Wait", ps.SingleQuote(ps.ToWindowsPath(path))), cmd.Stdout(w), cmd.PS())
 	if err != nil && ctx.Err() != nil {
 		return nil //nolint:nilerr // context cancellation is the expected stop signal
 	}

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -2,6 +2,7 @@ package remotefs
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -581,6 +582,19 @@ try {
 	default:
 		return false, fmt.Errorf("file-contains %s: %w: %q", name, errUnexpectedOutput, status)
 	}
+}
+
+// Follow streams new content appended to path to w until ctx is cancelled.
+// Cancelling ctx is the expected way to stop following and does not return an error.
+func (s *WinFS) Follow(ctx context.Context, path string, w io.Writer) error {
+	err := s.ExecContext(ctx, fmt.Sprintf("Get-Content -LiteralPath %s -Wait", ps.DoubleQuotePath(path)), cmd.Stdout(w), cmd.PS())
+	if err != nil && ctx.Err() != nil {
+		return nil //nolint:nilerr // context cancellation is the expected stop signal
+	}
+	if err != nil {
+		return fmt.Errorf("follow %s: %w", path, err)
+	}
+	return nil
 }
 
 // IsContainer reports whether the host is running inside a container.

--- a/remotefs/winfs_test.go
+++ b/remotefs/winfs_test.go
@@ -1,6 +1,10 @@
 package remotefs_test
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
 	"io/fs"
 	"testing"
 
@@ -8,6 +12,43 @@ import (
 	"github.com/k0sproject/rig/v2/rigtest"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWinFSFollow(t *testing.T) {
+	const path = `C:\logs\app.log`
+
+	t.Run("output flows to writer", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommand(rigtest.Contains("powershell.exe"), func(a *rigtest.A) error {
+			_, _ = a.Stdout.Write([]byte("new line\n"))
+			return nil
+		})
+		fsys := remotefs.NewWindowsFS(mr)
+		var buf bytes.Buffer
+		require.NoError(t, fsys.Follow(context.Background(), path, &buf))
+		require.Equal(t, "new line\n", buf.String())
+	})
+
+	t.Run("context cancellation returns nil", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		mr.AddCommand(rigtest.Contains("powershell.exe"), func(a *rigtest.A) error {
+			return a.Ctx.Err()
+		})
+		fsys := remotefs.NewWindowsFS(mr)
+		require.NoError(t, fsys.Follow(ctx, path, io.Discard), "context cancellation should not return an error")
+	})
+
+	t.Run("command error propagates", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandFailure(rigtest.Contains("powershell.exe"), errors.New("access denied"))
+		fsys := remotefs.NewWindowsFS(mr)
+		require.Error(t, fsys.Follow(context.Background(), path, io.Discard))
+	})
+}
 
 func TestWinFSChmod(t *testing.T) {
 	t.Run("writable mode clears read-only attribute", func(t *testing.T) {

--- a/remotefs/writefileatomic_test.go
+++ b/remotefs/writefileatomic_test.go
@@ -37,33 +37,33 @@ func (o *atomicOS) Rename(_, _ string) error                          { return o
 func (o *atomicOS) Remove(p string) error                             { o.removedPaths = append(o.removedPaths, p); return nil }
 
 // Unused methods — panic on call so misuse is caught immediately.
-func (o *atomicOS) RemoveAll(_ string) error               { panic("not implemented") }
-func (o *atomicOS) Mkdir(_ string, _ fs.FileMode) error    { panic("not implemented") }
-func (o *atomicOS) MkdirTemp(_, _ string) (string, error)  { panic("not implemented") }
-func (o *atomicOS) FileExist(_ string) bool                { panic("not implemented") }
-func (o *atomicOS) LookPath(_ string) (string, error)      { panic("not implemented") }
-func (o *atomicOS) Join(_ ...string) string                { panic("not implemented") }
-func (o *atomicOS) Chown(_ string, _ string) error         { panic("not implemented") }
-func (o *atomicOS) ChownInt(_ string, _, _ int) error      { panic("not implemented") }
-func (o *atomicOS) ChownTree(_ string, _ string) error     { panic("not implemented") }
-func (o *atomicOS) ChownTreeInt(_ string, _, _ int) error  { panic("not implemented") }
-func (o *atomicOS) Chtimes(_ string, _, _ int64) error     { panic("not implemented") }
-func (o *atomicOS) Touch(_ string, _ ...time.Time) error   { panic("not implemented") }
-func (o *atomicOS) Truncate(_ string, _ int64) error       { panic("not implemented") }
-func (o *atomicOS) Getenv(_ string) string                 { panic("not implemented") }
-func (o *atomicOS) FileContains(_, _ string) (bool, error)                 { panic("not implemented") }
-func (o *atomicOS) Follow(_ context.Context, _ string, _ io.Writer) error  { panic("not implemented") }
-func (o *atomicOS) IsContainer() (bool, error)                             { panic("not implemented") }
-func (o *atomicOS) Hostname() (string, error)              { panic("not implemented") }
-func (o *atomicOS) LongHostname() (string, error)          { panic("not implemented") }
-func (o *atomicOS) MachineID() (string, error)             { panic("not implemented") }
-func (o *atomicOS) SystemTime() (time.Time, error)         { panic("not implemented") }
-func (o *atomicOS) TempDir() string                        { panic("not implemented") }
-func (o *atomicOS) UserCacheDir() string                   { panic("not implemented") }
-func (o *atomicOS) UserConfigDir() string                  { panic("not implemented") }
-func (o *atomicOS) UserHomeDir() string                    { panic("not implemented") }
-func (o *atomicOS) Base(_ string) string                   { panic("not implemented") }
-func (o *atomicOS) CommandExist(_ string) bool             { panic("not implemented") }
+func (o *atomicOS) RemoveAll(_ string) error                              { panic("not implemented") }
+func (o *atomicOS) Mkdir(_ string, _ fs.FileMode) error                   { panic("not implemented") }
+func (o *atomicOS) MkdirTemp(_, _ string) (string, error)                 { panic("not implemented") }
+func (o *atomicOS) FileExist(_ string) bool                               { panic("not implemented") }
+func (o *atomicOS) LookPath(_ string) (string, error)                     { panic("not implemented") }
+func (o *atomicOS) Join(_ ...string) string                               { panic("not implemented") }
+func (o *atomicOS) Chown(_ string, _ string) error                        { panic("not implemented") }
+func (o *atomicOS) ChownInt(_ string, _, _ int) error                     { panic("not implemented") }
+func (o *atomicOS) ChownTree(_ string, _ string) error                    { panic("not implemented") }
+func (o *atomicOS) ChownTreeInt(_ string, _, _ int) error                 { panic("not implemented") }
+func (o *atomicOS) Chtimes(_ string, _, _ int64) error                    { panic("not implemented") }
+func (o *atomicOS) Touch(_ string, _ ...time.Time) error                  { panic("not implemented") }
+func (o *atomicOS) Truncate(_ string, _ int64) error                      { panic("not implemented") }
+func (o *atomicOS) Getenv(_ string) string                                { panic("not implemented") }
+func (o *atomicOS) FileContains(_, _ string) (bool, error)                { panic("not implemented") }
+func (o *atomicOS) Follow(_ context.Context, _ string, _ io.Writer) error { panic("not implemented") }
+func (o *atomicOS) IsContainer() (bool, error)                            { panic("not implemented") }
+func (o *atomicOS) Hostname() (string, error)                             { panic("not implemented") }
+func (o *atomicOS) LongHostname() (string, error)                         { panic("not implemented") }
+func (o *atomicOS) MachineID() (string, error)                            { panic("not implemented") }
+func (o *atomicOS) SystemTime() (time.Time, error)                        { panic("not implemented") }
+func (o *atomicOS) TempDir() string                                       { panic("not implemented") }
+func (o *atomicOS) UserCacheDir() string                                  { panic("not implemented") }
+func (o *atomicOS) UserConfigDir() string                                 { panic("not implemented") }
+func (o *atomicOS) UserHomeDir() string                                   { panic("not implemented") }
+func (o *atomicOS) Base(_ string) string                                  { panic("not implemented") }
+func (o *atomicOS) CommandExist(_ string) bool                            { panic("not implemented") }
 
 // Compile-time check that atomicOS satisfies remotefs.OS.
 var _ remotefs.OS = (*atomicOS)(nil)

--- a/remotefs/writefileatomic_test.go
+++ b/remotefs/writefileatomic_test.go
@@ -1,7 +1,9 @@
 package remotefs_test
 
 import (
+	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"path"
 	"testing"
@@ -49,8 +51,9 @@ func (o *atomicOS) Chtimes(_ string, _, _ int64) error     { panic("not implemen
 func (o *atomicOS) Touch(_ string, _ ...time.Time) error   { panic("not implemented") }
 func (o *atomicOS) Truncate(_ string, _ int64) error       { panic("not implemented") }
 func (o *atomicOS) Getenv(_ string) string                 { panic("not implemented") }
-func (o *atomicOS) FileContains(_, _ string) (bool, error) { panic("not implemented") }
-func (o *atomicOS) IsContainer() (bool, error)             { panic("not implemented") }
+func (o *atomicOS) FileContains(_, _ string) (bool, error)                 { panic("not implemented") }
+func (o *atomicOS) Follow(_ context.Context, _ string, _ io.Writer) error  { panic("not implemented") }
+func (o *atomicOS) IsContainer() (bool, error)                             { panic("not implemented") }
 func (o *atomicOS) Hostname() (string, error)              { panic("not implemented") }
 func (o *atomicOS) LongHostname() (string, error)          { panic("not implemented") }
 func (o *atomicOS) MachineID() (string, error)             { panic("not implemented") }

--- a/service.go
+++ b/service.go
@@ -169,8 +169,9 @@ func (m *Service) Logs(ctx context.Context, lines int) ([]string, error) {
 	return rows, nil
 }
 
-// StreamLogs streams service log output to w until ctx is cancelled or an error occurs.
-// Cancelling ctx is the expected way to stop streaming and does not return an error.
+// StreamLogs streams new service log output to w from the current point in time until ctx is
+// cancelled or an error occurs. Cancelling ctx is the expected way to stop streaming and does
+// not return an error.
 func (m *Service) StreamLogs(ctx context.Context, w io.Writer) error {
 	streamer, ok := m.initsys.(initsystem.ServiceManagerLogStreamer)
 	if !ok {

--- a/service.go
+++ b/service.go
@@ -178,6 +178,9 @@ func (m *Service) StreamLogs(ctx context.Context, w io.Writer) error {
 		return errLogStreamerNotSupported
 	}
 	if err := streamer.StreamServiceLogs(ctx, m.runner, m.name, w); err != nil {
+		if ctx.Err() != nil {
+			return nil //nolint:nilerr // context cancellation is the expected stop signal
+		}
 		return fmt.Errorf("stream logs for service '%s': %w", m.name, err)
 	}
 	return nil

--- a/service.go
+++ b/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"path"
 	"time"
@@ -148,6 +149,7 @@ func (m *Service) IsRunning(ctx context.Context) bool {
 
 var (
 	errLogReaderNotSupported    = errors.New("init system provider does not implement log reader")
+	errLogStreamerNotSupported  = errors.New("init system provider does not support log streaming")
 	errEnvManagerNotSupported   = errors.New("init system provider does not support service environment management")
 	errDaemonReloadNotSupported = errors.New("init system provider does not support daemon-reload")
 	errServiceFSNotAvailable    = errors.New("service has no filesystem access; use client.Service() instead of GetService()")
@@ -165,6 +167,19 @@ func (m *Service) Logs(ctx context.Context, lines int) ([]string, error) {
 		return nil, fmt.Errorf("get logs: %w", err)
 	}
 	return rows, nil
+}
+
+// StreamLogs streams service log output to w until ctx is cancelled or an error occurs.
+// Cancelling ctx is the expected way to stop streaming and does not return an error.
+func (m *Service) StreamLogs(ctx context.Context, w io.Writer) error {
+	streamer, ok := m.initsys.(initsystem.ServiceManagerLogStreamer)
+	if !ok {
+		return errLogStreamerNotSupported
+	}
+	if err := streamer.StreamServiceLogs(ctx, m.runner, m.name, w); err != nil {
+		return fmt.Errorf("stream logs: %w", err)
+	}
+	return nil
 }
 
 // SetEnvironment writes environment variable overrides for the service and triggers a daemon-reload

--- a/service.go
+++ b/service.go
@@ -177,7 +177,7 @@ func (m *Service) StreamLogs(ctx context.Context, w io.Writer) error {
 		return errLogStreamerNotSupported
 	}
 	if err := streamer.StreamServiceLogs(ctx, m.runner, m.name, w); err != nil {
-		return fmt.Errorf("stream logs: %w", err)
+		return fmt.Errorf("stream logs for service '%s': %w", m.name, err)
 	}
 	return nil
 }

--- a/service_test.go
+++ b/service_test.go
@@ -357,6 +357,14 @@ func TestServiceStreamLogs(t *testing.T) {
 		require.ErrorIs(t, err, streamErr)
 	})
 
+	t.Run("context cancellation returns nil", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		mgr := &mockLogStreamer{err: cancelCtx.Err()}
+		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: mgr}
+		require.NoError(t, svc.StreamLogs(cancelCtx, io.Discard), "context cancellation should not return an error")
+	})
+
 	t.Run("not supported", func(t *testing.T) {
 		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: &mockBasicManager{}}
 		err := svc.StreamLogs(ctx, io.Discard)

--- a/service_test.go
+++ b/service_test.go
@@ -1,8 +1,10 @@
 package rig
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"testing"
 
@@ -321,9 +323,51 @@ func TestServiceRestart(t *testing.T) {
 	})
 }
 
+// mockLogStreamer implements ServiceManager + ServiceManagerLogStreamer.
+type mockLogStreamer struct {
+	mockBasicManager
+	output string
+	err    error
+}
+
+func (m *mockLogStreamer) StreamServiceLogs(_ context.Context, _ cmd.ContextRunner, _ string, w io.Writer) error {
+	if m.err != nil {
+		return m.err
+	}
+	_, _ = w.Write([]byte(m.output))
+	return nil
+}
+
+func TestServiceStreamLogs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("delegates to streamer and writes output", func(t *testing.T) {
+		mgr := &mockLogStreamer{output: "log line\n"}
+		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: mgr}
+		var buf bytes.Buffer
+		require.NoError(t, svc.StreamLogs(ctx, &buf))
+		require.Equal(t, "log line\n", buf.String())
+	})
+
+	t.Run("propagates streamer error", func(t *testing.T) {
+		streamErr := errors.New("stream error")
+		mgr := &mockLogStreamer{err: streamErr}
+		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: mgr}
+		err := svc.StreamLogs(ctx, io.Discard)
+		require.ErrorIs(t, err, streamErr)
+	})
+
+	t.Run("not supported", func(t *testing.T) {
+		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: &mockBasicManager{}}
+		err := svc.StreamLogs(ctx, io.Discard)
+		require.ErrorIs(t, err, errLogStreamerNotSupported)
+	})
+}
+
 // Ensure initsystem.ServiceEnvironmentManager is satisfied by types implementing it.
 var _ initsystem.ServiceEnvironmentManager = (*mockEnvManager)(nil)
 var _ initsystem.ServiceManagerReloader = (*mockReloadEnvManager)(nil)
 var _ initsystem.ServiceManager = (*mockBasicManager)(nil)
 var _ initsystem.ServiceManager = (*mockLifecycleManager)(nil)
 var _ initsystem.ServiceManagerRestarter = (*mockNativeRestarter)(nil)
+var _ initsystem.ServiceManagerLogStreamer = (*mockLogStreamer)(nil)


### PR DESCRIPTION
  - `Service.StreamLogs(ctx, w)` streams service logs in real time until the context is cancelled. Implemented for Systemd (journalctl -f), Upstart (tail -f), Runit (tail -f), and Launchd (log stream). Context cancellation is the expected stop signal and returns nil.
  - `remotefs.OS.Follow(ctx, path, w)` generic file tailing added to the OS interface, implemented on PosixFS (tail -f) and WinFS (Get-Content -LiteralPath -Wait).
  - `ServiceManagerLogStreamer` interface new optional interface in initsystem, parallel to the existing ServiceManagerLogReader, checked at runtime via type assertion in Service.StreamLogs.
  - WinSCM ServiceLogs injection fix — pre-existing: service name was interpolated raw into a PowerShell -like "*name*" pattern. Fixed by switching to -match [regex]::Escape('name'), which is safe for any service name including those with $, *, ?, [.
  - WinSCM scope clarification — ServiceLogs doc comment now states it returns SCM lifecycle events only (start/stop/crash), not the service's own application output.

### Notes

  - WinSCM has no streaming implementation — the Windows Event Log has no native follow mechanism and polling would be semantically different. Service.StreamLogs returns errLogStreamerNotSupported on Windows.
  - OpenRC and SysVinit remain log-reader-only (no standard per-service log location for either snapshot or 


Part of the rig v2 last mile effort - breaking API is not a concern as rig v2 has not been released yet.
