### PR TITLE
fix(windows): replace shell-sensitive commands with explicit PS equivalents

### DIFF
--- a/initsystem/winscm.go
+++ b/initsystem/winscm.go
@@ -17,7 +17,7 @@ type WinSCM struct{}
 
 // StartService starts a service.
 func (c WinSCM) StartService(ctx context.Context, h cmd.ContextRunner, s string) error {
-	if err := h.ExecContext(ctx, "sc.exe start "+ps.DoubleQuote(s)); err != nil {
+	if err := h.ExecContext(ctx, "$ErrorActionPreference='Stop'\nStart-Service "+ps.SingleQuote(s)+" -ErrorAction Stop", cmd.PS()); err != nil {
 		return fmt.Errorf("failed to start service %s: %w", s, err)
 	}
 	return nil
@@ -25,7 +25,7 @@ func (c WinSCM) StartService(ctx context.Context, h cmd.ContextRunner, s string)
 
 // StopService stops a service.
 func (c WinSCM) StopService(ctx context.Context, h cmd.ContextRunner, s string) error {
-	if err := h.ExecContext(ctx, "sc.exe stop "+ps.DoubleQuote(s)); err != nil {
+	if err := h.ExecContext(ctx, "$ErrorActionPreference='Stop'\nStop-Service "+ps.SingleQuote(s)+" -ErrorAction Stop", cmd.PS()); err != nil {
 		return fmt.Errorf("failed to stop service %s: %w", s, err)
 	}
 	return nil
@@ -38,15 +38,15 @@ func (c WinSCM) ServiceScriptPath(_ context.Context, _ cmd.ContextRunner, _ stri
 
 // RestartService restarts a service.
 func (c WinSCM) RestartService(ctx context.Context, h cmd.ContextRunner, s string) error {
-	if err := h.ExecContext(ctx, "Restart-Service "+ps.DoubleQuote(s), cmd.PS()); err != nil {
+	if err := h.ExecContext(ctx, "$ErrorActionPreference='Stop'\nRestart-Service "+ps.SingleQuote(s)+" -ErrorAction Stop", cmd.PS()); err != nil {
 		return fmt.Errorf("failed to restart service %s: %w", s, err)
 	}
 	return nil
 }
 
-// EnableService enables a service.
+// EnableService enables a service by setting its startup type to Automatic.
 func (c WinSCM) EnableService(ctx context.Context, h cmd.ContextRunner, s string) error {
-	if err := h.ExecContext(ctx, fmt.Sprintf("sc.exe config %s start=enabled", ps.DoubleQuote(s))); err != nil {
+	if err := h.ExecContext(ctx, fmt.Sprintf("$ErrorActionPreference='Stop'\nSet-Service -Name %s -StartupType Automatic -ErrorAction Stop", ps.SingleQuote(s)), cmd.PS()); err != nil {
 		return fmt.Errorf("failed to enable service %s: %w", s, err)
 	}
 
@@ -65,9 +65,9 @@ func (c WinSCM) ServiceLogs(ctx context.Context, h cmd.ContextRunner, s string, 
 	return strings.Split(out, "\n"), nil
 }
 
-// DisableService disables a service.
+// DisableService disables a service by setting its startup type to Disabled.
 func (c WinSCM) DisableService(ctx context.Context, h cmd.ContextRunner, s string) error {
-	if err := h.ExecContext(ctx, fmt.Sprintf("sc.exe config %s start=disabled", ps.DoubleQuote(s))); err != nil {
+	if err := h.ExecContext(ctx, fmt.Sprintf("$ErrorActionPreference='Stop'\nSet-Service -Name %s -StartupType Disabled -ErrorAction Stop", ps.SingleQuote(s)), cmd.PS()); err != nil {
 		return fmt.Errorf("failed to disable service %s: %w", s, err)
 	}
 	return nil
@@ -75,7 +75,7 @@ func (c WinSCM) DisableService(ctx context.Context, h cmd.ContextRunner, s strin
 
 // ServiceIsRunning returns true if a service is running.
 func (c WinSCM) ServiceIsRunning(ctx context.Context, h cmd.ContextRunner, s string) bool {
-	return h.ExecContext(ctx, fmt.Sprintf(`sc.exe query %s | findstr "RUNNING"`, ps.DoubleQuote(s))) == nil
+	return h.ExecContext(ctx, fmt.Sprintf("$ErrorActionPreference='Stop'\nif ((Get-Service %s -ErrorAction SilentlyContinue).Status -ne 'Running') { exit 1 }", ps.SingleQuote(s)), cmd.PS()) == nil
 }
 
 // RegisterWinSCM registers the WinSCM in a repository.

--- a/initsystem/winscm_test.go
+++ b/initsystem/winscm_test.go
@@ -1,0 +1,145 @@
+package initsystem_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/k0sproject/rig/v2/initsystem"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+func newWinRunner() *rigtest.MockRunner {
+	mr := rigtest.NewMockRunner()
+	mr.Windows = true
+	return mr
+}
+
+// decodePSCmd decodes a powershell.exe -E <base64> command back to the
+// original PowerShell source using proper UTF-16LE decoding. It asserts
+// that the command is in encoded form and fails the test otherwise.
+func decodePSCmd(t *testing.T, cmd string) string {
+	t.Helper()
+	_, b64, ok := strings.Cut(cmd, " -E ")
+	require.True(t, ok, "command should use -EncodedCommand (-E) form: %q", cmd)
+	data, err := base64.StdEncoding.DecodeString(b64)
+	require.NoError(t, err, "base64 decode failed")
+	require.True(t, len(data)%2 == 0, "decoded bytes must be even (UTF-16LE)")
+	words := make([]uint16, len(data)/2)
+	for i := range words {
+		words[i] = uint16(data[i*2]) | uint16(data[i*2+1])<<8
+	}
+	return string(utf16.Decode(words))
+}
+
+func TestWinSCMStartService(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+		require.NoError(t, initsystem.WinSCM{}.StartService(context.Background(), mr, "myservice"))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("sc.exe")))
+		script := decodePSCmd(t, mr.LastCommand())
+		require.Contains(t, script, "Start-Service")
+		require.Contains(t, script, "-ErrorAction Stop")
+		require.Contains(t, script, "'myservice'")
+	})
+	t.Run("failure", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
+		require.Error(t, initsystem.WinSCM{}.StartService(context.Background(), mr, "myservice"))
+	})
+}
+
+func TestWinSCMStopService(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+		require.NoError(t, initsystem.WinSCM{}.StopService(context.Background(), mr, "myservice"))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("sc.exe")))
+		script := decodePSCmd(t, mr.LastCommand())
+		require.Contains(t, script, "Stop-Service")
+		require.Contains(t, script, "-ErrorAction Stop")
+		require.Contains(t, script, "'myservice'")
+	})
+	t.Run("failure", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
+		require.Error(t, initsystem.WinSCM{}.StopService(context.Background(), mr, "myservice"))
+	})
+}
+
+func TestWinSCMRestartService(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+		require.NoError(t, initsystem.WinSCM{}.RestartService(context.Background(), mr, "myservice"))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("sc.exe")))
+		script := decodePSCmd(t, mr.LastCommand())
+		require.Contains(t, script, "Restart-Service")
+		require.Contains(t, script, "-ErrorAction Stop")
+		require.Contains(t, script, "'myservice'")
+	})
+	t.Run("failure", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
+		require.Error(t, initsystem.WinSCM{}.RestartService(context.Background(), mr, "myservice"))
+	})
+}
+
+func TestWinSCMEnableService(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+		require.NoError(t, initsystem.WinSCM{}.EnableService(context.Background(), mr, "myservice"))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("sc.exe")))
+		script := decodePSCmd(t, mr.LastCommand())
+		require.Contains(t, script, "Set-Service")
+		require.Contains(t, script, "-ErrorAction Stop")
+		require.Contains(t, script, "'myservice'")
+	})
+	t.Run("failure", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
+		require.Error(t, initsystem.WinSCM{}.EnableService(context.Background(), mr, "myservice"))
+	})
+}
+
+func TestWinSCMDisableService(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+		require.NoError(t, initsystem.WinSCM{}.DisableService(context.Background(), mr, "myservice"))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("sc.exe")))
+		script := decodePSCmd(t, mr.LastCommand())
+		require.Contains(t, script, "Set-Service")
+		require.Contains(t, script, "-ErrorAction Stop")
+		require.Contains(t, script, "'myservice'")
+	})
+	t.Run("failure", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
+		require.Error(t, initsystem.WinSCM{}.DisableService(context.Background(), mr, "myservice"))
+	})
+}
+
+func TestWinSCMServiceIsRunning(t *testing.T) {
+	t.Run("running", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+		require.True(t, initsystem.WinSCM{}.ServiceIsRunning(context.Background(), mr, "myservice"))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("findstr")))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("sc.exe")))
+		script := decodePSCmd(t, mr.LastCommand())
+		require.Contains(t, script, "Get-Service")
+		require.Contains(t, script, "'myservice'")
+	})
+	t.Run("not running", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
+		require.False(t, initsystem.WinSCM{}.ServiceIsRunning(context.Background(), mr, "myservice"))
+	})
+}

--- a/powershell/powershell.go
+++ b/powershell/powershell.go
@@ -132,6 +132,14 @@ func DoubleQuotePath(v string) string {
 	return DoubleQuote(ToWindowsPath(v))
 }
 
+// SingleQuotePath single-quotes a path and converts forward slashes to backslashes.
+// Use this instead of DoubleQuotePath when the value is passed to a -LiteralPath
+// parameter or any context where PowerShell variable interpolation (e.g. '$' in
+// directory names like C:\$Recycle.Bin) must not occur.
+func SingleQuotePath(v string) string {
+	return SingleQuote(ToWindowsPath(v))
+}
+
 // ToWindowsPath converts a unix-style forward slash separated path to a windows-style path.
 func ToWindowsPath(v string) string {
 	return strings.ReplaceAll(v, "/", "\\")

--- a/remotefs/http_test.go
+++ b/remotefs/http_test.go
@@ -14,26 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// decodePSScript extracts and decodes the PowerShell script from a command using the -E encoded flag.
-// PS -EncodedCommand encoding: script is UTF-16LE encoded then base64 encoded. For ASCII-only scripts
-// each character occupies two bytes (char_byte, 0x00), so decoding strips every other byte.
-func decodePSScript(psCmd string) string {
-	const marker = " -E "
-	idx := strings.Index(psCmd, marker)
-	if idx < 0 {
-		return ""
-	}
-	raw, err := base64.StdEncoding.DecodeString(psCmd[idx+len(marker):])
-	if err != nil {
-		return ""
-	}
-	var sb strings.Builder
-	for i := 0; i+1 < len(raw); i += 2 {
-		sb.WriteByte(raw[i])
-	}
-	return sb.String()
-}
-
 func TestPosixRoundTripGET(t *testing.T) {
 	rawResp := "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nhello"
 	encoded := base64.StdEncoding.EncodeToString([]byte(rawResp))
@@ -236,7 +216,9 @@ func TestWinRoundTripWithRequestBody(t *testing.T) {
 	defer resp.Body.Close()
 
 	require.Equal(t, 201, resp.StatusCode)
-	require.Contains(t, decodePSScript(mr.LastCommand()), "OpenStandardInput")
+	script, ok := decodePSScript(mr.LastCommand())
+	require.True(t, ok, "expected encoded PS command")
+	require.Contains(t, script, "OpenStandardInput")
 }
 
 func TestRoundTripURLValidation(t *testing.T) {

--- a/remotefs/pstest_helpers_test.go
+++ b/remotefs/pstest_helpers_test.go
@@ -1,0 +1,36 @@
+package remotefs_test
+
+import (
+	"encoding/base64"
+	"strings"
+	"unicode/utf16"
+)
+
+// decodePSScript decodes a powershell.exe -E <base64> command back to the
+// original PowerShell source using proper UTF-16LE decoding. Returns ("", false)
+// if the command is not in encoded form.
+func decodePSScript(cmd string) (string, bool) {
+	// Parse argv-style tokens and extract only the argument immediately
+	// following -E or -EncodedCommand so benign flag reordering or trailing
+	// arguments do not corrupt the base64 payload.
+	fields := strings.Fields(cmd)
+	var b64 string
+	for i := 0; i < len(fields)-1; i++ {
+		if fields[i] == "-E" || fields[i] == "-EncodedCommand" {
+			b64 = fields[i+1]
+			break
+		}
+	}
+	if b64 == "" {
+		return "", false
+	}
+	data, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil || len(data)%2 != 0 {
+		return "", false
+	}
+	words := make([]uint16, len(data)/2)
+	for i := range words {
+		words[i] = uint16(data[i*2]) | uint16(data[i*2+1])<<8
+	}
+	return string(utf16.Decode(words)), true
+}

--- a/remotefs/reboot_test.go
+++ b/remotefs/reboot_test.go
@@ -15,84 +15,110 @@ import (
 func TestWinFSRebootSequence(t *testing.T) {
 	runner := rigtest.NewMockRunner()
 	runner.Windows = true
-	runner.AddCommandSuccess(rigtest.Contains("schtasks /create"))
-	runner.AddCommandSuccess(rigtest.Contains("schtasks /run"))
-	runner.AddCommandSuccess(rigtest.Contains("schtasks /delete"))
+	runner.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
 
 	fs := remotefs.NewWindowsFS(runner)
 	require.NoError(t, fs.Reboot(context.Background()))
-	require.NoError(t, runner.Received(rigtest.Contains(`/tr "shutdown /r /f /t 5"`)))
-	require.NoError(t, runner.Received(rigtest.Contains(`/sc once /st 23:59 /z /f /ru SYSTEM`)))
-	require.NoError(t, runner.Received(rigtest.Contains("schtasks /run")))
-	require.NoError(t, runner.Received(rigtest.Contains("schtasks /delete")))
+
+	cmds := runner.MockConnection.Commands()
+	require.Len(t, cmds, 3, "expected create + run + delete = 3 commands")
+
+	create, ok := decodePSScript(cmds[0])
+	require.True(t, ok, "create command should be an encoded PS command")
+	require.Contains(t, create, "Register-ScheduledTask")
+	require.Contains(t, create, "shutdown.exe")
+	require.Contains(t, create, "SYSTEM")
+	require.Contains(t, create, "/r /f /t 5")
+
+	run, ok := decodePSScript(cmds[1])
+	require.True(t, ok, "run command should be an encoded PS command")
+	require.Contains(t, run, "Start-ScheduledTask")
+
+	del, ok := decodePSScript(cmds[2])
+	require.True(t, ok, "delete command should be an encoded PS command")
+	require.Contains(t, del, "Unregister-ScheduledTask")
+
+	// Must not fall back to the old schtasks CLI approach.
+	require.NoError(t, runner.NotReceived(rigtest.Contains("schtasks")))
 }
 
 func TestWinFSRebootCreateFails(t *testing.T) {
 	runner := rigtest.NewMockRunner()
 	runner.Windows = true
-	runner.AddCommandFailure(rigtest.Contains("schtasks /create"), errors.New("access denied"))
+	runner.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("access denied"))
 
 	fs := remotefs.NewWindowsFS(runner)
 	err := fs.Reboot(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "create reboot task")
-	require.Error(t, runner.Received(rigtest.Contains("schtasks /run")))
+	require.Equal(t, 1, runner.Len(), "run must not be called after a create failure")
 }
 
 func TestWinFSRebootRunConnectionError(t *testing.T) {
 	runner := rigtest.NewMockRunner()
 	runner.Windows = true
-	runner.AddCommandSuccess(rigtest.Contains("schtasks /create"))
-	runner.AddCommandFailure(rigtest.Contains("schtasks /run"), io.EOF)
-	runner.AddCommandSuccess(rigtest.Contains("schtasks /delete"))
+	call := 0
+	runner.AddCommand(rigtest.HasPrefix("powershell.exe"), func(_ *rigtest.A) error {
+		call++
+		if call == 2 { // run script
+			return io.EOF // transport-level error
+		}
+		return nil
+	})
 
 	fs := remotefs.NewWindowsFS(runner)
 	require.NoError(t, fs.Reboot(context.Background()), "transport-level run error should be treated as success")
-	require.NoError(t, runner.Received(rigtest.Contains("schtasks /delete")))
+	require.Equal(t, 3, runner.Len(), "delete must still be attempted after transport error")
 }
 
 func TestWinFSRebootRunLogicalError(t *testing.T) {
 	runner := rigtest.NewMockRunner()
 	runner.Windows = true
-	runner.AddCommandSuccess(rigtest.Contains("schtasks /create"))
-	runner.AddCommandFailure(rigtest.Contains("schtasks /run"), errors.New("exit code 1"))
-	runner.AddCommandSuccess(rigtest.Contains("schtasks /delete"))
+	call := 0
+	runner.AddCommand(rigtest.HasPrefix("powershell.exe"), func(_ *rigtest.A) error {
+		call++
+		if call == 2 { // run script
+			return errors.New("exit code 1")
+		}
+		return nil
+	})
 
 	fs := remotefs.NewWindowsFS(runner)
 	err := fs.Reboot(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "run reboot task")
-	require.NoError(t, runner.Received(rigtest.Contains("schtasks /delete")))
+	require.Equal(t, 3, runner.Len(), "delete must still be attempted after logical run error")
 }
 
 func TestWinFSRebootUniqueTaskNames(t *testing.T) {
 	runner := rigtest.NewMockRunner()
 	runner.Windows = true
-	runner.AddCommandSuccess(rigtest.Contains("schtasks"))
+	runner.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
 
 	fs := remotefs.NewWindowsFS(runner)
 	require.NoError(t, fs.Reboot(context.Background()))
 	require.NoError(t, fs.Reboot(context.Background()))
 
-	var names []string
-	for _, c := range runner.MockConnection.Commands() {
-		if !strings.Contains(c, "schtasks /create") {
-			continue
-		}
-		const marker = `/tn "`
-		i := strings.Index(c, marker)
-		if i < 0 {
-			continue
-		}
-		rest := c[i+len(marker):]
-		j := strings.Index(rest, `"`)
-		if j < 0 {
-			continue
-		}
-		names = append(names, rest[:j])
+	// Extract task names from the Start-ScheduledTask (run) commands — index 1 and 4.
+	cmds := runner.MockConnection.Commands()
+	require.Len(t, cmds, 6, "2 reboots × 3 commands each = 6")
+
+	extractTaskName := func(cmd string) string {
+		t.Helper()
+		decoded, ok := decodePSScript(cmd)
+		require.True(t, ok)
+		const marker = "Start-ScheduledTask -TaskName \""
+		i := strings.Index(decoded, marker)
+		require.GreaterOrEqual(t, i, 0, "run command must contain Start-ScheduledTask -TaskName")
+		rest := decoded[i+len(marker):]
+		j := strings.Index(rest, "\"")
+		require.GreaterOrEqual(t, j, 0)
+		return rest[:j]
 	}
-	require.Len(t, names, 2)
-	require.NotEqual(t, names[0], names[1], "task names should be unique per call")
+
+	name1 := extractTaskName(cmds[1]) // run command of first Reboot
+	name2 := extractTaskName(cmds[4]) // run command of second Reboot
+	require.NotEqual(t, name1, name2, "task names should be unique per call")
 }
 
 func TestPosixFSRebootSuccess(t *testing.T) {

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -398,15 +398,19 @@ func (s *WinFS) Chtimes(name string, atime, mtime int64) error {
 
 // Chmod changes the mode of the named file to mode. On Windows, only the 0200
 // bit (owner writable) of mode is used: if set, the read-only attribute is
-// cleared (attrib -R); if unset, it is set (attrib +R).
+// cleared; if unset, it is set.
 func (s *WinFS) Chmod(name string, mode fs.FileMode) error {
-	var attribSign string
+	var op string
 	if mode&0o200 != 0 {
-		attribSign = "-" // owner-write set → clear read-only
+		op = "-band -bnot [IO.FileAttributes]::ReadOnly" // owner-write set → clear read-only
 	} else {
-		attribSign = "+" // owner-write not set → set read-only
+		op = "-bor [IO.FileAttributes]::ReadOnly" // owner-write not set → set read-only
 	}
-	if err := s.Exec(fmt.Sprintf("attrib %sR %s", attribSign, ps.DoubleQuotePath(name))); err != nil {
+	// Use a newline to separate statements so powershell.Cmd chooses
+	// -EncodedCommand; this prevents $a from being expanded by an outer
+	// PowerShell host (e.g. when SSH DefaultShell is PowerShell).
+	script := fmt.Sprintf("$a=Get-Item -LiteralPath %s -Force -ErrorAction Stop\n$a.Attributes=($a.Attributes %s)", ps.SingleQuotePath(name), op)
+	if err := s.Exec(script, cmd.PS()); err != nil {
 		return fmt.Errorf("chmod %s: %w", name, err)
 	}
 	return nil
@@ -717,37 +721,37 @@ func toSlashes(path string) string {
 }
 
 // Reboot triggers an immediate restart of the remote host via a SYSTEM-context
-// one-shot scheduled task running 'shutdown /r /f /t 5'. Running via a
+// on-demand scheduled task running 'shutdown.exe /r /f /t 5'. Running via a
 // scheduled task bypasses the filtered Administrator token used by WinRM
 // sessions (e.g. on AWS EC2) which lacks SeShutdownPrivilege — issuing
 // 'shutdown /r' directly in such a session is silently ignored by the OS.
 //
-// The scheduled time uses '/sc once /st 23:59' to avoid locale-sensitive
-// date parsing; the task is immediately triggered via 'schtasks /run' so the
-// scheduled time is irrelevant. The '/z' flag asks Windows to delete the
-// task after it fires, and a best-effort 'schtasks /delete' is attempted in
-// all cases to prevent a delayed fallback fire if '/run' never triggered the
-// shutdown.
+// The task is registered without a time-based trigger so it can only fire when
+// explicitly started via Start-ScheduledTask. A best-effort
+// Unregister-ScheduledTask is attempted in all cases.
 func (s *WinFS) Reboot(ctx context.Context) error {
 	taskName := fmt.Sprintf("RigReboot%d_%d", time.Now().UnixNano(), rebootTaskCounter.Add(1))
 	const shutdownDelay = 5
-	createCmd := fmt.Sprintf(
-		`schtasks /create /tn "%s" /tr "shutdown /r /f /t %d" /sc once /st 23:59 /z /f /ru SYSTEM`,
-		taskName, shutdownDelay,
+	createScript := fmt.Sprintf(
+		`$ErrorActionPreference='Stop'`+
+			`; $a=New-ScheduledTaskAction -Execute 'shutdown.exe' -Argument %s`+
+			`; $p=New-ScheduledTaskPrincipal -UserId 'SYSTEM' -RunLevel Highest -LogonType ServiceAccount`+
+			`; Register-ScheduledTask -TaskName %s -Action $a -Principal $p -Force | Out-Null`,
+		ps.SingleQuote(fmt.Sprintf("/r /f /t %d", shutdownDelay)),
+		ps.DoubleQuote(taskName),
 	)
-	if err := s.ExecContext(ctx, createCmd, cmd.AllowWinStderr()); err != nil {
+	if err := s.ExecContext(ctx, createScript, cmd.PS(), cmd.AllowWinStderr()); err != nil {
 		return fmt.Errorf("create reboot task: %w", err)
 	}
 
-	runCmd := fmt.Sprintf(`schtasks /run /tn "%s"`, taskName)
-	deleteCmd := fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName)
+	runScript := "$ErrorActionPreference='Stop'; Start-ScheduledTask -TaskName " + ps.DoubleQuote(taskName)
+	deleteScript := fmt.Sprintf("Unregister-ScheduledTask -TaskName %s -Confirm:$false", ps.DoubleQuote(taskName))
 
-	if err := s.ExecContext(ctx, runCmd, cmd.AllowWinStderr()); err != nil {
+	if err := s.ExecContext(ctx, runScript, cmd.PS(), cmd.AllowWinStderr()); err != nil {
 		// Best-effort delete in all error paths to prevent the task from
 		// firing later. Ignore the delete error: if the host is already
-		// rebooting it will fail anyway, and if the task never fired the
-		// auto-delete (/z) won't trigger either.
-		_ = s.ExecContext(ctx, deleteCmd, cmd.AllowWinStderr())
+		// rebooting it will fail anyway.
+		_ = s.ExecContext(ctx, deleteScript, cmd.PS(), cmd.AllowWinStderr())
 		if !isTransportClosed(err) {
 			return fmt.Errorf("run reboot task: %w", err)
 		}
@@ -757,8 +761,7 @@ func (s *WinFS) Reboot(ctx context.Context) error {
 	}
 
 	// Run succeeded. Best-effort cleanup; deleting the task entry does not
-	// cancel the already-started shutdown countdown, it only prevents a
-	// delayed fallback fire if /run somehow did not trigger.
-	_ = s.ExecContext(ctx, deleteCmd, cmd.AllowWinStderr())
+	// cancel the already-started shutdown countdown.
+	_ = s.ExecContext(ctx, deleteScript, cmd.PS(), cmd.AllowWinStderr())
 	return nil
 }

--- a/remotefs/winfs_test.go
+++ b/remotefs/winfs_test.go
@@ -322,22 +322,33 @@ func TestWinFSChmod(t *testing.T) {
 	t.Run("writable mode clears read-only attribute", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
 		mr.Windows = true
-		mr.AddCommandSuccess(rigtest.Contains("attrib"))
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
 		fsys := remotefs.NewWindowsFS(mr)
-		// 0o644 has the owner-write bit (0o200) set → should clear read-only (attrib -R).
+		// 0o644 has the owner-write bit (0o200) set → should clear read-only.
 		require.NoError(t, fsys.Chmod(`C:\file.txt`, 0o644))
-		require.NoError(t, mr.Received(rigtest.Contains("attrib -R")))
-		require.NoError(t, mr.NotReceived(rigtest.Contains("attrib +R")))
+		require.NoError(t, mr.Received(rigtest.HasPrefix("powershell.exe")))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("attrib")))
+		// Decode the -EncodedCommand payload and verify the bitwise-clear operation.
+		script, ok := decodePSScript(mr.LastCommand())
+		require.True(t, ok, "Chmod should use an encoded PS command to prevent $a expansion by an outer PS host")
+		require.Contains(t, script, "Get-Item")
+		require.Contains(t, script, "-band -bnot [IO.FileAttributes]::ReadOnly")
 	})
 
 	t.Run("read-only mode sets read-only attribute", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
 		mr.Windows = true
-		mr.AddCommandSuccess(rigtest.Contains("attrib"))
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
 		fsys := remotefs.NewWindowsFS(mr)
-		// 0o444 has no owner-write bit → should set read-only (attrib +R).
+		// 0o444 has no owner-write bit → should set read-only.
 		require.NoError(t, fsys.Chmod(`C:\file.txt`, fs.FileMode(0o444)))
-		require.NoError(t, mr.Received(rigtest.Contains("attrib +R")))
-		require.NoError(t, mr.NotReceived(rigtest.Contains("attrib -R")))
+		require.NoError(t, mr.Received(rigtest.HasPrefix("powershell.exe")))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("attrib")))
+		// Decode the -EncodedCommand payload and verify the bitwise-set operation.
+		script, ok := decodePSScript(mr.LastCommand())
+		require.True(t, ok, "Chmod should use an encoded PS command to prevent $a expansion by an outer PS host")
+		require.Contains(t, script, "Get-Item")
+		require.Contains(t, script, "-bor [IO.FileAttributes]::ReadOnly")
 	})
 }
+


### PR DESCRIPTION
All Windows command execs that relied on cmd.exe being the default shell are now wrapped with cmd.PS() using PowerShell-native cmdlets. This fixes breakage when the SSH default shell on a Windows host is PowerShell.

initsystem/winscm.go:
- StartService/StopService: sc.exe start/stop → Start-Service/Stop-Service
- EnableService: sc.exe config start=enabled → Set-Service -StartupType Automatic (also fixes a latent bug: "enabled" is not a valid sc.exe start= value)
- DisableService: sc.exe config start=disabled → Set-Service -StartupType Disabled
- ServiceIsRunning: sc.exe query | findstr → Get-Service status check

remotefs/winfs.go:
- Chmod: bare attrib ±R → Get-Item / .Attributes FileAttributes bitmask via PS
- Reboot: schtasks /create|run|delete → Register/Start/Unregister-ScheduledTask (preserves SYSTEM-principal scheduled-task approach for UAC token bypass)

cmd.exe /c del, rmdir, mkdir remain unchanged — those explicitly invoke cmd.exe and are unaffected by the default-shell setting.

Tests updated/added for all changed methods.