### PR TITLE
 fix: context propagation in service lifecycle, ExecInteractive and Windows detection

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - gocyclo
     - godox
     - goheader
+    - gomodguard
     - ireturn
     - lll
     - mnd

--- a/client.go
+++ b/client.go
@@ -370,9 +370,10 @@ func (c *Client) Disconnect() {
 var errInteractiveNotSupported = errors.New("the connection does not provide interactive exec support")
 
 // ExecInteractive executes a command on the host and passes stdin/stdout/stderr as-is to the session.
-func (c *Client) ExecInteractive(cmd string, stdin io.Reader, stdout, stderr io.Writer) error {
+// The session is terminated when ctx is cancelled or its deadline is exceeded.
+func (c *Client) ExecInteractive(ctx context.Context, cmd string, stdin io.Reader, stdout, stderr io.Writer) error {
 	if conn, ok := c.connection.(protocol.InteractiveExecer); ok {
-		if err := conn.ExecInteractive(cmd, stdin, stdout, stderr); err != nil {
+		if err := conn.ExecInteractive(ctx, cmd, stdin, stdout, stderr); err != nil {
 			return fmt.Errorf("exec interactive: %w", err)
 		}
 		return nil

--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package rig_test
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/k0sproject/rig/v2"
@@ -342,4 +343,63 @@ func TestClientRebootFSErrorWrapped(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, mockErr)
 	require.Contains(t, err.Error(), "reboot:")
+}
+
+// interactiveConn embeds MockConnection and additionally implements InteractiveExecer
+// so that Client.ExecInteractive forwards through to it.
+type interactiveConn struct {
+	*rigtest.MockConnection
+	receivedCtx context.Context
+	receivedCmd string
+	returnErr   error
+}
+
+func (c *interactiveConn) ExecInteractive(ctx context.Context, cmd string, _ io.Reader, _ io.Writer, _ io.Writer) error {
+	c.receivedCtx = ctx
+	c.receivedCmd = cmd
+	return c.returnErr
+}
+
+func TestClientExecInteractiveForwardsContext(t *testing.T) {
+	conn := &interactiveConn{MockConnection: rigtest.NewMockConnection()}
+	client, err := rig.NewClient(rig.WithConnection(conn))
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(context.Background()))
+
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
+
+	require.NoError(t, client.ExecInteractive(ctx, "echo hello", nil, nil, nil))
+	require.Equal(t, "echo hello", conn.receivedCmd)
+	require.Equal(t, "marker", conn.receivedCtx.Value(ctxKey{}))
+}
+
+func TestClientExecInteractiveCancelledContext(t *testing.T) {
+	conn := &interactiveConn{
+		MockConnection: rigtest.NewMockConnection(),
+		returnErr:      context.Canceled,
+	}
+	client, err := rig.NewClient(rig.WithConnection(conn))
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(context.Background()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = client.ExecInteractive(ctx, "sleep 60", nil, nil, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestClientExecInteractiveNotSupported(t *testing.T) {
+	// MockConnection does not implement InteractiveExecer, so the client should
+	// return an error indicating that interactive exec is unsupported.
+	conn := rigtest.NewMockConnection()
+	client, err := rig.NewClient(rig.WithConnection(conn))
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(context.Background()))
+
+	err = client.ExecInteractive(context.Background(), "sh", nil, nil, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "interactive")
 }

--- a/protocol/connection.go
+++ b/protocol/connection.go
@@ -44,7 +44,7 @@ type WindowsChecker interface {
 
 // InteractiveExecer is a connection that can start an interactive session.
 type InteractiveExecer interface {
-	ExecInteractive(cmd string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error
+	ExecInteractive(ctx context.Context, cmd string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error
 }
 
 // Connection is the minimum interface for protocol implementations.

--- a/protocol/localhost/connection.go
+++ b/protocol/localhost/connection.go
@@ -81,7 +81,8 @@ func (c *Connection) command(ctx context.Context, cmd string) *exec.Cmd {
 }
 
 // ExecInteractive executes a command on the host and passes stdin/stdout/stderr as-is to the session.
-func (c *Connection) ExecInteractive(cmd string, stdin io.Reader, stdout, stderr io.Writer) error { //nolint:cyclop
+// The process is killed when ctx is cancelled.
+func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.Reader, stdout, stderr io.Writer) error { //nolint:cyclop
 	if cmd == "" {
 		cmd = os.Getenv("SHELL") + " -l"
 	}
@@ -152,7 +153,16 @@ func (c *Connection) ExecInteractive(cmd string, stdin io.Reader, stdout, stderr
 		return fmt.Errorf("failed to start process: %w", err)
 	}
 
+	// Kill the process when the context is done.
+	go func() {
+		<-ctx.Done()
+		_ = proc.Kill()
+	}()
+
 	if _, err := proc.Wait(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err() //nolint:wrapcheck // context error is the real cause
+		}
 		return fmt.Errorf("process wait: %w", err)
 	}
 	return nil

--- a/protocol/localhost/connection.go
+++ b/protocol/localhost/connection.go
@@ -81,8 +81,17 @@ func (c *Connection) command(ctx context.Context, cmd string) *exec.Cmd {
 }
 
 // ExecInteractive executes a command on the host and passes stdin/stdout/stderr as-is to the session.
-// The process is killed when ctx is cancelled.
+// The process is killed when ctx is cancelled. Nil streams default to os.Stdin/os.Stdout/os.Stderr.
 func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.Reader, stdout, stderr io.Writer) error { //nolint:cyclop
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
 	if cmd == "" {
 		cmd = os.Getenv("SHELL") + " -l"
 	}

--- a/protocol/localhost/connection.go
+++ b/protocol/localhost/connection.go
@@ -153,10 +153,16 @@ func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.R
 		return fmt.Errorf("failed to start process: %w", err)
 	}
 
-	// Kill the process when the context is done.
+	// Kill the process when the context is done, but also stop watching when
+	// the function returns normally so that the goroutine does not leak.
+	watchDone := make(chan struct{})
+	defer close(watchDone)
 	go func() {
-		<-ctx.Done()
-		_ = proc.Kill()
+		select {
+		case <-ctx.Done():
+			_ = proc.Kill()
+		case <-watchDone:
+		}
 	}()
 
 	if _, err := proc.Wait(); err != nil {

--- a/protocol/openssh/connection.go
+++ b/protocol/openssh/connection.go
@@ -72,10 +72,14 @@ func (c *Connection) IPAddress() string {
 // ensuring the connection is established before calling this method.
 func (c *Connection) detectWindows(ctx context.Context) bool {
 	isWinProc, err := c.StartProcess(ctx, "cmd.exe /c exit 0", nil, nil, nil)
-	isWin := err == nil && isWinProc.Wait() == nil
-	// Don't cache a probe that failed due to context cancellation — the
-	// result would be a false negative that persists for the lifetime of
-	// the connection.
+	if err != nil {
+		// Probe couldn't start (e.g. not yet connected); don't cache so a
+		// subsequent call after Connect can succeed.
+		return false
+	}
+	isWin := isWinProc.Wait() == nil
+	// Don't cache when the context was cancelled — the probe result may
+	// reflect cancellation rather than the actual remote OS.
 	if ctx.Err() != nil {
 		return false
 	}

--- a/protocol/openssh/connection.go
+++ b/protocol/openssh/connection.go
@@ -67,25 +67,42 @@ func (c *Connection) IPAddress() string {
 	return c.Address
 }
 
-// IsWindows returns true if the remote host is windows.
-func (c *Connection) IsWindows() bool {
-	// Implement your logic here
-	if c.isWindows != nil {
-		return *c.isWindows
+// detectWindows probes the remote host to determine whether it is running
+// Windows and stores the result in the cache. The caller is responsible for
+// ensuring the connection is established before calling this method.
+func (c *Connection) detectWindows(ctx context.Context) bool {
+	isWinProc, err := c.StartProcess(ctx, "cmd.exe /c exit 0", nil, nil, nil)
+	isWin := err == nil && isWinProc.Wait() == nil
+	// Don't cache a probe that failed due to context cancellation — the
+	// result would be a false negative that persists for the lifetime of
+	// the connection.
+	if ctx.Err() != nil {
+		return false
 	}
+	c.controlMutex.Lock()
+	c.isWindows = &isWin
+	c.controlMutex.Unlock()
+	log.Trace(ctx, fmt.Sprintf("host is windows: %t", isWin), log.KeyHost, c)
+	return isWin
+}
 
-	var isWin bool
+// IsWindows returns true if the remote host is windows.
+// The result is cached after the first probe; subsequent calls are O(1).
+// For reliable context propagation, Connect should be called first —
+// detection is also triggered during Connect using the connect context.
+func (c *Connection) IsWindows() bool {
+	c.controlMutex.Lock()
+	if c.isWindows != nil {
+		result := *c.isWindows
+		c.controlMutex.Unlock()
+		return result
+	}
+	c.controlMutex.Unlock()
 
+	// Fallback: probe with a bounded background context.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-
-	isWinProc, err := c.StartProcess(ctx, "cmd.exe /c exit 0", nil, nil, nil)
-	isWin = err == nil && isWinProc.Wait() == nil
-
-	c.isWindows = &isWin
-	log.Trace(context.Background(), fmt.Sprintf("host is windows: %t", *c.isWindows), log.KeyHost, c)
-
-	return *c.isWindows
+	return c.detectWindows(ctx)
 }
 
 // DefaultOptionArguments are the default options for the OpenSSH client.
@@ -172,11 +189,14 @@ func (c *Connection) Connect(ctx context.Context) error {
 		c.controlMutex.Lock()
 		c.isConnected = true
 		c.controlMutex.Unlock()
+		// Pre-warm Windows detection using the connect context. This avoids
+		// context.Background() probes on every first IsWindows() call.
+		c.detectWindows(ctx)
 		return nil
 	}
 
-	defer c.controlMutex.Unlock()
-
+	// Multiplexing path: manage the lock explicitly so we can release it
+	// before calling detectWindows (StartProcess acquires the same lock).
 	opts := c.Options.Copy()
 	opts.Set("ControlMaster", true)
 	opts.Set("ControlPersist", 600)
@@ -194,6 +214,7 @@ func (c *Connection) Connect(ctx context.Context) error {
 	log.Trace(ctx, "starting ssh control master", log.KeyHost, c, log.KeyCommand, strings.Join(args, " "))
 	if err := cmd.Run(); err != nil {
 		c.isConnected = false
+		c.controlMutex.Unlock()
 		errOut := errBuf.String()
 		if isHostKeyError(errOut) {
 			return fmt.Errorf("%w: host key verification failed: %w (%s)", protocol.ErrNonRetryable, err, errOut)
@@ -206,6 +227,11 @@ func (c *Connection) Connect(ctx context.Context) error {
 		c.controlPath = cp
 	}
 	log.Trace(ctx, "started ssh multiplexing control master", log.KeyHost, c)
+	c.controlMutex.Unlock()
+
+	// Pre-warm Windows detection using the connect context. This avoids
+	// context.Background() probes on every first IsWindows() call.
+	c.detectWindows(ctx)
 
 	return nil
 }
@@ -267,7 +293,7 @@ func (c *Connection) StartProcess(ctx context.Context, cmdStr string, stdin io.R
 func (c *Connection) ExecInteractive(ctx context.Context, cmdStr string, stdin io.Reader, stdout, stderr io.Writer) error {
 	cmd, err := c.StartProcess(ctx, cmdStr, stdin, stdout, stderr)
 	if err != nil {
-		return err //nolint:wrapcheck // StartProcess already wraps
+		return err
 	}
 	if err := cmd.Wait(); err != nil {
 		if ctx.Err() != nil {

--- a/protocol/openssh/connection.go
+++ b/protocol/openssh/connection.go
@@ -189,9 +189,7 @@ func (c *Connection) Connect(ctx context.Context) error {
 		c.controlMutex.Lock()
 		c.isConnected = true
 		c.controlMutex.Unlock()
-		// Pre-warm Windows detection using the connect context. This avoids
-		// context.Background() probes on every first IsWindows() call.
-		c.detectWindows(ctx)
+		c.prewarmWindows(ctx)
 		return nil
 	}
 
@@ -229,11 +227,22 @@ func (c *Connection) Connect(ctx context.Context) error {
 	log.Trace(ctx, "started ssh multiplexing control master", log.KeyHost, c)
 	c.controlMutex.Unlock()
 
-	// Pre-warm Windows detection using the connect context. This avoids
-	// context.Background() probes on every first IsWindows() call.
-	c.detectWindows(ctx)
+	c.prewarmWindows(ctx)
 
 	return nil
+}
+
+// prewarmWindows calls detectWindows with a short bounded context derived from
+// ctx so that Connect does not block indefinitely on the OS probe. A cancelled
+// or expired ctx causes the probe to be skipped entirely, leaving the cache
+// empty (IsWindows will probe on first call instead).
+func (c *Connection) prewarmWindows(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	c.detectWindows(probeCtx)
 }
 
 func (c *Connection) closeControl() error {

--- a/protocol/openssh/connection.go
+++ b/protocol/openssh/connection.go
@@ -263,12 +263,16 @@ func (c *Connection) StartProcess(ctx context.Context, cmdStr string, stdin io.R
 }
 
 // ExecInteractive executes a command on the host and passes stdin/stdout/stderr as-is to the session.
-func (c *Connection) ExecInteractive(cmdStr string, stdin io.Reader, stdout, stderr io.Writer) error {
-	cmd, err := c.StartProcess(context.Background(), cmdStr, stdin, stdout, stderr)
+// The session is terminated when ctx is cancelled.
+func (c *Connection) ExecInteractive(ctx context.Context, cmdStr string, stdin io.Reader, stdout, stderr io.Writer) error {
+	cmd, err := c.StartProcess(ctx, cmdStr, stdin, stdout, stderr)
 	if err != nil {
-		return err
+		return err //nolint:wrapcheck // StartProcess already wraps
 	}
 	if err := cmd.Wait(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err() //nolint:wrapcheck // context error is the real cause
+		}
 		return fmt.Errorf("command wait: %w", err)
 	}
 	return nil

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -211,14 +211,13 @@ func (c *Connection) Disconnect() {
 	c.disconnect()
 }
 
-// IsWindows is true when the host is running windows.
-func (c *Connection) IsWindows() bool {
+// detectWindows probes the remote host to determine whether it is running
+// Windows and stores the result in the cache. The caller is responsible for
+// ensuring the connection is established before calling this method.
+// If called concurrently, the probe may run more than once, but the cached
+// result is always consistent.
+func (c *Connection) detectWindows(ctx context.Context) bool {
 	c.mu.Lock()
-	if c.isWindows != nil {
-		result := *c.isWindows
-		c.mu.Unlock()
-		return result
-	}
 	client := c.client
 	c.mu.Unlock()
 
@@ -227,7 +226,7 @@ func (c *Connection) IsWindows() bool {
 	}
 
 	serverVersion := strings.ToLower(string(client.ServerVersion()))
-	log.Trace(context.Background(), "checking if host is windows", "server_version", serverVersion)
+	log.Trace(ctx, "checking if host is windows", "server_version", serverVersion)
 
 	boolPtr := func(b bool) *bool { return &b }
 	var isWin bool
@@ -237,20 +236,42 @@ func (c *Connection) IsWindows() bool {
 	case isKnownPosix(serverVersion):
 		isWin = false
 	default:
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
 		isWinProc, err := c.StartProcess(ctx, "ver.exe", nil, nil, nil)
 		isWin = err == nil && isWinProc.Wait() == nil
+		// Don't cache a probe that failed due to context cancellation — the
+		// result would be a false negative that persists for the lifetime of
+		// the connection.
+		if ctx.Err() != nil {
+			return false
+		}
 	}
 
-	log.Trace(context.Background(), fmt.Sprintf("host is windows: %t", isWin))
+	log.Trace(ctx, fmt.Sprintf("host is windows: %t", isWin))
 
 	c.mu.Lock()
 	c.isWindows = boolPtr(isWin)
 	c.mu.Unlock()
 
 	return isWin
+}
+
+// IsWindows is true when the host is running windows.
+// The result is cached after the first probe; subsequent calls are O(1).
+// For reliable context propagation, Connect should be called first —
+// detection is also triggered during Connect using the connect context.
+func (c *Connection) IsWindows() bool {
+	c.mu.Lock()
+	if c.isWindows != nil {
+		result := *c.isWindows
+		c.mu.Unlock()
+		return result
+	}
+	c.mu.Unlock()
+
+	// Fallback: probe with a bounded background context.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return c.detectWindows(ctx)
 }
 
 func knownhostsCallback(path string, permissive, hash bool) (ssh.HostKeyCallback, error) {
@@ -497,6 +518,10 @@ func (c *Connection) Connect(ctx context.Context) error {
 	c.startKeepalive()
 	c.mu.Unlock()
 
+	// Pre-warm the Windows detection cache using the connect context so that
+	// callers who cancel after Connect never trigger a context.Background() probe.
+	c.detectWindows(ctx)
+
 	return nil
 }
 
@@ -616,6 +641,32 @@ func (c *Connection) StartProcess(ctx context.Context, cmd string, stdin io.Read
 	return session, nil
 }
 
+// setupInteractivePTY configures a PTY on the session for a file-backed stdin
+// and returns the raw-mode restore function. It sets the local terminal to raw
+// mode so that keystrokes are forwarded unmodified.
+func setupInteractivePTY(session *ssh.Session, inF *os.File) (func(), error) {
+	stdinFD := int(os.Stdin.Fd())
+	old, err := term.MakeRaw(stdinFD)
+	if err != nil {
+		return nil, fmt.Errorf("make local terminal raw: %w", err)
+	}
+
+	rows, cols, err := term.GetSize(stdinFD)
+	if err != nil {
+		_ = term.Restore(stdinFD, old)
+		return nil, fmt.Errorf("get terminal size: %w", err)
+	}
+
+	modes := ssh.TerminalModes{ssh.ECHO: 1}
+	if err := session.RequestPty("xterm", cols, rows, modes); err != nil {
+		_ = term.Restore(stdinFD, old)
+		return nil, fmt.Errorf("request pty: %w", err)
+	}
+
+	_ = inF // kept for signature clarity; caller passes it as input
+	return func() { _ = term.Restore(stdinFD, old) }, nil
+}
+
 // ExecInteractive executes a command on the host and passes stdin/stdout/stderr as-is to the session.
 // The session is closed when ctx is cancelled.
 func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.Reader, stdout, stderr io.Writer) error {
@@ -631,40 +682,29 @@ func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.R
 	}
 	defer session.Close()
 
-	// Close the session when the context is done.
+	// Close the session when the context is done, but also stop watching when
+	// the function returns normally so that the goroutine does not leak.
+	watchDone := make(chan struct{})
+	defer close(watchDone)
 	go func() {
-		<-ctx.Done()
-		_ = session.Close()
+		select {
+		case <-ctx.Done():
+			_ = session.Close()
+		case <-watchDone:
+		}
 	}()
 
 	session.Stdout = stdout
 	session.Stderr = stderr
-	var input io.Reader
 
+	input := stdin
 	if inF, ok := stdin.(*os.File); ok {
-		fd := int(os.Stdin.Fd())
-		old, err := term.MakeRaw(fd)
+		restore, err := setupInteractivePTY(session, inF)
 		if err != nil {
-			return fmt.Errorf("make local terminal raw: %w", err)
+			return err
 		}
-
-		defer func(fd int, old *term.State) {
-			_ = term.Restore(fd, old)
-		}(fd, old)
-
-		rows, cols, err := term.GetSize(fd)
-		if err != nil {
-			return fmt.Errorf("get terminal size: %w", err)
-		}
-
-		modes := ssh.TerminalModes{ssh.ECHO: 1}
-		err = session.RequestPty("xterm", cols, rows, modes)
-		if err != nil {
-			return fmt.Errorf("request pty: %w", err)
-		}
+		defer restore()
 		input = inF
-	} else {
-		input = stdin
 	}
 
 	stdinpipe, err := session.StdinPipe()
@@ -683,7 +723,6 @@ func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.R
 	} else {
 		err = session.Start(cmd)
 	}
-
 	if err != nil {
 		return fmt.Errorf("start ssh session: %w", err)
 	}

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -617,7 +617,8 @@ func (c *Connection) StartProcess(ctx context.Context, cmd string, stdin io.Read
 }
 
 // ExecInteractive executes a command on the host and passes stdin/stdout/stderr as-is to the session.
-func (c *Connection) ExecInteractive(cmd string, stdin io.Reader, stdout, stderr io.Writer) error {
+// The session is closed when ctx is cancelled.
+func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.Reader, stdout, stderr io.Writer) error {
 	c.mu.Lock()
 	client := c.client
 	c.mu.Unlock()
@@ -629,6 +630,12 @@ func (c *Connection) ExecInteractive(cmd string, stdin io.Reader, stdout, stderr
 		return fmt.Errorf("ssh new session: %w", err)
 	}
 	defer session.Close()
+
+	// Close the session when the context is done.
+	go func() {
+		<-ctx.Done()
+		_ = session.Close()
+	}()
 
 	session.Stdout = stdout
 	session.Stderr = stderr
@@ -682,6 +689,9 @@ func (c *Connection) ExecInteractive(cmd string, stdin io.Reader, stdout, stderr
 	}
 
 	if err := session.Wait(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err() //nolint:wrapcheck // context error is the real cause
+		}
 		return fmt.Errorf("ssh session wait: %w", err)
 	}
 

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -459,7 +459,22 @@ func (c *Connection) connectViaBastion(ctx context.Context, dst string, config *
 	c.startKeepalive()
 	c.mu.Unlock()
 
+	c.prewarmWindows(ctx)
+
 	return nil
+}
+
+// prewarmWindows calls detectWindows with a short bounded context derived from
+// ctx so that Connect does not block indefinitely on the OS probe. A cancelled
+// or expired ctx causes the probe to be skipped entirely, leaving the cache
+// empty (IsWindows will probe on first call instead).
+func (c *Connection) prewarmWindows(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	c.detectWindows(probeCtx)
 }
 
 // startKeepalive starts the keepalive goroutine. Caller must hold c.mu.
@@ -518,9 +533,7 @@ func (c *Connection) Connect(ctx context.Context) error {
 	c.startKeepalive()
 	c.mu.Unlock()
 
-	// Pre-warm the Windows detection cache using the connect context so that
-	// callers who cancel after Connect never trigger a context.Background() probe.
-	c.detectWindows(ctx)
+	c.prewarmWindows(ctx)
 
 	return nil
 }
@@ -645,25 +658,24 @@ func (c *Connection) StartProcess(ctx context.Context, cmd string, stdin io.Read
 // and returns the raw-mode restore function. It sets the local terminal to raw
 // mode so that keystrokes are forwarded unmodified.
 func setupInteractivePTY(session *ssh.Session, inF *os.File) (func(), error) {
-	stdinFD := int(os.Stdin.Fd())
+	stdinFD := int(inF.Fd())
 	old, err := term.MakeRaw(stdinFD)
 	if err != nil {
 		return nil, fmt.Errorf("make local terminal raw: %w", err)
 	}
 
-	rows, cols, err := term.GetSize(stdinFD)
+	width, height, err := term.GetSize(stdinFD)
 	if err != nil {
 		_ = term.Restore(stdinFD, old)
 		return nil, fmt.Errorf("get terminal size: %w", err)
 	}
 
 	modes := ssh.TerminalModes{ssh.ECHO: 1}
-	if err := session.RequestPty("xterm", cols, rows, modes); err != nil {
+	if err := session.RequestPty("xterm", height, width, modes); err != nil {
 		_ = term.Restore(stdinFD, old)
 		return nil, fmt.Errorf("request pty: %w", err)
 	}
 
-	_ = inF // kept for signature clarity; caller passes it as input
 	return func() { _ = term.Restore(stdinFD, old) }, nil
 }
 

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -679,9 +679,44 @@ func setupInteractivePTY(session *ssh.Session, inF *os.File) (func(), error) {
 	return func() { _ = term.Restore(stdinFD, old) }, nil
 }
 
+// prepareSessionInput wires stdin to the session. If stdin is a terminal
+// *os.File a PTY is requested and a raw-mode restore function is returned;
+// otherwise the reader is used as-is and the restore is a no-op.
+func prepareSessionInput(session *ssh.Session, stdin io.Reader) (input io.Reader, restore func(), err error) {
+	restore = func() {}
+	inF, ok := stdin.(*os.File)
+	if !ok {
+		return stdin, restore, nil
+	}
+	if term.IsTerminal(int(inF.Fd())) {
+		restore, err = setupInteractivePTY(session, inF)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return inF, restore, nil
+}
+
+// defaultInteractiveStreams replaces nil streams with the process's standard
+// streams so that callers can safely pass nil for any stream they don't need
+// to redirect.
+func defaultInteractiveStreams(stdin io.Reader, stdout, stderr io.Writer) (io.Reader, io.Writer, io.Writer) {
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	return stdin, stdout, stderr
+}
+
 // ExecInteractive executes a command on the host and passes stdin/stdout/stderr as-is to the session.
-// The session is closed when ctx is cancelled.
+// The session is closed when ctx is cancelled. Nil streams default to os.Stdin/os.Stdout/os.Stderr.
 func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.Reader, stdout, stderr io.Writer) error {
+	stdin, stdout, stderr = defaultInteractiveStreams(stdin, stdout, stderr)
 	c.mu.Lock()
 	client := c.client
 	c.mu.Unlock()
@@ -709,15 +744,11 @@ func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.R
 	session.Stdout = stdout
 	session.Stderr = stderr
 
-	input := stdin
-	if inF, ok := stdin.(*os.File); ok {
-		restore, err := setupInteractivePTY(session, inF)
-		if err != nil {
-			return err
-		}
-		defer restore()
-		input = inF
+	input, restoreTerm, err := prepareSessionInput(session, stdin)
+	if err != nil {
+		return err
 	}
+	defer restoreTerm()
 
 	stdinpipe, err := session.StdinPipe()
 	if err != nil {

--- a/protocol/winrm/connection.go
+++ b/protocol/winrm/connection.go
@@ -373,7 +373,8 @@ func (c *Connection) StartProcess(ctx context.Context, cmd string, stdin io.Read
 }
 
 // ExecInteractive executes a command on the host and passes stdin/stdout/stderr as-is to the session.
-func (c *Connection) ExecInteractive(cmd string, stdin io.Reader, stdout, stderr io.Writer) error {
+// The session is terminated when ctx is cancelled.
+func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.Reader, stdout, stderr io.Writer) error {
 	c.mu.Lock()
 	client := c.client
 	c.mu.Unlock()
@@ -383,8 +384,11 @@ func (c *Connection) ExecInteractive(cmd string, stdin io.Reader, stdout, stderr
 	if cmd == "" {
 		cmd = "cmd.exe"
 	}
-	_, err := client.RunWithContextWithInput(context.Background(), cmd, stdout, stderr, stdin)
+	_, err := client.RunWithContextWithInput(ctx, cmd, stdout, stderr, stdin)
 	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err() //nolint:wrapcheck // context error is the real cause
+		}
 		return fmt.Errorf("execute command in interactive mode: %w", err)
 	}
 	return nil

--- a/service.go
+++ b/service.go
@@ -46,24 +46,30 @@ func (m *Service) String() string {
 	return fmt.Sprintf("%s@%s", m.Name(), m.runner.String())
 }
 
-// Start the service.
+// Start the service. If ctx has no deadline, a 2-minute default timeout is applied.
 func (m *Service) Start(ctx context.Context) error {
+	ctx, cancel := withServiceTimeout(ctx)
+	defer cancel()
 	if err := m.initsys.StartService(ctx, m.runner, m.name); err != nil {
 		return fmt.Errorf("failed to start service '%s': %w", m.name, err)
 	}
 	return m.waitState(ctx, serviceStateStarted)
 }
 
-// Stop the service.
+// Stop the service. If ctx has no deadline, a 2-minute default timeout is applied.
 func (m *Service) Stop(ctx context.Context) error {
+	ctx, cancel := withServiceTimeout(ctx)
+	defer cancel()
 	if err := m.initsys.StopService(ctx, m.runner, m.name); err != nil {
 		return fmt.Errorf("failed to stop service '%s': %w", m.name, err)
 	}
 	return m.waitState(ctx, serviceStateStopped)
 }
 
-// Restart the service.
+// Restart the service. If ctx has no deadline, a 2-minute default timeout is applied.
 func (m *Service) Restart(ctx context.Context) error {
+	ctx, cancel := withServiceTimeout(ctx)
+	defer cancel()
 	if restarter, ok := m.initsys.(initsystem.ServiceManagerRestarter); ok {
 		if err := restarter.RestartService(ctx, m.runner, m.name); err != nil {
 			return fmt.Errorf("failed to restart service '%s': %w", m.name, err)
@@ -82,7 +88,19 @@ func (m *Service) Restart(ctx context.Context) error {
 const (
 	serviceStatePollMinInterval = 100 * time.Millisecond
 	serviceStatePollMaxInterval = 1000 * time.Millisecond
+	// serviceDefaultTimeout is applied when a caller passes a context with no deadline.
+	// It covers systemd's default 90-second start/stop timeout plus overhead.
+	serviceDefaultTimeout = 2 * time.Minute
 )
+
+// withServiceTimeout wraps ctx with serviceDefaultTimeout when ctx has no deadline.
+// The returned cancel must always be called.
+func withServiceTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, serviceDefaultTimeout)
+}
 
 func (m *Service) waitState(ctx context.Context, state serviceState) error {
 	delay := serviceStatePollMinInterval
@@ -107,8 +125,10 @@ func (m *Service) waitState(ctx context.Context, state serviceState) error {
 	}
 }
 
-// Enable the service.
+// Enable the service. If ctx has no deadline, a 2-minute default timeout is applied.
 func (m *Service) Enable(ctx context.Context) error {
+	ctx, cancel := withServiceTimeout(ctx)
+	defer cancel()
 	if err := m.initsys.EnableService(ctx, m.runner, m.name); err != nil {
 		return fmt.Errorf("failed to enable service: %w", err)
 	}
@@ -120,8 +140,10 @@ func (m *Service) Enable(ctx context.Context) error {
 	return nil
 }
 
-// Disable the service.
+// Disable the service. If ctx has no deadline, a 2-minute default timeout is applied.
 func (m *Service) Disable(ctx context.Context) error {
+	ctx, cancel := withServiceTimeout(ctx)
+	defer cancel()
 	if err := m.initsys.DisableService(ctx, m.runner, m.name); err != nil {
 		return fmt.Errorf("failed to disable service '%s': %w", m.name, err)
 	}
@@ -218,7 +240,10 @@ func (m *Service) SetEnvironment(ctx context.Context, env map[string]string) err
 
 // DaemonReload triggers a daemon-reload on the init system, if supported. This is useful after
 // manually writing service unit files outside of rig. Enable and Disable call this automatically.
+// If ctx has no deadline, a 2-minute default timeout is applied.
 func (m *Service) DaemonReload(ctx context.Context) error {
+	ctx, cancel := withServiceTimeout(ctx)
+	defer cancel()
 	reloader, ok := m.initsys.(initsystem.ServiceManagerReloader)
 	if !ok {
 		return errDaemonReloadNotSupported

--- a/service.go
+++ b/service.go
@@ -66,16 +66,20 @@ func (m *Service) Stop(ctx context.Context) error {
 	return m.waitState(ctx, serviceStateStopped)
 }
 
-// Restart the service. If ctx has no deadline, a 2-minute default timeout is applied.
+// Restart the service. For init systems with a native restart operation, a
+// 2-minute default timeout is applied if ctx has no deadline. For the
+// stop+start fallback, each step applies its own independent default timeout
+// so the combined operation can take up to 4 minutes.
 func (m *Service) Restart(ctx context.Context) error {
-	ctx, cancel := withServiceTimeout(ctx)
-	defer cancel()
 	if restarter, ok := m.initsys.(initsystem.ServiceManagerRestarter); ok {
-		if err := restarter.RestartService(ctx, m.runner, m.name); err != nil {
+		rctx, cancel := withServiceTimeout(ctx)
+		defer cancel()
+		if err := restarter.RestartService(rctx, m.runner, m.name); err != nil {
 			return fmt.Errorf("failed to restart service '%s': %w", m.name, err)
 		}
-		return m.waitState(ctx, serviceStateStarted)
+		return m.waitState(rctx, serviceStateStarted)
 	}
+	// Fall back to stop+start; each applies its own default timeout independently.
 	if err := m.Stop(ctx); err != nil {
 		return fmt.Errorf("failed to stop service '%s' for restart: %w", m.name, err)
 	}

--- a/service.go
+++ b/service.go
@@ -156,7 +156,10 @@ func (m *Service) Disable(ctx context.Context) error {
 }
 
 // ScriptPath returns the path to the service script.
+// If ctx has no deadline, a 2-minute default timeout is applied.
 func (m *Service) ScriptPath(ctx context.Context) (string, error) {
+	ctx, cancel := withServiceTimeout(ctx)
+	defer cancel()
 	scriptPath, err := m.initsys.ServiceScriptPath(ctx, m.runner, m.name)
 	if err != nil {
 		return "", fmt.Errorf("failed to get service script path: %w", err)
@@ -165,7 +168,10 @@ func (m *Service) ScriptPath(ctx context.Context) (string, error) {
 }
 
 // IsRunning returns true if the service is running.
+// If ctx has no deadline, a 2-minute default timeout is applied.
 func (m *Service) IsRunning(ctx context.Context) bool {
+	ctx, cancel := withServiceTimeout(ctx)
+	defer cancel()
 	return m.initsys.ServiceIsRunning(ctx, m.runner, m.name)
 }
 
@@ -178,7 +184,10 @@ var (
 )
 
 // Logs returns latest log lines for the service.
+// If ctx has no deadline, a 2-minute default timeout is applied.
 func (m *Service) Logs(ctx context.Context, lines int) ([]string, error) {
+	ctx, cancel := withServiceTimeout(ctx)
+	defer cancel()
 	logreader, ok := m.initsys.(initsystem.ServiceManagerLogReader)
 	if !ok {
 		return nil, errLogReaderNotSupported
@@ -210,8 +219,10 @@ func (m *Service) StreamLogs(ctx context.Context, w io.Writer) error {
 
 // SetEnvironment writes environment variable overrides for the service and triggers a daemon-reload
 // if the init system requires it (e.g. systemd). The init system determines the file path and format;
-// any existing content is replaced.
+// any existing content is replaced. If ctx has no deadline, a 2-minute default timeout is applied.
 func (m *Service) SetEnvironment(ctx context.Context, env map[string]string) error {
+	ctx, cancel := withServiceTimeout(ctx)
+	defer cancel()
 	envManager, ok := m.initsys.(initsystem.ServiceEnvironmentManager)
 	if !ok {
 		return errEnvManagerNotSupported

--- a/service_test.go
+++ b/service_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"testing"
+	"time"
 
 	"github.com/k0sproject/rig/v2/cmd"
 	"github.com/k0sproject/rig/v2/initsystem"
@@ -369,6 +370,27 @@ func TestServiceStreamLogs(t *testing.T) {
 		svc := &Service{runner: rigtest.NewMockRunner(), name: "svc", initsys: &mockBasicManager{}}
 		err := svc.StreamLogs(ctx, io.Discard)
 		require.ErrorIs(t, err, errLogStreamerNotSupported)
+	})
+}
+
+func TestWithServiceTimeout(t *testing.T) {
+	t.Run("adds deadline when none present", func(t *testing.T) {
+		ctx, cancel := withServiceTimeout(context.Background())
+		defer cancel()
+		_, ok := ctx.Deadline()
+		require.True(t, ok, "expected a deadline to be set when context.Background() is passed")
+	})
+
+	t.Run("preserves existing deadline", func(t *testing.T) {
+		parent, parentCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer parentCancel()
+		wantDeadline, _ := parent.Deadline()
+
+		ctx, cancel := withServiceTimeout(parent)
+		defer cancel()
+		gotDeadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.Equal(t, wantDeadline, gotDeadline, "existing deadline must not be overridden")
 	})
 }
 


### PR DESCRIPTION
Adds fallbacks when passed in context does not have a timeout so that service functions don't block indefinetly.

Also adds context to `ExecInteractive` and makes the `IsWindows()` use a 10 second timeout.

`gomodguard` v1 is disabled in `.golangci.yml` because it nags about it being deprecated over v2 (which I assume is enabled via the `all`)

Part of rig v2 final stretch, breaking API is not a problem as rig v2 has not been published yet.
