### PR TITLE
Use the "sh" package where applicable

### DIFF
--- a/initsystem/upstart.go
+++ b/initsystem/upstart.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/k0sproject/rig/v2/cmd"
 	"github.com/k0sproject/rig/v2/sh"
-	"github.com/k0sproject/rig/v2/sh/shellescape"
 )
 
 // Upstart is the init system used by Ubuntu 14.04 and older.
@@ -65,7 +64,7 @@ func (i Upstart) EnableService(ctx context.Context, h cmd.ContextRunner, s strin
 // DisableService for Upstart.
 func (i Upstart) DisableService(ctx context.Context, h cmd.ContextRunner, s string) error {
 	overridePath := fmt.Sprintf("/etc/init/%s.override", s)
-	if err := h.ExecContext(ctx, "echo 'manual' > "+shellescape.Quote(overridePath)); err != nil {
+	if err := h.ExecContext(ctx, sh.Command("tee", overridePath), cmd.StdinString("manual\n"), cmd.HideOutput()); err != nil {
 		return fmt.Errorf("failed to create override file %s: %w", overridePath, err)
 	}
 	return nil

--- a/remotefs/posixfile.go
+++ b/remotefs/posixfile.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/k0sproject/rig/v2/cmd"
 	"github.com/k0sproject/rig/v2/iostream"
+	"github.com/k0sproject/rig/v2/sh"
 	"github.com/k0sproject/rig/v2/sh/shellescape"
 )
 
@@ -90,7 +91,7 @@ func (f *PosixFile) Read(p []byte) (int, error) {
 
 	bs, skip, count := f.ddParams(f.pos, len(p))
 
-	if err := f.fs.Exec(fmt.Sprintf("dd if=%s bs=%d skip=%d count=%d", shellescape.Quote(f.path), bs, skip, count), cmd.Stdout(buf), cmd.HideOutput()); err != nil {
+	if err := f.fs.Exec(sh.Command("dd", "if="+f.path, fmt.Sprintf("bs=%d", bs), fmt.Sprintf("skip=%d", skip), fmt.Sprintf("count=%d", count)), cmd.Stdout(buf), cmd.HideOutput()); err != nil {
 		return 0, fmt.Errorf("failed to execute dd: %w", err)
 	}
 
@@ -124,7 +125,7 @@ func (f *PosixFile) Write(p []byte) (int, error) {
 		limitedReader := bytes.NewReader(remaining[:toWrite])
 
 		err := f.fs.Exec(
-			fmt.Sprintf("dd if=/dev/stdin of=%s bs=%d count=%d seek=%d conv=notrunc", f.path, bs, count, skip),
+			sh.Command("dd", "if=/dev/stdin", "of="+f.path, fmt.Sprintf("bs=%d", bs), fmt.Sprintf("count=%d", count), fmt.Sprintf("seek=%d", skip), "conv=notrunc"),
 			cmd.Stdin(limitedReader),
 		)
 		if err != nil {
@@ -158,7 +159,7 @@ func (f *PosixFile) CopyTo(dst io.Writer) (int64, error) {
 	counter := &iostream.ByteCounter{}
 	writer := io.MultiWriter(dst, counter)
 	err := f.fs.Exec(
-		fmt.Sprintf("dd if=%s bs=%d skip=%d count=%d", shellescape.Quote(f.path), bs, skip, count),
+		sh.Command("dd", "if="+f.path, fmt.Sprintf("bs=%d", bs), fmt.Sprintf("skip=%d", skip), fmt.Sprintf("count=%d", count)),
 		cmd.Stdout(writer),
 		cmd.HideOutput(),
 	)
@@ -182,7 +183,7 @@ func (f *PosixFile) CopyFrom(src io.Reader) (int64, error) {
 	counter := &iostream.ByteCounter{}
 
 	err := f.fs.Exec(
-		fmt.Sprintf("dd if=/dev/stdin of=%s bs=%d seek=%d conv=notrunc", shellescape.Quote(f.path), f.fsBlockSize(), f.pos),
+		sh.Command("dd", "if=/dev/stdin", "of="+f.path, fmt.Sprintf("bs=%d", f.fsBlockSize()), fmt.Sprintf("seek=%d", f.pos), "conv=notrunc"),
 		cmd.Stdin(io.TeeReader(src, counter)),
 	)
 	if err != nil {

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -347,7 +347,7 @@ func (s *PosixFS) Truncate(name string, size int64) error {
 
 // Chmod changes the mode of the named file to mode.
 func (s *PosixFS) Chmod(name string, mode fs.FileMode) error {
-	if err := s.Exec(fmt.Sprintf("chmod %#o %s", mode, shellescape.Quote(name))); err != nil {
+	if err := s.Exec(sh.Command("chmod", fmt.Sprintf("%#o", mode), name)); err != nil {
 		if isNotExist(err) {
 			return PathError("chmod", name, fs.ErrNotExist)
 		}
@@ -641,7 +641,7 @@ func (s *PosixFS) openNew(name string, flags int, perm fs.FileMode) (fs.FileInfo
 		return nil, PathErrorf(OpOpen, name, "%w: failed to stat parent directory", fs.ErrInvalid)
 	}
 
-	if err := s.Exec(fmt.Sprintf("install -m %#o /dev/null %s", perm, shellescape.Quote(name))); err != nil {
+	if err := s.Exec(sh.Command("install", "-m", fmt.Sprintf("%#o", perm), "/dev/null", name)); err != nil {
 		return nil, PathError(OpOpen, name, err)
 	}
 
@@ -800,7 +800,6 @@ func (s *PosixFS) TempDir() string {
 // MkdirAll creates a new directory structure with the specified name and permission bits.
 // If the directory already exists, MkDirAll does nothing and returns nil.
 func (s *PosixFS) MkdirAll(name string, perm fs.FileMode) error {
-	dir := shellescape.Quote(name)
 	if existing, err := s.Stat(name); err == nil {
 		if existing.IsDir() {
 			return nil
@@ -808,7 +807,7 @@ func (s *PosixFS) MkdirAll(name string, perm fs.FileMode) error {
 		return fmt.Errorf("mkdir %s: %w", name, fs.ErrExist)
 	}
 
-	if err := s.Exec(fmt.Sprintf("install -d -m %#o %s", perm, shellescape.Quote(dir))); err != nil {
+	if err := s.Exec(sh.Command("install", "-d", "-m", fmt.Sprintf("%#o", perm), name)); err != nil {
 		return fmt.Errorf("mkdir %s: %w", name, err)
 	}
 
@@ -817,7 +816,7 @@ func (s *PosixFS) MkdirAll(name string, perm fs.FileMode) error {
 
 // Mkdir creates a new directory with the specified name and permission bits.
 func (s *PosixFS) Mkdir(name string, perm fs.FileMode) error {
-	if err := s.Exec(fmt.Sprintf("mkdir -m %#o %s", perm, shellescape.Quote(name))); err != nil {
+	if err := s.Exec(sh.Command("mkdir", "-m", fmt.Sprintf("%#o", perm), name)); err != nil {
 		return PathError("mkdir", name, err)
 	}
 
@@ -826,7 +825,7 @@ func (s *PosixFS) Mkdir(name string, perm fs.FileMode) error {
 
 // WriteFile writes data to a file named by filename.
 func (s *PosixFS) WriteFile(filename string, data []byte, perm fs.FileMode) error {
-	if err := s.Exec(fmt.Sprintf("install -D -m %#o /dev/stdin %s", perm, shellescape.Quote(filename)), cmd.Stdin(bytes.NewReader(data))); err != nil {
+	if err := s.Exec(sh.Command("install", "-D", "-m", fmt.Sprintf("%#o", perm), "/dev/stdin", filename), cmd.Stdin(bytes.NewReader(data))); err != nil {
 		return fmt.Errorf("write file %s: %w", filename, err)
 	}
 	return nil
@@ -903,7 +902,7 @@ func (s *PosixFS) CommandExist(name string) bool {
 
 // Getenv returns the value of the environment variable named by the key.
 func (s *PosixFS) Getenv(key string) string {
-	out, err := s.ExecOutput(fmt.Sprintf("echo ${%s}", key), cmd.HideOutput())
+	out, err := s.ExecOutput(sh.Command("printenv", key), cmd.HideOutput())
 	if err != nil {
 		return ""
 	}

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -902,7 +902,7 @@ func (s *PosixFS) CommandExist(name string) bool {
 
 // Getenv returns the value of the environment variable named by the key.
 func (s *PosixFS) Getenv(key string) string {
-	out, err := s.ExecOutput(sh.Command("printenv", key), cmd.HideOutput())
+	out, err := s.ExecOutput(fmt.Sprintf("printf '%%s' \"${%s}\"", key), cmd.HideOutput())
 	if err != nil {
 		return ""
 	}

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -900,8 +900,28 @@ func (s *PosixFS) CommandExist(name string) bool {
 	return err == nil
 }
 
+// isValidEnvVarName reports whether key is a valid POSIX environment variable name.
+func isValidEnvVarName(key string) bool {
+	if len(key) == 0 {
+		return false
+	}
+	for i, r := range key {
+		if r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
+			continue
+		}
+		if i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 // Getenv returns the value of the environment variable named by the key.
 func (s *PosixFS) Getenv(key string) string {
+	if !isValidEnvVarName(key) {
+		return ""
+	}
 	out, err := s.ExecOutput(fmt.Sprintf("printf '%%s' \"${%s}\"", key), cmd.HideOutput())
 	if err != nil {
 		return ""

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -5,13 +5,11 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"io"
 	"io/fs"
 	"testing"
 	"time"
 
-	"github.com/k0sproject/rig/v2/powershell"
 	"github.com/k0sproject/rig/v2/remotefs"
 	"github.com/k0sproject/rig/v2/rigtest"
 	"github.com/stretchr/testify/require"
@@ -62,50 +60,6 @@ func TestPosixSystemTime(t *testing.T) {
 		require.Error(t, err)
 	})
 }
-
-func TestWindowsMachineID(t *testing.T) {
-	t.Run("ok", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
-		fs := remotefs.NewWindowsFS(mr)
-		id, err := fs.MachineID()
-		require.NoError(t, err)
-		require.Equal(t, "6ba7b810-9dad-11d1-80b4-00c04fd430c8", id)
-	})
-
-	t.Run("empty", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "")
-		fs := remotefs.NewWindowsFS(mr)
-		_, err := fs.MachineID()
-		require.ErrorIs(t, err, remotefs.ErrEmptyMachineID)
-	})
-}
-
-func TestWindowsSystemTime(t *testing.T) {
-	t.Run("ok", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "1700000000")
-		fs := remotefs.NewWindowsFS(mr)
-		got, err := fs.SystemTime()
-		require.NoError(t, err)
-		require.Equal(t, time.Unix(1700000000, 0), got)
-	})
-
-	t.Run("invalid output", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "not-a-number")
-		fs := remotefs.NewWindowsFS(mr)
-		_, err := fs.SystemTime()
-		require.Error(t, err)
-	})
-}
-
-// PosixFS
 
 func TestPosixDownloadURL(t *testing.T) {
 	t.Run("curl", func(t *testing.T) {
@@ -242,97 +196,6 @@ func TestPosixTouch(t *testing.T) {
 	})
 }
 
-// WinFS — PS commands match by powershell.exe prefix (simple scripts use -Command, complex ones use -EncodedCommand).
-
-func TestWindowsDownloadURL(t *testing.T) {
-	t.Run("ok", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
-		f := remotefs.NewWindowsFS(mr)
-		require.NoError(t, f.DownloadURL("http://example.com/file", `C:\tmp\file`))
-	})
-
-	t.Run("failure", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
-		f := remotefs.NewWindowsFS(mr)
-		err := f.DownloadURL("http://example.com/file", `C:\tmp\file`)
-		require.Error(t, err)
-	})
-}
-
-func TestWindowsFileContains(t *testing.T) {
-	t.Run("match", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "MATCH")
-		f := remotefs.NewWindowsFS(mr)
-		ok, err := f.FileContains(`C:\tmp\file`, "needle")
-		require.NoError(t, err)
-		require.True(t, ok)
-	})
-
-	t.Run("no match", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "NO_MATCH")
-		f := remotefs.NewWindowsFS(mr)
-		ok, err := f.FileContains(`C:\tmp\file`, "needle")
-		require.NoError(t, err)
-		require.False(t, ok)
-	})
-
-	t.Run("not found", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "NOT_FOUND")
-		f := remotefs.NewWindowsFS(mr)
-		ok, err := f.FileContains(`C:\tmp\file`, "needle")
-		require.ErrorIs(t, err, fs.ErrNotExist)
-		require.False(t, ok)
-	})
-
-	t.Run("script error", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "ERROR:access denied")
-		f := remotefs.NewWindowsFS(mr)
-		ok, err := f.FileContains(`C:\tmp\file`, "needle")
-		require.Error(t, err)
-		require.False(t, ok)
-	})
-}
-
-func TestWindowsTouch(t *testing.T) {
-	t.Run("no timestamp", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
-		f := remotefs.NewWindowsFS(mr)
-		require.NoError(t, f.Touch(`C:\tmp\file`))
-	})
-
-	t.Run("with timestamp", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
-		f := remotefs.NewWindowsFS(mr)
-		ts := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
-		require.NoError(t, f.Touch(`C:\tmp\file`, ts))
-	})
-}
-
-func TestWindowsIsContainer(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.Windows = true
-	f := remotefs.NewWindowsFS(mr)
-	ok, err := f.IsContainer()
-	require.ErrorIs(t, err, remotefs.ErrNotSupported)
-	require.False(t, ok)
-}
-
 func TestPosixDir(t *testing.T) {
 	f := remotefs.NewPosixFS(rigtest.NewMockRunner())
 	require.Equal(t, "/foo/bar", f.Dir("/foo/bar/baz"))
@@ -361,65 +224,6 @@ func TestPosixCommandExist(t *testing.T) {
 		mr := rigtest.NewMockRunner()
 		mr.AddCommandFailure(rigtest.Equal("command -v curl"), errors.New("not found"))
 		f := remotefs.NewPosixFS(mr)
-		require.False(t, f.CommandExist("curl"))
-	})
-}
-
-func TestWindowsDir(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.Windows = true
-	f := remotefs.NewWindowsFS(mr)
-	require.Equal(t, `C:\foo\bar`, f.Dir(`C:\foo\bar\baz`))
-	require.Equal(t, `C:\foo`, f.Dir(`C:\foo\bar`))
-	require.Equal(t, `C:\`, f.Dir(`C:\foo`))
-	require.Equal(t, `C:\`, f.Dir(`C:\`))
-	require.Equal(t, ".", f.Dir("foo"))
-	require.Equal(t, ".", f.Dir(""))
-	require.Equal(t, `\`, f.Dir(`\`))
-	require.Equal(t, `/`, f.Dir(`/`))
-	// forward slashes preserved
-	require.Equal(t, "C:/foo", f.Dir("C:/foo/bar"))
-	require.Equal(t, "C:/", f.Dir("C:/foo"))
-	require.Equal(t, "C:/", f.Dir("C:/"))
-}
-
-func TestWindowsBase(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.Windows = true
-	f := remotefs.NewWindowsFS(mr)
-	require.Equal(t, "baz", f.Base(`C:\foo\bar\baz`))
-	require.Equal(t, "bar", f.Base(`C:\foo\bar`))
-	require.Equal(t, "foo", f.Base(`C:\foo`))
-	require.Equal(t, "foo", f.Base("foo"))
-	require.Equal(t, ".", f.Base(""))
-	require.Equal(t, `\`, f.Base(`\`))
-	require.Equal(t, `\`, f.Base(`\\`))
-	require.Equal(t, `/`, f.Base(`/`))
-	// drive roots
-	require.Equal(t, `C:\`, f.Base(`C:\`))
-	require.Equal(t, `C:/`, f.Base(`C:/`))
-}
-
-func TestWindowsCommandExist(t *testing.T) {
-	t.Run("found", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), `C:\Windows\System32\curl.exe`)
-		f := remotefs.NewWindowsFS(mr)
-		require.True(t, f.CommandExist("curl"))
-	})
-	t.Run("not found via error", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("not found"))
-		f := remotefs.NewWindowsFS(mr)
-		require.False(t, f.CommandExist("curl"))
-	})
-	t.Run("not found via empty output", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "")
-		f := remotefs.NewWindowsFS(mr)
 		require.False(t, f.CommandExist("curl"))
 	})
 }
@@ -469,15 +273,6 @@ func TestPosixChownTreeInt(t *testing.T) {
 	})
 }
 
-func TestWindowsChownVariantsNotSupported(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.Windows = true
-	f := remotefs.NewWindowsFS(mr)
-	require.ErrorIs(t, f.ChownInt("/tmp/file", 1000, 2000), remotefs.ErrNotSupported)
-	require.ErrorIs(t, f.ChownTree("/tmp", "root"), remotefs.ErrNotSupported)
-	require.ErrorIs(t, f.ChownTreeInt("/tmp", 0, 0), remotefs.ErrNotSupported)
-}
-
 func TestPosixHTTPStatus(t *testing.T) {
 	t.Run("200", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
@@ -507,42 +302,6 @@ func TestPosixHTTPStatus(t *testing.T) {
 		f := remotefs.NewPosixFS(mr)
 		_, err := remotefs.HTTPStatus(context.Background(), f, "http://example.com/health")
 		require.Error(t, err)
-	})
-}
-
-func TestWindowsHTTPStatus(t *testing.T) {
-	t.Run("200", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		resp200 := base64.StdEncoding.EncodeToString([]byte("HTTP/1.1 200 OK\r\n\r\n"))
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), resp200)
-		f := remotefs.NewWindowsFS(mr)
-		code, err := remotefs.HTTPStatus(context.Background(), f, "http://example.com/health")
-		require.NoError(t, err)
-		require.Equal(t, 200, code)
-	})
-	t.Run("failure", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
-		f := remotefs.NewWindowsFS(mr)
-		_, err := remotefs.HTTPStatus(context.Background(), f, "http://example.com/health")
-		require.Error(t, err)
-	})
-}
-
-func TestWindowsCreateTemp(t *testing.T) {
-	t.Run("ok", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		// Stub TempDir's TEMP lookup first (exact match), then the CreateTemp script (broad prefix).
-		// The exact match on powershell.Cmd(...) distinguishes the two calls regardless of encoding.
-		mr.AddCommandOutput(rigtest.Equal(powershell.Cmd("[System.Environment]::GetEnvironmentVariable('TEMP')")), `C:\Windows\Temp`)
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), `C:\Windows\Temp\rig-abc123.tmp`)
-		f := remotefs.NewWindowsFS(mr)
-		path, err := f.CreateTemp("", "rig-")
-		require.NoError(t, err)
-		require.Equal(t, "C:/Windows/Temp/rig-abc123.tmp", path)
 	})
 }
 
@@ -594,6 +353,24 @@ func TestPosixInitStat(t *testing.T) {
 	}
 }
 
+func TestPosixGetenv(t *testing.T) {
+	t.Run("valid key executes command", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.Contains("HOME"), "/home/user")
+		f := remotefs.NewPosixFS(mr)
+		require.Equal(t, "/home/user", f.Getenv("HOME"))
+		require.NoError(t, mr.Received(rigtest.Contains("HOME")))
+	})
+	t.Run("injection attempt returns empty without executing", func(t *testing.T) {
+		for _, key := range []string{`FOO}"`, `}; rm -rf /`, `A=B`, `FOO bar`, ``} {
+			mr := rigtest.NewMockRunner()
+			f := remotefs.NewPosixFS(mr)
+			require.Empty(t, f.Getenv(key), "key: %q", key)
+			require.Equal(t, 0, mr.Len(), "no command should be run for key: %q", key)
+		}
+	})
+}
+
 func TestPosixCreateTemp(t *testing.T) {
 	t.Run("with prefix", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
@@ -613,36 +390,6 @@ func TestPosixCreateTemp(t *testing.T) {
 		require.Error(t, err)
 	})
 }
-
-func TestWindowsRename(t *testing.T) {
-	const src = `C:\src\file.txt`
-	const dst = `C:\dst\file.txt`
-	// Move-Item uses double-quoted paths, which forces powershell.Cmd into
-	// -EncodedCommand mode. Build the expected command the same way WinFS.Rename does.
-	renameCmd := powershell.Cmd(fmt.Sprintf("Move-Item -Force -LiteralPath %s -Destination %s",
-		powershell.DoubleQuotePath(src), powershell.DoubleQuotePath(dst)))
-
-	t.Run("uses Force and LiteralPath", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandSuccess(rigtest.Equal(renameCmd))
-		f := remotefs.NewWindowsFS(mr)
-		require.NoError(t, f.Rename(src, dst))
-		require.NoError(t, mr.Received(rigtest.Equal(renameCmd)))
-	})
-
-	t.Run("error includes both paths", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("access denied"))
-		f := remotefs.NewWindowsFS(mr)
-		err := f.Rename(src, dst)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), src)
-		require.Contains(t, err.Error(), dst)
-	})
-}
-
 
 func TestPosixFSFollow(t *testing.T) {
 	const path = "/var/log/app.log"

--- a/remotefs/winfs_test.go
+++ b/remotefs/winfs_test.go
@@ -3,15 +3,283 @@ package remotefs_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"testing"
+	"time"
 
+	"github.com/k0sproject/rig/v2/powershell"
 	"github.com/k0sproject/rig/v2/remotefs"
 	"github.com/k0sproject/rig/v2/rigtest"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWindowsMachineID(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+		fs := remotefs.NewWindowsFS(mr)
+		id, err := fs.MachineID()
+		require.NoError(t, err)
+		require.Equal(t, "6ba7b810-9dad-11d1-80b4-00c04fd430c8", id)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "")
+		fs := remotefs.NewWindowsFS(mr)
+		_, err := fs.MachineID()
+		require.ErrorIs(t, err, remotefs.ErrEmptyMachineID)
+	})
+}
+
+func TestWindowsSystemTime(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "1700000000")
+		fs := remotefs.NewWindowsFS(mr)
+		got, err := fs.SystemTime()
+		require.NoError(t, err)
+		require.Equal(t, time.Unix(1700000000, 0), got)
+	})
+
+	t.Run("invalid output", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "not-a-number")
+		fs := remotefs.NewWindowsFS(mr)
+		_, err := fs.SystemTime()
+		require.Error(t, err)
+	})
+}
+
+func TestWindowsDownloadURL(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+		f := remotefs.NewWindowsFS(mr)
+		require.NoError(t, f.DownloadURL("http://example.com/file", `C:\tmp\file`))
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
+		f := remotefs.NewWindowsFS(mr)
+		err := f.DownloadURL("http://example.com/file", `C:\tmp\file`)
+		require.Error(t, err)
+	})
+}
+
+func TestWindowsFileContains(t *testing.T) {
+	t.Run("match", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "MATCH")
+		f := remotefs.NewWindowsFS(mr)
+		ok, err := f.FileContains(`C:\tmp\file`, "needle")
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "NO_MATCH")
+		f := remotefs.NewWindowsFS(mr)
+		ok, err := f.FileContains(`C:\tmp\file`, "needle")
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "NOT_FOUND")
+		f := remotefs.NewWindowsFS(mr)
+		ok, err := f.FileContains(`C:\tmp\file`, "needle")
+		require.ErrorIs(t, err, fs.ErrNotExist)
+		require.False(t, ok)
+	})
+
+	t.Run("script error", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "ERROR:access denied")
+		f := remotefs.NewWindowsFS(mr)
+		ok, err := f.FileContains(`C:\tmp\file`, "needle")
+		require.Error(t, err)
+		require.False(t, ok)
+	})
+}
+
+func TestWindowsTouch(t *testing.T) {
+	t.Run("no timestamp", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+		f := remotefs.NewWindowsFS(mr)
+		require.NoError(t, f.Touch(`C:\tmp\file`))
+	})
+
+	t.Run("with timestamp", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+		f := remotefs.NewWindowsFS(mr)
+		ts := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+		require.NoError(t, f.Touch(`C:\tmp\file`, ts))
+	})
+}
+
+func TestWindowsIsContainer(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.Windows = true
+	f := remotefs.NewWindowsFS(mr)
+	ok, err := f.IsContainer()
+	require.ErrorIs(t, err, remotefs.ErrNotSupported)
+	require.False(t, ok)
+}
+
+func TestWindowsDir(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.Windows = true
+	f := remotefs.NewWindowsFS(mr)
+	require.Equal(t, `C:\foo\bar`, f.Dir(`C:\foo\bar\baz`))
+	require.Equal(t, `C:\foo`, f.Dir(`C:\foo\bar`))
+	require.Equal(t, `C:\`, f.Dir(`C:\foo`))
+	require.Equal(t, `C:\`, f.Dir(`C:\`))
+	require.Equal(t, ".", f.Dir("foo"))
+	require.Equal(t, ".", f.Dir(""))
+	require.Equal(t, `\`, f.Dir(`\`))
+	require.Equal(t, `/`, f.Dir(`/`))
+	// forward slashes preserved
+	require.Equal(t, "C:/foo", f.Dir("C:/foo/bar"))
+	require.Equal(t, "C:/", f.Dir("C:/foo"))
+	require.Equal(t, "C:/", f.Dir("C:/"))
+}
+
+func TestWindowsBase(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.Windows = true
+	f := remotefs.NewWindowsFS(mr)
+	require.Equal(t, "baz", f.Base(`C:\foo\bar\baz`))
+	require.Equal(t, "bar", f.Base(`C:\foo\bar`))
+	require.Equal(t, "foo", f.Base(`C:\foo`))
+	require.Equal(t, "foo", f.Base("foo"))
+	require.Equal(t, ".", f.Base(""))
+	require.Equal(t, `\`, f.Base(`\`))
+	require.Equal(t, `\`, f.Base(`\\`))
+	require.Equal(t, `/`, f.Base(`/`))
+	// drive roots
+	require.Equal(t, `C:\`, f.Base(`C:\`))
+	require.Equal(t, `C:/`, f.Base(`C:/`))
+}
+
+func TestWindowsCommandExist(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), `C:\Windows\System32\curl.exe`)
+		f := remotefs.NewWindowsFS(mr)
+		require.True(t, f.CommandExist("curl"))
+	})
+	t.Run("not found via error", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("not found"))
+		f := remotefs.NewWindowsFS(mr)
+		require.False(t, f.CommandExist("curl"))
+	})
+	t.Run("not found via empty output", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "")
+		f := remotefs.NewWindowsFS(mr)
+		require.False(t, f.CommandExist("curl"))
+	})
+}
+
+func TestWindowsChownVariantsNotSupported(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.Windows = true
+	f := remotefs.NewWindowsFS(mr)
+	require.ErrorIs(t, f.ChownInt("/tmp/file", 1000, 2000), remotefs.ErrNotSupported)
+	require.ErrorIs(t, f.ChownTree("/tmp", "root"), remotefs.ErrNotSupported)
+	require.ErrorIs(t, f.ChownTreeInt("/tmp", 0, 0), remotefs.ErrNotSupported)
+}
+
+func TestWindowsHTTPStatus(t *testing.T) {
+	t.Run("200", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		resp200 := base64.StdEncoding.EncodeToString([]byte("HTTP/1.1 200 OK\r\n\r\n"))
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), resp200)
+		f := remotefs.NewWindowsFS(mr)
+		code, err := remotefs.HTTPStatus(context.Background(), f, "http://example.com/health")
+		require.NoError(t, err)
+		require.Equal(t, 200, code)
+	})
+	t.Run("failure", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
+		f := remotefs.NewWindowsFS(mr)
+		_, err := remotefs.HTTPStatus(context.Background(), f, "http://example.com/health")
+		require.Error(t, err)
+	})
+}
+
+func TestWindowsCreateTemp(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		// Stub TempDir's TEMP lookup first (exact match), then the CreateTemp script (broad prefix).
+		// The exact match on powershell.Cmd(...) distinguishes the two calls regardless of encoding.
+		mr.AddCommandOutput(rigtest.Equal(powershell.Cmd("[System.Environment]::GetEnvironmentVariable('TEMP')")), `C:\Windows\Temp`)
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), `C:\Windows\Temp\rig-abc123.tmp`)
+		f := remotefs.NewWindowsFS(mr)
+		path, err := f.CreateTemp("", "rig-")
+		require.NoError(t, err)
+		require.Equal(t, "C:/Windows/Temp/rig-abc123.tmp", path)
+	})
+}
+
+func TestWindowsRename(t *testing.T) {
+	const src = `C:\src\file.txt`
+	const dst = `C:\dst\file.txt`
+	// Move-Item uses double-quoted paths, which forces powershell.Cmd into
+	// -EncodedCommand mode. Build the expected command the same way WinFS.Rename does.
+	renameCmd := powershell.Cmd(fmt.Sprintf("Move-Item -Force -LiteralPath %s -Destination %s",
+		powershell.DoubleQuotePath(src), powershell.DoubleQuotePath(dst)))
+
+	t.Run("uses Force and LiteralPath", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandSuccess(rigtest.Equal(renameCmd))
+		f := remotefs.NewWindowsFS(mr)
+		require.NoError(t, f.Rename(src, dst))
+		require.NoError(t, mr.Received(rigtest.Equal(renameCmd)))
+	})
+
+	t.Run("error includes both paths", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("access denied"))
+		f := remotefs.NewWindowsFS(mr)
+		err := f.Rename(src, dst)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), src)
+		require.Contains(t, err.Error(), dst)
+	})
+}
 
 func TestWinFSFollow(t *testing.T) {
 	const path = `C:\logs\app.log`

--- a/sh/shellescape/shellescape.go
+++ b/sh/shellescape/shellescape.go
@@ -119,9 +119,9 @@ func Join(args ...string) string { //nolint:cyclop
 		case !singleQ && !special:
 			builder.WriteString(arg)
 		case special && !singleQ:
-			escapeTo(arg, builder)
-		default:
 			wrapTo(arg, builder)
+		default:
+			escapeTo(arg, builder)
 		}
 		if i < len(args)-1 {
 			builder.WriteByte(' ')

--- a/sh/shellescape/shellescape_test.go
+++ b/sh/shellescape/shellescape_test.go
@@ -30,6 +30,25 @@ func TestQuote(t *testing.T) {
 	}
 }
 
+func TestJoin(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{"Basic", []string{"ls", "-l", "file with space"}, `ls -l 'file with space'`},
+		{"Single quote in arg", []string{"touch", "it's here"}, `touch 'it'"'"'s here'`},
+		{"Single quote only", []string{"echo", "'"}, `echo ''"'"''`},
+		{"Single quote and special", []string{"rm", "/path/it's bad"}, `rm '/path/it'"'"'s bad'`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, shellescape.Join(tt.input...))
+		})
+	}
+}
+
 func TestQuoteCommand(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
There were several places there rig didn't "dogfood" on the `sh` package for building commands.
