### PR TITLE
add sync.Pools for high-impact functions

### DIFF
--- a/cmd/executor.go
+++ b/cmd/executor.go
@@ -34,6 +34,11 @@ var (
 	errOddUTF16Length = errors.New("odd byte length in UTF-16LE payload")
 )
 
+// bufferPool recycles bytes.Buffer instances for ExecOutputContext to reduce allocations.
+var bufferPool = sync.Pool{
+	New: func() any { return &bytes.Buffer{} },
+}
+
 // Executor is an Runner that runs commands on a host.
 type Executor struct {
 	log.LoggerInjectable
@@ -277,8 +282,16 @@ func (r *Executor) Exec(command string, opts ...ExecOption) error {
 
 // ExecOutputContext executes the command and returns the stdout output or an error.
 func (r *Executor) ExecOutputContext(ctx context.Context, command string, opts ...ExecOption) (string, error) {
-	out := &bytes.Buffer{}
-	defer out.Reset()
+	out, ok := bufferPool.Get().(*bytes.Buffer)
+	if !ok {
+		out = &bytes.Buffer{}
+	}
+	defer func() {
+		if out.Cap() <= 64<<10 {
+			out.Reset()
+			bufferPool.Put(out)
+		}
+	}()
 
 	opts = append(opts, Stdout(out))
 

--- a/cmd/executor.go
+++ b/cmd/executor.go
@@ -288,6 +288,7 @@ func (r *Executor) ExecOutputContext(ctx context.Context, command string, opts .
 	}
 	defer func() {
 		if out.Cap() <= 64<<10 {
+			clear(out.Bytes()) // zero backing array so output doesn't linger in pool memory
 			out.Reset()
 			bufferPool.Put(out)
 		}

--- a/powershell/powershell.go
+++ b/powershell/powershell.go
@@ -63,6 +63,8 @@ func CompressedCmd(psCmd string) string {
 	_ = compBuf.gz.Close()
 	encoded := base64.StdEncoding.EncodeToString(compBuf.buf.Bytes())
 	if compBuf.buf.Cap() <= 64<<10 {
+		clear(compBuf.buf.Bytes()) // zero compressed bytes before pooling
+		compBuf.buf.Reset()
 		compressPool.Put(compBuf)
 	}
 	scriptlet := `$z="` + encoded + `"

--- a/powershell/powershell.go
+++ b/powershell/powershell.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"strings"
+	"sync"
 	"unicode/utf16"
 )
 
@@ -14,6 +15,26 @@ const PipeHasEnded = "The pipe has been ended."
 
 // PipeIsBeingClosed string is used during the base64+sha265 upload process.
 const PipeIsBeingClosed = "The pipe is being closed."
+
+// compressBuf pairs a buffer with a gzip.Writer so both can be pooled together.
+type compressBuf struct {
+	buf *bytes.Buffer
+	gz  *gzip.Writer
+}
+
+// compressPool recycles compressBuf instances to reduce allocations in CompressedCmd.
+var compressPool = sync.Pool{
+	New: func() any {
+		buf := &bytes.Buffer{}
+		gz, _ := gzip.NewWriterLevel(buf, gzip.BestCompression) // level is always valid
+		return &compressBuf{buf: buf, gz: gz}
+	},
+}
+
+// builderPool recycles strings.Builder instances for SingleQuote and DoubleQuote.
+var builderPool = sync.Pool{
+	New: func() any { return &strings.Builder{} },
+}
 
 // CompressedCmd creates a scriptlet that will decompress and execute a gzipped script to both avoid
 // command line length limits and to reduce data transferred.
@@ -27,14 +48,19 @@ func CompressedCmd(psCmd string) string {
 		trimmed = append(trimmed, line)
 	}
 	cmd := strings.Join(trimmed, "\n")
-	var b bytes.Buffer
-	w, err := gzip.NewWriterLevel(&b, gzip.BestCompression)
-	if err != nil {
-		panic(err) // BestCompression level is always valid
+	compBuf, ok := compressPool.Get().(*compressBuf)
+	if !ok {
+		buf := &bytes.Buffer{}
+		gz, _ := gzip.NewWriterLevel(buf, gzip.BestCompression)
+		compBuf = &compressBuf{buf: buf, gz: gz}
 	}
-	_, _ = w.Write([]byte(cmd))
-	_ = w.Close()
-	scriptlet := `$z="` + base64.StdEncoding.EncodeToString(b.Bytes()) + `"
+	compBuf.buf.Reset()
+	compBuf.gz.Reset(compBuf.buf)
+	_, _ = compBuf.gz.Write([]byte(cmd))
+	_ = compBuf.gz.Close()
+	encoded := base64.StdEncoding.EncodeToString(compBuf.buf.Bytes())
+	compressPool.Put(compBuf)
+	scriptlet := `$z="` + encoded + `"
 $d=[Convert]::FromBase64String($z)
 Set-Alias NO New-Object
 $m=NO IO.MemoryStream
@@ -87,11 +113,18 @@ func Cmd(psCmd string) string {
 
 // SingleQuote quotes and escapes a string in a format that is accepted by powershell scriptlets
 // from jbrekelmans/go-winrm/util.go PowerShellSingleQuotedStringLiteral.
-func SingleQuote(v string) string {
-	var buf strings.Builder
-	buf.Grow(len(v) + 3)
+func SingleQuote(str string) string {
+	buf, ok := builderPool.Get().(*strings.Builder)
+	if !ok {
+		buf = &strings.Builder{}
+	}
+	defer func() {
+		buf.Reset()
+		builderPool.Put(buf)
+	}()
+	buf.Grow(len(str) + 3)
 	buf.WriteRune('\'')
-	for _, rune := range v {
+	for _, rune := range str {
 		switch rune {
 		case '\n', '\r', '\t', '\v', '\f', '\a', '\b', '\'', '`', '\x00':
 			buf.WriteString("`")
@@ -105,16 +138,23 @@ func SingleQuote(v string) string {
 }
 
 // DoubleQuote adds double quotes around a string and escapes any double quotes inside.
-func DoubleQuote(v string) string {
-	if len(v) > 0 && v[0] == '"' && v[len(v)-1] == '"' {
+func DoubleQuote(str string) string {
+	if len(str) > 0 && str[0] == '"' && str[len(str)-1] == '"' {
 		// already quoted
-		return v
+		return str
 	}
 
-	var buf strings.Builder
-	buf.Grow(len(v) + 4)
+	buf, ok := builderPool.Get().(*strings.Builder)
+	if !ok {
+		buf = &strings.Builder{}
+	}
+	defer func() {
+		buf.Reset()
+		builderPool.Put(buf)
+	}()
+	buf.Grow(len(str) + 4)
 	buf.WriteRune('"')
-	for _, rune := range v {
+	for _, rune := range str {
 		switch rune {
 		case '"':
 			buf.WriteString("`\"")

--- a/powershell/powershell.go
+++ b/powershell/powershell.go
@@ -32,6 +32,9 @@ var compressPool = sync.Pool{
 }
 
 // builderPool recycles strings.Builder instances for SingleQuote and DoubleQuote.
+// Safety: Reset() nils the internal buffer, so a subsequent Grow allocates fresh
+// memory; the string returned by String() before Reset keeps its own reference to
+// the old backing array and remains valid after the builder is reused.
 var builderPool = sync.Pool{
 	New: func() any { return &strings.Builder{} },
 }
@@ -59,7 +62,9 @@ func CompressedCmd(psCmd string) string {
 	_, _ = compBuf.gz.Write([]byte(cmd))
 	_ = compBuf.gz.Close()
 	encoded := base64.StdEncoding.EncodeToString(compBuf.buf.Bytes())
-	compressPool.Put(compBuf)
+	if compBuf.buf.Cap() <= 64<<10 {
+		compressPool.Put(compBuf)
+	}
 	scriptlet := `$z="` + encoded + `"
 $d=[Convert]::FromBase64String($z)
 Set-Alias NO New-Object
@@ -119,8 +124,10 @@ func SingleQuote(str string) string {
 		buf = &strings.Builder{}
 	}
 	defer func() {
-		buf.Reset()
-		builderPool.Put(buf)
+		if buf.Cap() <= 64<<10 {
+			buf.Reset()
+			builderPool.Put(buf)
+		}
 	}()
 	buf.Grow(len(str) + 3)
 	buf.WriteRune('\'')
@@ -149,8 +156,10 @@ func DoubleQuote(str string) string {
 		buf = &strings.Builder{}
 	}
 	defer func() {
-		buf.Reset()
-		builderPool.Put(buf)
+		if buf.Cap() <= 64<<10 {
+			buf.Reset()
+			builderPool.Put(buf)
+		}
 	}()
 	buf.Grow(len(str) + 4)
 	buf.WriteRune('"')

--- a/powershell/powershell_test.go
+++ b/powershell/powershell_test.go
@@ -129,3 +129,92 @@ func TestEncodeCmdUnicode(t *testing.T) {
 	decoded := decodeEncodeCmd(t, powershell.EncodeCmd(script))
 	require.Contains(t, decoded, "héllo wörld 日本語")
 }
+
+func TestSingleQuote(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello", `'hello'`},
+		{"", `''`},
+		{"it's", "'it`'s'"},
+		{"back`tick", "'back``tick'"},
+		{"line\nbreak", "'line`\nbreak'"},
+		{"tab\there", "'tab`\there'"},
+		{"\x00null", `'` + "`\x00null'"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := powershell.SingleQuote(tc.input)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestSingleQuotePoolReuse calls SingleQuote repeatedly to exercise sync.Pool reuse
+// and verify correctness is preserved across multiple uses of the same builder.
+func TestSingleQuotePoolReuse(t *testing.T) {
+	inputs := []string{"alpha", "beta's", "gamma`delta", "epsilon\nzeta"}
+	for range 10 {
+		for _, input := range inputs {
+			got := powershell.SingleQuote(input)
+			require.True(t, strings.HasPrefix(got, "'"), "expected opening quote: %s", got)
+			require.True(t, strings.HasSuffix(got, "'"), "expected closing quote: %s", got)
+		}
+	}
+}
+
+func TestDoubleQuote(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello", `"hello"`},
+		{"", `""`},
+		{`say "hi"`, "\"say `\"hi`\"\""},
+		{`"already quoted"`, `"already quoted"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := powershell.DoubleQuote(tc.input)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestDoubleQuotePoolReuse calls DoubleQuote repeatedly to exercise sync.Pool reuse.
+func TestDoubleQuotePoolReuse(t *testing.T) {
+	inputs := []string{"alpha", `beta "quoted"`, "gamma"}
+	for range 10 {
+		for _, input := range inputs {
+			got := powershell.DoubleQuote(input)
+			require.True(t, strings.HasPrefix(got, `"`), "expected opening double-quote: %s", got)
+			require.True(t, strings.HasSuffix(got, `"`), "expected closing double-quote: %s", got)
+		}
+	}
+}
+
+func TestCompressedCmd(t *testing.T) {
+	script := `
+# This comment should be stripped
+$a = 1
+$b = 2
+Write-Output ($a + $b)
+`
+	out := powershell.CompressedCmd(script)
+	// CompressedCmd always encodes (the scriptlet contains newlines), so it
+	// must use -EncodedCommand rather than -Command.
+	require.Contains(t, out, "powershell.exe")
+	require.Contains(t, out, " -E ")
+}
+
+// TestCompressedCmdPoolReuse calls CompressedCmd repeatedly to exercise the
+// compressPool reuse path and verify the output is stable across calls.
+func TestCompressedCmdPoolReuse(t *testing.T) {
+	script := "$x = Get-Date\nWrite-Output $x"
+	first := powershell.CompressedCmd(script)
+	for range 10 {
+		got := powershell.CompressedCmd(script)
+		require.Equal(t, first, got, "CompressedCmd must be deterministic across pool reuse")
+	}
+}

--- a/remotefs/windir.go
+++ b/remotefs/windir.go
@@ -73,54 +73,60 @@ var fileInfoPool = sync.Pool{
 // a slice of up to n fs.DirEntry values in directory order.
 // Subsequent calls on the same file will yield further DirEntry values.
 func (f *winDir) ReadDir(n int) ([]fs.DirEntry, error) {
-	if f.buffer == nil {
-		pipeR, pipeW := io.Pipe()
-		cmd, err := f.fs.Start(context.Background(), fmt.Sprintf(statDirTemplate, f.path), cmd.PS(), cmd.Stdout(pipeW))
-		if err != nil {
-			pipeW.Close()
-			return nil, fmt.Errorf("readdir: %w", err)
-		}
+	if f.buffer != nil {
+		return f.buffer.Next(n)
+	}
 
-		fileinfosptr, ok := fileInfoPool.Get().(*[]*winFileInfo)
-		if !ok {
-			infos := make([]*winFileInfo, 0)
-			fileinfosptr = &infos
-		}
-		fileinfos := *fileinfosptr
-		fileinfos = fileinfos[:0]
-		defer fileInfoPool.Put(fileinfosptr)
+	pipeR, pipeW := io.Pipe()
+	proc, err := f.fs.Start(context.Background(), fmt.Sprintf(statDirTemplate, f.path), cmd.PS(), cmd.Stdout(pipeW))
+	if err != nil {
+		pipeW.Close()
+		return nil, fmt.Errorf("readdir: %w", err)
+	}
 
-		var decodeErr error
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			decoder := json.NewDecoder(pipeR)
-			decodeErr = decoder.Decode(&fileinfos)
-			pipeR.Close()
-		}()
-		if err := cmd.Wait(); err != nil {
-			pipeW.Close()
-			<-done
-			return nil, fmt.Errorf("readdir: %w", err)
+	fileinfosptr, ok := fileInfoPool.Get().(*[]*winFileInfo)
+	if !ok {
+		infos := make([]*winFileInfo, 0)
+		fileinfosptr = &infos
+	}
+	fileinfos := *fileinfosptr
+	fileinfos = fileinfos[:0]
+	defer func() {
+		if cap(fileinfos) <= 1000 {
+			*fileinfosptr = fileinfos
+			fileInfoPool.Put(fileinfosptr)
 		}
+	}()
+
+	var decodeErr error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		decoder := json.NewDecoder(pipeR)
+		decodeErr = decoder.Decode(&fileinfos)
+		pipeR.Close()
+	}()
+	if err := proc.Wait(); err != nil {
 		pipeW.Close()
 		<-done
-		*fileinfosptr = fileinfos // sync the (possibly grown) slice back before returning it to the pool
-
-		if decodeErr != nil {
-			return nil, fmt.Errorf("decode readdir output: %w", decodeErr)
-		}
-
-		for _, info := range fileinfos {
-			info.fs = f.fs
-		}
-
-		entries := make([]fs.DirEntry, len(fileinfos))
-		for i, info := range fileinfos {
-			entries[i] = fs.DirEntry(info)
-		}
-		f.buffer = newDirEntryBuffer(entries)
+		return nil, fmt.Errorf("readdir: %w", err)
 	}
+	pipeW.Close()
+	<-done
+
+	if decodeErr != nil {
+		return nil, fmt.Errorf("decode readdir output: %w", decodeErr)
+	}
+
+	for _, info := range fileinfos {
+		info.fs = f.fs
+	}
+
+	entries := make([]fs.DirEntry, len(fileinfos))
+	for i, info := range fileinfos {
+		entries[i] = fs.DirEntry(info)
+	}
+	f.buffer = newDirEntryBuffer(entries)
 	return f.buffer.Next(n)
 }
 

--- a/remotefs/windir.go
+++ b/remotefs/windir.go
@@ -81,6 +81,7 @@ func (f *winDir) ReadDir(n int) ([]fs.DirEntry, error) {
 	proc, err := f.fs.Start(context.Background(), fmt.Sprintf(statDirTemplate, f.path), cmd.PS(), cmd.Stdout(pipeW))
 	if err != nil {
 		pipeW.Close()
+		pipeR.Close()
 		return nil, fmt.Errorf("readdir: %w", err)
 	}
 
@@ -93,9 +94,10 @@ func (f *winDir) ReadDir(n int) ([]fs.DirEntry, error) {
 	fileinfos = fileinfos[:0]
 	defer func() {
 		if cap(fileinfos) <= 1000 {
-			// Clear backing array so pooled slice does not retain *winFileInfo
-			// pointers and block GC collection of previously decoded entries.
-			clear(fileinfos[:cap(fileinfos)])
+			// Clear the full backing array (resliced to capacity via three-index
+			// form) so pooled items do not retain *winFileInfo pointers and block
+			// GC collection of previously decoded directory entries.
+			clear(fileinfos[:cap(fileinfos):cap(fileinfos)])
 			*fileinfosptr = fileinfos[:0]
 			fileInfoPool.Put(fileinfosptr)
 		}

--- a/remotefs/windir.go
+++ b/remotefs/windir.go
@@ -105,6 +105,7 @@ func (f *winDir) ReadDir(n int) ([]fs.DirEntry, error) {
 		}
 		pipeW.Close()
 		<-done
+		*fileinfosptr = fileinfos // sync the (possibly grown) slice back before returning it to the pool
 
 		if decodeErr != nil {
 			return nil, fmt.Errorf("decode readdir output: %w", decodeErr)

--- a/remotefs/windir.go
+++ b/remotefs/windir.go
@@ -93,7 +93,10 @@ func (f *winDir) ReadDir(n int) ([]fs.DirEntry, error) {
 	fileinfos = fileinfos[:0]
 	defer func() {
 		if cap(fileinfos) <= 1000 {
-			*fileinfosptr = fileinfos
+			// Clear backing array so pooled slice does not retain *winFileInfo
+			// pointers and block GC collection of previously decoded entries.
+			clear(fileinfos[:cap(fileinfos)])
+			*fileinfosptr = fileinfos[:0]
 			fileInfoPool.Put(fileinfosptr)
 		}
 	}()


### PR DESCRIPTION
There were a couple of points where allocating buffers through sync.Pool will be meaningful, perhaps even more so than what already is pooled.
