### PR TITLE
Add connectivity probe to WinRM Connect

### DIFF
--- a/protocol/winrm/connection.go
+++ b/protocol/winrm/connection.go
@@ -37,8 +37,9 @@ type Connection struct {
 	key    []byte
 	cert   []byte
 
-	mu     sync.Mutex
-	client *winrm.Client
+	mu          sync.Mutex
+	client      *winrm.Client
+	bastionConn *ssh.Connection
 }
 
 type dialFunc func(network, addr string) (net.Conn, error)
@@ -84,6 +85,38 @@ func (c *Connection) IsWindows() bool {
 	return true
 }
 
+// probe runs a no-op command to verify the connection is alive and authenticated.
+// HTTP 401/403 responses are wrapped as ErrNonRetryable.
+func (c *Connection) probe(ctx context.Context) error {
+	proc, err := c.StartProcess(ctx, "cmd.exe /c exit 0", nil, nil, nil)
+	if err != nil {
+		if isAuthError(err) {
+			return fmt.Errorf("%w: %w", protocol.ErrNonRetryable, err)
+		}
+		return err
+	}
+	if err := proc.Wait(); err != nil {
+		return fmt.Errorf("probe: %w", err)
+	}
+	return nil
+}
+
+// isAuthError reports whether err looks like an HTTP 401/403 response from the
+// WinRM library. The library returns untyped formatted errors so we match by
+// substring. Both formats seen in the library are covered:
+//   - "http error 401: ..."       (http.go / auth.go)
+//   - "http response error: 401 - ..." (auth.go alternate path)
+func isAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "http error 401") ||
+		strings.Contains(msg, "http error 403") ||
+		strings.Contains(msg, "http response error: 401") ||
+		strings.Contains(msg, "http response error: 403")
+}
+
 // IsConnected returns true if the WinRM connection is alive by running a no-op
 // command. WinRM is stateless HTTP so the only real liveness test is a probe.
 func (c *Connection) IsConnected() bool {
@@ -95,11 +128,7 @@ func (c *Connection) IsConnected() bool {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	proc, err := c.StartProcess(ctx, "cmd.exe /c exit 0", nil, nil, nil)
-	if err != nil {
-		return false
-	}
-	return proc.Wait() == nil
+	return c.probe(ctx) == nil
 }
 
 func (c *Connection) loadCertificates() error {
@@ -133,23 +162,23 @@ func (c *Connection) loadCertificates() error {
 	return nil
 }
 
-func (c *Connection) bastionDialer(ctx context.Context) (dialFunc, error) {
+func (c *Connection) bastionDialer(ctx context.Context) (*ssh.Connection, dialFunc, error) {
 	bastion, err := c.Bastion.Connection() //nolint:contextcheck
 	if err != nil {
-		return nil, fmt.Errorf("create bastion connection: %w", err)
+		return nil, nil, fmt.Errorf("create bastion connection: %w", err)
 	}
 	bastionSSH, ok := bastion.(*ssh.Connection)
 	if !ok {
-		return nil, fmt.Errorf("%w: bastion connection is not an SSH connection", protocol.ErrNonRetryable)
+		return nil, nil, fmt.Errorf("%w: bastion connection is not an SSH connection", protocol.ErrNonRetryable)
 	}
 	log.Trace(ctx, "connecting to bastion", log.KeyHost, c)
 	if err := bastionSSH.Connect(ctx); err != nil {
 		if errors.Is(err, hostkey.ErrHostKeyMismatch) {
-			return nil, fmt.Errorf("%w: bastion connect: %w", protocol.ErrNonRetryable, err)
+			return nil, nil, fmt.Errorf("%w: bastion connect: %w", protocol.ErrNonRetryable, err)
 		}
-		return nil, fmt.Errorf("bastion connect: %w", err)
+		return nil, nil, fmt.Errorf("bastion connect: %w", err)
 	}
-	return bastionSSH.Dial, nil
+	return bastionSSH, bastionSSH.Dial, nil
 }
 
 // Connect opens the WinRM connection.
@@ -182,11 +211,14 @@ func (c *Connection) Connect(ctx context.Context) error {
 	params := winrm.DefaultParameters
 
 	if c.Bastion != nil {
-		dialer, err := c.bastionDialer(ctx)
+		bastionSSH, dialer, err := c.bastionDialer(ctx)
 		if err != nil {
 			return err
 		}
 		params.Dial = dialer
+		c.mu.Lock()
+		c.bastionConn = bastionSSH
+		c.mu.Unlock()
 	}
 
 	if c.UseNTLM {
@@ -199,12 +231,18 @@ func (c *Connection) Connect(ctx context.Context) error {
 
 	client, err := winrm.NewClientWithParameters(endpoint, c.User, c.Password, params)
 	if err != nil {
+		c.Disconnect()
 		return fmt.Errorf("create winrm client: %w", err)
 	}
 
 	c.mu.Lock()
 	c.client = client
 	c.mu.Unlock()
+
+	if err := c.probe(ctx); err != nil {
+		c.Disconnect()
+		return fmt.Errorf("connection probe: %w", err)
+	}
 
 	return nil
 }
@@ -213,7 +251,12 @@ func (c *Connection) Connect(ctx context.Context) error {
 func (c *Connection) Disconnect() {
 	c.mu.Lock()
 	c.client = nil
+	bastion := c.bastionConn
+	c.bastionConn = nil
 	c.mu.Unlock()
+	if bastion != nil {
+		bastion.Disconnect()
+	}
 }
 
 type command struct {
@@ -277,6 +320,7 @@ func (c *Connection) StartProcess(ctx context.Context, cmd string, stdin io.Read
 	}
 	proc, err := shell.ExecuteWithContext(ctx, cmd)
 	if err != nil {
+		shell.Close()
 		return nil, fmt.Errorf("execute command: %w", err)
 	}
 	started := time.Now()

--- a/protocol/winrm/connection.go
+++ b/protocol/winrm/connection.go
@@ -117,9 +117,13 @@ func isAuthError(err error) bool {
 		strings.Contains(msg, "http response error: 403")
 }
 
-// endpointTimeout returns time.Minute, or the context deadline if it is shorter.
-// This bounds the WinRM HTTP transport timeout so CreateShell honours ctx cancellation.
+// endpointTimeout returns the WinRM HTTP transport timeout to use. It returns
+// time.Minute, the remaining context deadline if shorter, or 1ms if the context
+// is already canceled or expired (so the HTTP call fails quickly).
 func endpointTimeout(ctx context.Context) time.Duration {
+	if ctx.Err() != nil {
+		return time.Millisecond
+	}
 	timeout := time.Minute
 	if deadline, ok := ctx.Deadline(); ok {
 		if d := time.Until(deadline); d > 0 && d < timeout {

--- a/protocol/winrm/connection.go
+++ b/protocol/winrm/connection.go
@@ -117,6 +117,18 @@ func isAuthError(err error) bool {
 		strings.Contains(msg, "http response error: 403")
 }
 
+// endpointTimeout returns time.Minute, or the context deadline if it is shorter.
+// This bounds the WinRM HTTP transport timeout so CreateShell honours ctx cancellation.
+func endpointTimeout(ctx context.Context) time.Duration {
+	timeout := time.Minute
+	if deadline, ok := ctx.Deadline(); ok {
+		if d := time.Until(deadline); d > 0 && d < timeout {
+			return d
+		}
+	}
+	return timeout
+}
+
 // IsConnected returns true if the WinRM connection is alive by running a no-op
 // command. WinRM is stateless HTTP so the only real liveness test is a probe.
 func (c *Connection) IsConnected() bool {
@@ -193,7 +205,7 @@ func (c *Connection) Connect(ctx context.Context) error {
 		HTTPS:         c.UseHTTPS,
 		Insecure:      c.Insecure,
 		TLSServerName: c.TLSServerName,
-		Timeout:       time.Minute,
+		Timeout:       endpointTimeout(ctx),
 	}
 
 	if len(c.caCert) > 0 {

--- a/protocol/winrm/connection.go
+++ b/protocol/winrm/connection.go
@@ -193,8 +193,10 @@ func (c *Connection) bastionDialer(ctx context.Context) (*ssh.Connection, dialFu
 	return bastionSSH, bastionSSH.Dial, nil
 }
 
-// Connect opens the WinRM connection.
+// Connect opens the WinRM connection. Any existing connection is torn down first.
 func (c *Connection) Connect(ctx context.Context) error {
+	c.Disconnect()
+
 	if err := c.loadCertificates(); err != nil {
 		return fmt.Errorf("%w: failed to load certificates: %w", protocol.ErrNonRetryable, err)
 	}
@@ -253,7 +255,7 @@ func (c *Connection) Connect(ctx context.Context) error {
 
 	if err := c.probe(ctx); err != nil {
 		c.Disconnect()
-		return fmt.Errorf("connection probe: %w", err)
+		return err
 	}
 
 	return nil

--- a/protocol/winrm/connection_test.go
+++ b/protocol/winrm/connection_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/k0sproject/rig/v2/protocol"
 )
@@ -187,7 +188,9 @@ func TestConnect_probeClassification(t *testing.T) {
 				t.Fatalf("NewConnection() error = %v", err)
 			}
 
-			err = conn.Connect(context.Background())
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			err = conn.Connect(ctx)
 			if err == nil {
 				t.Fatal("Connect() succeeded against stub server, want error")
 			}

--- a/protocol/winrm/connection_test.go
+++ b/protocol/winrm/connection_test.go
@@ -1,0 +1,205 @@
+package winrm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/protocol"
+)
+
+func Test_isAuthError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "http error 401",
+			err:  fmt.Errorf("http error 401: Unauthorized"),
+			want: true,
+		},
+		{
+			name: "http error 403",
+			err:  fmt.Errorf("http error 403: Forbidden"),
+			want: true,
+		},
+		{
+			name: "http response error 401",
+			err:  fmt.Errorf("http response error: 401 - %w", errors.New("unauthorized")),
+			want: true,
+		},
+		{
+			name: "http response error 403",
+			err:  fmt.Errorf("http response error: 403 - %w", errors.New("forbidden")),
+			want: true,
+		},
+		{
+			name: "connection refused",
+			err:  fmt.Errorf("dial tcp 10.0.0.1:5985: connect: connection refused"),
+			want: false,
+		},
+		{
+			name: "http error 500",
+			err:  fmt.Errorf("http error 500: Internal Server Error"),
+			want: false,
+		},
+		{
+			name: "create shell error wrapping auth",
+			err:  fmt.Errorf("create shell: http error 401: Unauthorized"),
+			want: true,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "timeout",
+			err:  fmt.Errorf("context deadline exceeded"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAuthError(tt.err)
+			if got != tt.want {
+				t.Errorf("isAuthError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// Test_authErrorWrapping verifies that the classification/wrapping logic used in
+// probe produces ErrNonRetryable for auth errors and leaves other errors retryable.
+// probe itself is not called here because it requires a live WinRM client; see the
+// todo item for WinRM integration tests.
+func Test_authErrorWrapping(t *testing.T) {
+	authErr := fmt.Errorf("create shell: http error 401: Unauthorized")
+	nonAuthErr := fmt.Errorf("dial tcp 10.0.0.1:5985: connect: connection refused")
+
+	tests := []struct {
+		name           string
+		startErr       error
+		wantNonRetry   bool
+		wantErrContain string
+	}{
+		{
+			name:           "auth failure becomes ErrNonRetryable",
+			startErr:       authErr,
+			wantNonRetry:   true,
+			wantErrContain: authErr.Error(),
+		},
+		{
+			name:           "network failure stays retryable",
+			startErr:       nonAuthErr,
+			wantNonRetry:   false,
+			wantErrContain: nonAuthErr.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Exercise the classification logic directly rather than through the full
+			// probe method (which requires a real WinRM client). Integration coverage
+			// against a real WinRM server is deferred to the todo item for WinRM tests.
+			var err error
+			if isAuthError(tt.startErr) {
+				err = fmt.Errorf("%w: %w", protocol.ErrNonRetryable, tt.startErr)
+			} else {
+				err = tt.startErr
+			}
+
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			gotNonRetry := errors.Is(err, protocol.ErrNonRetryable)
+			if gotNonRetry != tt.wantNonRetry {
+				t.Errorf("errors.Is(err, ErrNonRetryable) = %v, want %v (err: %v)", gotNonRetry, tt.wantNonRetry, err)
+			}
+			if tt.wantErrContain != "" {
+				if msg := err.Error(); !strings.Contains(msg, tt.wantErrContain) {
+					t.Errorf("err.Error() = %q, want it to contain %q", msg, tt.wantErrContain)
+				}
+			}
+		})
+	}
+}
+
+func TestConnect_probeClassification(t *testing.T) {
+	tests := []struct {
+		name         string
+		statusCode   int
+		wantNonRetry bool
+	}{
+		{
+			name:         "401 becomes ErrNonRetryable",
+			statusCode:   http.StatusUnauthorized,
+			wantNonRetry: true,
+		},
+		{
+			name:         "403 becomes ErrNonRetryable",
+			statusCode:   http.StatusForbidden,
+			wantNonRetry: true,
+		},
+		{
+			name:         "500 stays retryable",
+			statusCode:   http.StatusInternalServerError,
+			wantNonRetry: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			t.Cleanup(srv.Close)
+
+			// Parse host and port from the test server URL.
+			u, parseErr := url.Parse(srv.URL)
+			if parseErr != nil {
+				t.Fatalf("url.Parse(%q) error = %v", srv.URL, parseErr)
+			}
+			host, portStr, splitErr := net.SplitHostPort(u.Host)
+			if splitErr != nil {
+				t.Fatalf("net.SplitHostPort(%q) error = %v", u.Host, splitErr)
+			}
+			port, convErr := strconv.Atoi(portStr)
+			if convErr != nil {
+				t.Fatalf("strconv.Atoi(%q) error = %v", portStr, convErr)
+			}
+
+			conn, err := NewConnection(Config{
+				Address:  host,
+				Port:     port,
+				User:     "user",
+				Password: "pass",
+			})
+			if err != nil {
+				t.Fatalf("NewConnection() error = %v", err)
+			}
+
+			err = conn.Connect(context.Background())
+			if err == nil {
+				t.Fatal("Connect() succeeded against stub server, want error")
+			}
+
+			gotNonRetry := errors.Is(err, protocol.ErrNonRetryable)
+			if gotNonRetry != tt.wantNonRetry {
+				t.Errorf("Connect() errors.Is(err, ErrNonRetryable) = %v, want %v (err: %v)", gotNonRetry, tt.wantNonRetry, err)
+			}
+
+			if conn.IsConnected() {
+				t.Error("IsConnected() = true after failed Connect, want false")
+			}
+		})
+	}
+}


### PR DESCRIPTION
v0.x ran a no-op command during Connect to verify credentials and reachability; v2 only constructed the HTTP client, so bad credentials or unreachable endpoints did not fail until the first real command.

Restore that behaviour: after creating the winrm.Client, run `cmd.exe /c exit 0` as a probe using the caller's context. HTTP 401/403 responses are classified as ErrNonRetryable so retry loops don't hammer with bad credentials. On probe failure c.client is cleared so IsConnected() remains consistent.

Extract probe() as a shared helper used by both Connect and IsConnected, replacing the inline StartProcess call in IsConnected.