### PR TITLE
fix windows OS helpers to not assume cmd.exe as default shell

### DIFF
--- a/os/windows.go
+++ b/os/windows.go
@@ -124,7 +124,8 @@ func (c Windows) ReadFile(h Host, path string) (string, error) {
 
 // DeleteFile deletes a file from the host.
 func (c Windows) DeleteFile(h Host, path string) error {
-	if err := h.Exec(fmt.Sprintf(`del /f %s`, ps.DoubleQuotePath(path))); err != nil {
+	cmd := fmt.Sprintf(`Remove-Item -LiteralPath %s -Force -ErrorAction Stop`, ps.DoubleQuotePath(path))
+	if err := h.Exec(ps.Cmd(cmd)); err != nil {
 		return fmt.Errorf("failed to delete file %s: %w", path, err)
 	}
 	return nil
@@ -187,7 +188,7 @@ func (c Windows) Reboot(h Host) error {
 
 // StartService starts a service
 func (c Windows) StartService(h Host, s string) error {
-	if err := h.Execf(`sc start %s`, ps.DoubleQuote(s)); err != nil {
+	if err := h.Exec(ps.Cmd(fmt.Sprintf(`Start-Service -Name %s -ErrorAction Stop`, ps.SingleQuote(s)))); err != nil {
 		return fmt.Errorf("failed to start service %s: %w", s, err)
 	}
 	return nil
@@ -195,7 +196,7 @@ func (c Windows) StartService(h Host, s string) error {
 
 // StopService stops a service
 func (c Windows) StopService(h Host, s string) error {
-	if err := h.Execf(`sc stop %s`, ps.DoubleQuote(s)); err != nil {
+	if err := h.Exec(ps.Cmd(fmt.Sprintf(`Stop-Service -Name %s -ErrorAction Stop`, ps.SingleQuote(s)))); err != nil {
 		return fmt.Errorf("failed to stop service %s: %w", s, err)
 	}
 	return nil

--- a/os/windows.go
+++ b/os/windows.go
@@ -48,7 +48,7 @@ func (c Windows) InstallPackage(h Host, s ...string) error {
 
 // InstallFile on windows is a regular file move operation
 func (c Windows) InstallFile(h Host, src, dst, _ string) error {
-	if err := h.Execf("move /y %s %s", ps.DoubleQuotePath(src), ps.DoubleQuotePath(dst), exec.Sudo(h)); err != nil {
+	if err := h.Execf("cmd.exe /c move /y %s %s", ps.DoubleQuotePath(src), ps.DoubleQuotePath(dst), exec.Sudo(h)); err != nil {
 		return fmt.Errorf("failed to move %s to %s: %w", src, dst, err)
 	}
 	return nil
@@ -56,7 +56,7 @@ func (c Windows) InstallFile(h Host, src, dst, _ string) error {
 
 // Pwd returns the current working directory
 func (c Windows) Pwd(h Host) string {
-	if pwd, err := h.ExecOutput("echo %cd%"); err == nil {
+	if pwd, err := h.ExecOutput("cmd.exe /c echo %cd%"); err == nil {
 		return pwd
 	}
 
@@ -124,8 +124,7 @@ func (c Windows) ReadFile(h Host, path string) (string, error) {
 
 // DeleteFile deletes a file from the host.
 func (c Windows) DeleteFile(h Host, path string) error {
-	cmd := fmt.Sprintf(`Remove-Item -LiteralPath %s -Force -ErrorAction Stop`, ps.DoubleQuotePath(path))
-	if err := h.Exec(ps.Cmd(cmd)); err != nil {
+	if err := h.Exec(fmt.Sprintf(`cmd.exe /c del /f %s`, ps.DoubleQuotePath(path))); err != nil {
 		return fmt.Errorf("failed to delete file %s: %w", path, err)
 	}
 	return nil
@@ -188,7 +187,7 @@ func (c Windows) Reboot(h Host) error {
 
 // StartService starts a service
 func (c Windows) StartService(h Host, s string) error {
-	if err := h.Exec(ps.Cmd(fmt.Sprintf(`Start-Service -Name %s -ErrorAction Stop`, ps.SingleQuote(s)))); err != nil {
+	if err := h.Execf(`cmd.exe /c sc start %s`, ps.DoubleQuote(s)); err != nil {
 		return fmt.Errorf("failed to start service %s: %w", s, err)
 	}
 	return nil
@@ -196,7 +195,7 @@ func (c Windows) StartService(h Host, s string) error {
 
 // StopService stops a service
 func (c Windows) StopService(h Host, s string) error {
-	if err := h.Exec(ps.Cmd(fmt.Sprintf(`Stop-Service -Name %s -ErrorAction Stop`, ps.SingleQuote(s)))); err != nil {
+	if err := h.Execf(`cmd.exe /c sc stop %s`, ps.DoubleQuote(s)); err != nil {
 		return fmt.Errorf("failed to stop service %s: %w", s, err)
 	}
 	return nil


### PR DESCRIPTION
Addresses https://github.com/k0sproject/rig/issues/346

Without this change rig breaks when the default shell for windows hosts is powershell. The windows helpers run `cmd`  commands without explicitly invoking `cmd.exe`. The result is on these hosts that invalid commands are run within powershell. `rig` should either invoke `cmd.exe`  or `powershell.exe` explicitly.

This PR fixes it by wrapping the relevant helpers with `cmd.exe /c`