### PR TITLE
Add golden output tests for powershell, sh, sudo, and cmd

### DIFF
--- a/cmd/golden_test.go
+++ b/cmd/golden_test.go
@@ -1,0 +1,111 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/k0sproject/rig/v2/cmd"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWindowsCommandWrappingGolden pins the exact command strings sent to the
+// connection when running on a Windows host. The cmd.exe /C prefix must be
+// added for plain commands and must NOT be added for *.exe commands.
+func TestWindowsCommandWrappingGolden(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain command gets cmd.exe /C prefix",
+			input: "k0s version",
+			want:  "cmd.exe /C k0s version",
+		},
+		{
+			name:  "powershell.exe command is not wrapped",
+			input: "powershell.exe -Command Get-Date",
+			want:  "powershell.exe -Command Get-Date",
+		},
+		{
+			name:  "cmd.exe command is not wrapped",
+			input: "cmd.exe /C echo hello",
+			want:  "cmd.exe /C echo hello",
+		},
+		{
+			name:  "path-qualified exe is not wrapped",
+			input: `C:\Windows\System32\ipconfig.exe /all`,
+			want:  `C:\Windows\System32\ipconfig.exe /all`,
+		},
+		{
+			name:  "k0s install with flags gets wrapped",
+			input: "k0s install controller --config C:\\k0s\\k0s.yaml",
+			want:  "cmd.exe /C k0s install controller --config C:\\k0s\\k0s.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := rigtest.NewMockConnection()
+			conn.Windows = true
+			// Accept any command (we capture what was received).
+			conn.AddCommand(rigtest.Match("."), func(_ *rigtest.A) error { return nil })
+			runner := cmd.NewExecutor(conn)
+			_ = runner.Exec(tt.input)
+			rigtest.ReceivedEqual(t, conn, tt.want)
+		})
+	}
+}
+
+// TestRedactPreservesWireCommand verifies that sensitive strings passed via Redact()
+// do not alter the command sent over the wire — only log representations are masked.
+func TestRedactPreservesWireCommand(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	conn.AddCommand(rigtest.Match("."), func(_ *rigtest.A) error { return nil })
+	runner := cmd.NewExecutor(conn)
+
+	secret := "s3cr3tP@ss"
+	err := runner.Exec("curl -u admin:"+secret+" https://registry.example.com/v2/", cmd.Redact(secret))
+	require.NoError(t, err)
+
+	// The raw command sent to the connection must still contain the secret —
+	// redaction is a logging-only concern and must not alter the wire command.
+	rigtest.ReceivedContains(t, conn, secret)
+}
+
+// TestDecoratorPipelineGolden pins the exact string produced when global and
+// per-call decorators are applied in order: per-call first, global second.
+// Both decorators are prefixes so the order is observable in the output.
+func TestDecoratorPipelineGolden(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	conn.AddCommand(rigtest.Match("."), func(_ *rigtest.A) error { return nil })
+
+	// Global decorator: prefix all commands with "env VAR=1".
+	globalDec := func(c string) string { return "env VAR=1 " + c }
+	runner := cmd.NewExecutor(conn, globalDec)
+
+	// Per-call decorator: prefix with "sudo".
+	// Applied before the global decorator, so the expected output is
+	// "env VAR=1 sudo myapp run" (not "sudo env VAR=1 myapp run").
+	callDec := func(c string) string { return "sudo " + c }
+	_ = runner.Exec("myapp run", cmd.Decorate(callDec))
+
+	// Expected: per-call applied first ("sudo myapp run"), then global prefix.
+	rigtest.ReceivedEqual(t, conn, "env VAR=1 sudo myapp run")
+}
+
+// TestExecOutputTrimGolden verifies that ExecOutput trims trailing whitespace
+// by default and preserves it when TrimOutput(false) is used.
+func TestExecOutputTrimGolden(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandOutput(rigtest.Equal("hostname"), "node-01.example.com\n")
+
+	out, err := mr.ExecOutput("hostname")
+	require.NoError(t, err)
+	assert.Equal(t, "node-01.example.com", out, "output should be trimmed by default")
+
+	out, err = mr.ExecOutput("hostname", cmd.TrimOutput(false))
+	require.NoError(t, err)
+	assert.Equal(t, "node-01.example.com\n", out, "output should be preserved with TrimOutput(false)")
+}

--- a/powershell/golden_test.go
+++ b/powershell/golden_test.go
@@ -1,0 +1,131 @@
+package powershell_test
+
+import (
+	"testing"
+
+	"github.com/k0sproject/rig/v2/powershell"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCmdGolden pins the exact command strings produced by Cmd for a set of
+// realistic PowerShell fixtures. Any formatting change — whitespace, flag
+// ordering, quoting — will cause a failure and requires a deliberate update.
+func TestCmdGolden(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "simple one-liner uses -Command",
+			input: "Get-Service k0s",
+			want:  `powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -Command "$ProgressPreference='SilentlyContinue'; Get-Service k0s"`,
+		},
+		{
+			name:  "pipe metachar forces -EncodedCommand",
+			input: "Get-Service k0s | Select Status",
+			want:  `powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -E JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsAIABHAGUAdAAtAFMAZQByAHYAaQBjAGUAIABrADAAcwAgAHwAIABTAGUAbABlAGMAdAAgAFMAdABhAHQAdQBzAA==`,
+		},
+		{
+			name:  "newline forces -EncodedCommand",
+			input: "$a = 1\n$b = 2\nWrite-Output $a,$b",
+			want:  `powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -E JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsAIAAkAGEAIAA9ACAAMQAKACQAYgAgAD0AIAAyAAoAVwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIAAkAGEALAAkAGIA`,
+		},
+		{
+			name:  "double quote forces -EncodedCommand",
+			input: `New-Item -Path "C:\k0s"`,
+			want:  `powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -E JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsAIABOAGUAdwAtAEkAdABlAG0AIAAtAFAAYQB0AGgAIAAiAEMAOgBcAGsAMABzACIA`,
+		},
+		{
+			name:  "begin block skips ProgressPreference prefix",
+			input: "begin { $x = 1 } process { Write-Output $x }",
+			want:  `powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -Command "begin { $x = 1 } process { Write-Output $x }"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := powershell.Cmd(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestSingleQuoteGolden pins exact SingleQuote output for realistic inputs.
+func TestSingleQuoteGolden(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "simple string",
+			input: "hello world",
+			want:  `'hello world'`,
+		},
+		{
+			name:  "embedded single quote",
+			input: "it's here",
+			want:  "'it`'s here'",
+		},
+		{
+			name:  "windows path with backslashes",
+			input: `C:\Users\Admin\Documents`,
+			want:  `'C:\Users\Admin\Documents'`,
+		},
+		{
+			name:  "string with embedded newline",
+			input: "line1\nline2",
+			want:  "'line1`\nline2'",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "''",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := powershell.SingleQuote(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestDoubleQuoteGolden pins exact DoubleQuote output for realistic inputs.
+func TestDoubleQuoteGolden(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "simple string",
+			input: "hello world",
+			want:  `"hello world"`,
+		},
+		{
+			name:  "embedded double quote is escaped with backtick",
+			input: `say "hi"`,
+			want:  "\"say `\"hi`\"\"",
+		},
+		{
+			name:  "already-quoted string is returned unchanged",
+			input: `"already quoted"`,
+			want:  `"already quoted"`,
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  `""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := powershell.DoubleQuote(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/sh/golden_test.go
+++ b/sh/golden_test.go
@@ -1,0 +1,172 @@
+package sh_test
+
+import (
+	"testing"
+
+	"github.com/k0sproject/rig/v2/sh"
+	"github.com/k0sproject/rig/v2/sh/shellescape"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCommandGolden pins the exact output of sh.Command for realistic fixtures.
+// Any change to quoting logic will be caught here.
+func TestCommandGolden(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		args []string
+		want string
+	}{
+		{
+			name: "no args returns bare command",
+			cmd:  "true",
+			want: "true",
+		},
+		{
+			name: "word with special chars is quoted",
+			cmd:  "echo",
+			args: []string{"hello world"},
+			want: "echo 'hello world'",
+		},
+		{
+			name: "path with spaces is quoted",
+			cmd:  "cat",
+			args: []string{"/path/to my/file.txt"},
+			want: "cat '/path/to my/file.txt'",
+		},
+		{
+			name: "plain flags are not quoted",
+			cmd:  "k0s",
+			args: []string{"install", "--config", "/etc/k0s/k0s.yaml"},
+			want: "k0s install --config /etc/k0s/k0s.yaml",
+		},
+		{
+			name: "value with percent sign is quoted",
+			cmd:  "systemctl",
+			args: []string{"set-property", "k0s", "CPUQuota=50%"},
+			want: "systemctl set-property k0s 'CPUQuota=50%'",
+		},
+		{
+			name: "path containing single quote is escaped",
+			cmd:  "ls",
+			args: []string{"/home/bob's dir"},
+			want: "ls '/home/bob'\"'\"'s dir'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sh.Command(tt.cmd, tt.args...)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestCommandBuilderGolden pins the exact string produced by CommandBuilder
+// chains for realistic use-cases found in k0sctl and rig internals.
+func TestCommandBuilderGolden(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "pipe grep filters output",
+			got:  sh.CommandBuilder("cat /etc/os-release").Pipe("grep", "^ID=").String(),
+			// Note: ^ is not in shellescape's special-char set so ^ID= is not quoted.
+			want: "cat /etc/os-release | grep ^ID=",
+		},
+		{
+			name: "stderr to null suppresses errors",
+			got:  sh.CommandBuilder("which k0s").ErrToNull().String(),
+			want: "which k0s 2>/dev/null",
+		},
+		{
+			name: "stdout and stderr merged",
+			got:  sh.CommandBuilder("journalctl -u k0s").ErrToOut().String(),
+			want: "journalctl -u k0s 2>&1",
+		},
+		{
+			name: "output redirected to file",
+			got:  sh.CommandBuilder("k0s kubectl get nodes -o json").OutToFile("/tmp/nodes.json").String(),
+			want: "k0s kubectl get nodes -o json >/tmp/nodes.json",
+		},
+		{
+			name: "output redirected to path with spaces",
+			got:  sh.CommandBuilder("echo ok").OutToFile("/tmp/my output.txt").String(),
+			want: "echo ok >'/tmp/my output.txt'",
+		},
+		{
+			name: "arg appended to builder",
+			got:  sh.CommandBuilder("ls").Arg("-la").Arg("/var/lib/k0s").String(),
+			want: "ls -la /var/lib/k0s",
+		},
+		{
+			name: "pipe chains build left-to-right",
+			got: sh.CommandBuilder("cat /proc/mounts").
+				Pipe("grep", "overlay").
+				Pipe("awk", "{print $2}").
+				String(),
+			want: "cat /proc/mounts | grep overlay | awk '{print $2}'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.got)
+		})
+	}
+}
+
+// TestQuoteGolden pins the exact output of shellescape.Quote for edge cases
+// that affect correctness when commands are interpreted by a POSIX shell.
+func TestQuoteGolden(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string produces paired single quotes",
+			input: "",
+			want:  "''",
+		},
+		{
+			name:  "plain identifier is returned unquoted",
+			input: "foo.example.com",
+			want:  "foo.example.com",
+		},
+		{
+			name:  "dollar sign forces single quotes",
+			input: "$HOME",
+			want:  "'$HOME'",
+		},
+		{
+			name:  "pipe forces single quotes",
+			input: "a|b",
+			want:  "'a|b'",
+		},
+		{
+			name:  "both single quote and special chars use escaped form",
+			input: "it's $special",
+			want:  "'it'\"'\"'s $special'",
+		},
+		{
+			name:  "double quote wraps in single quotes",
+			input: `say "hello"`,
+			want:  `'say "hello"'`,
+		},
+		{
+			name:  "backslash forces single quotes",
+			input: `C:\Windows`,
+			want:  `'C:\Windows'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shellescape.Quote(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/sudo/sudo_test.go
+++ b/sudo/sudo_test.go
@@ -1,0 +1,57 @@
+package sudo_test
+
+import (
+	"testing"
+
+	"github.com/k0sproject/rig/v2/sudo"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSudoGolden pins the exact command strings produced by the Sudo decorator
+// for realistic fixtures. This ensures that changes to quoting or the sudo
+// invocation template are caught before release.
+func TestSudoGolden(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "simple command with flags",
+			input: "apt-get install -y docker.io",
+			want:  `sudo -n -- "${SHELL-sh}" -c 'apt-get install -y docker.io'`,
+		},
+		{
+			name:  "command with embedded single-quoted argument",
+			input: "bash -c 'systemctl restart k0s'",
+			want:  "sudo -n -- \"${SHELL-sh}\" -c 'bash -c '\"'\"'systemctl restart k0s'\"'\"''",
+		},
+		{
+			name:  "plain path without special characters",
+			input: "cat /etc/k0s/k0s.yaml",
+			want:  `sudo -n -- "${SHELL-sh}" -c 'cat /etc/k0s/k0s.yaml'`,
+		},
+		{
+			name:  "path with spaces requires quoting",
+			input: "cat \"/etc/k0s/my config/k0s.yaml\"",
+			want:  `sudo -n -- "${SHELL-sh}" -c 'cat "/etc/k0s/my config/k0s.yaml"'`,
+		},
+		{
+			name:  "k0s install command with full config path",
+			input: "k0s install controller --config /etc/k0s/k0s.yaml",
+			want:  `sudo -n -- "${SHELL-sh}" -c 'k0s install controller --config /etc/k0s/k0s.yaml'`,
+		},
+		{
+			name:  "command that already uses shell pipes",
+			input: "journalctl -u k0s | tail -20",
+			want:  `sudo -n -- "${SHELL-sh}" -c 'journalctl -u k0s | tail -20'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sudo.Sudo(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Pin exact output strings for command formatting APIs. Tests use realistic fixtures (k0s, systemctl, apt-get, journalctl) rather than synthetic strings.

- powershell: TestCmdGolden pins -Command vs -EncodedCommand selection and exact command strings for pipe, newline, double-quote, and begin-block inputs; TestSingleQuoteGolden and TestDoubleQuoteGolden cover PS quoting edge cases
- sh: TestCommandGolden pins sh.Command output for flags, paths, and args with special characters; TestCommandBuilderGolden pins chained Pipe/Arg/redirect operations; TestQuoteGolden captures shellescape edge cases 
- sudo: TestSudoGolden pins the sudo -n -- "${SHELL-sh}" -c template for simple commands, nested-quoted arguments, and pipe-containing commands
- cmd: TestWindowsCommandWrappingGolden pins cmd.exe /C wrapping vs exe pass-through; TestRedactInCommandLog verifies redaction does not sanitize commands; TestDecoratorPipelineGolden pins global-then-per-call decorator ordering; TestExecOutputTrimGolden pins default-trim behavior