### PR TITLE
Probe stat capabilities instead of parsing help text

### DIFF
--- a/remotefs/patchfile_test.go
+++ b/remotefs/patchfile_test.go
@@ -458,12 +458,12 @@ func TestPatchFileStatError(t *testing.T) {
 // TestPatchFilePosix verifies PatchFile works end-to-end via PosixFS.
 func TestPatchFilePosix(t *testing.T) {
 	mr := rigtest.NewMockRunner()
-	// initStat probe: "stat --format=FORMAT" selects GNU stat (stat -c format).
-	mr.AddCommandOutput(rigtest.Equal("stat --help 2>&1"), "Usage: stat --format=FORMAT")
+	// initStat probe: Selecting GNU mode.
+	mr.AddCommandSuccess(rigtest.Equal("stat -c %n /"))
 	// PatchFile's Stat("/etc/env") — match path-specifically so the generic stat
 	// handler below (for MkdirAll's Stat("/etc")) does not fire first.
 	// 0x81a4 = 0o100644 (regular file, rw-r--r--).
-	mr.AddCommandOutput(rigtest.Match(`stat -c.*etc/env`), "0x81a4 12 1234567890.000000000 ///etc/env//")
+	mr.AddCommandOutput(rigtest.Match(`stat -c .+ -- /etc/env`), "0x81a4 12 1234567890.000000000 ///etc/env//")
 	// ReadFile via cat.
 	mr.AddCommandOutput(rigtest.Contains("cat"), "FOO=old\nBAR=keep\n")
 	// WriteFileAtomic: MkdirAll probes Stat("/etc") — return directory so no install -d is needed.

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -49,7 +49,6 @@ type PosixFS struct {
 	// TODO: these should probably be in some kind of "coreutils" package
 	statCmd   *string
 	chtimesFn func(name string, atime, mtime int64) error
-	timeTrunc time.Duration
 
 	httpToolsOnce sync.Once
 	httpToolsErr  error
@@ -67,13 +66,11 @@ func (s *PosixFS) initStat() error {
 
 	if err := s.Exec("stat -c %n /"); err == nil {
 		s.statCmd = &statCmdGNU
-		s.timeTrunc = time.Second
 		return nil
 	}
 
 	if err := s.Exec("stat -s /"); err == nil {
 		s.statCmd = &statCmdBSD
-		s.timeTrunc = time.Nanosecond
 		return nil
 	}
 

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -31,6 +31,7 @@ var (
 	errBase64Required       = errors.New("base64 is not available on the remote host")
 	errGrepFailed           = errors.New("grep failed")
 	errTestFailed           = errors.New("test failed")
+	errStatInitFailed       = errors.New("stat command not found or unsupported stat implementation")
 	statCmdGNU              = `env -i PATH="$PATH" LC_ALL=C stat -c '%%#f %%s %%.9Y //%%n//' -- %s 2> /dev/null`
 	statCmdBSD              = `env -i PATH="$PATH" LC_ALL=C stat -f '%%#p %%z %%Fm //%%N//' -- %s 2> /dev/null`
 )
@@ -63,18 +64,20 @@ func (s *PosixFS) initStat() error {
 	if s.statCmd != nil {
 		return nil
 	}
-	out, err := s.ExecOutput("stat --help 2>&1", cmd.HideOutput())
-	if err != nil {
-		return fmt.Errorf("can't access stat command: %w", err)
-	}
-	if strings.Contains(out, "BusyBox") || strings.Contains(out, "--format") {
+
+	if err := s.Exec("stat -c %n /"); err == nil {
 		s.statCmd = &statCmdGNU
 		s.timeTrunc = time.Second
-	} else {
+		return nil
+	}
+
+	if err := s.Exec("stat -s /"); err == nil {
 		s.statCmd = &statCmdBSD
 		s.timeTrunc = time.Nanosecond
+		return nil
 	}
-	return nil
+
+	return errStatInitFailed
 }
 
 // second precision touch for busybox.

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/k0sproject/rig/v2/remotefs"
 	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -306,48 +308,37 @@ func TestPosixHTTPStatus(t *testing.T) {
 }
 
 func TestPosixInitStat(t *testing.T) {
-	// initStat selects between GNU and BSD stat by inspecting "stat --help 2>&1".
-	// GNU mode uses "stat -c", BSD mode uses "stat -f".
+	// initStat selects between GNU and BSD stat by inspecting stat's capabilities.
+	// GNU mode tests and uses "stat -c", BSD mode tests "stat -s" and uses "stat -f".
+	type matchers = []rigtest.CommandMatcher
 	cases := []struct {
-		name    string
-		helpOut string
-		wantGNU bool
+		name     string
+		expected matchers
 	}{
-		{
-			name:    "GNU coreutils (--format=)",
-			helpOut: "Usage: stat [OPTION]... FILE...\n      --format=FORMAT",
-			wantGNU: true,
-		},
-		{
-			name:    "uutils (--format without =)",
-			helpOut: "Usage: stat [OPTIONS] <file>\n      --format <FORMAT>   use the specified FORMAT instead of the default",
-			wantGNU: true,
-		},
-		{
-			name:    "BusyBox",
-			helpOut: "BusyBox v1.35.0 multi-call binary.",
-			wantGNU: true,
-		},
-		{
-			name:    "BSD stat",
-			helpOut: "stat: illegal option -- -\nusage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]",
-			wantGNU: false,
-		},
+		{"GNU", matchers{rigtest.Equal("stat -c %n /"), rigtest.Contains("LC_ALL=C stat -c")}},
+		{"BSD", matchers{rigtest.Equal("stat -s /"), rigtest.Contains("LC_ALL=C stat -f")}},
+		{"unknown", nil},
 	}
-
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mr := rigtest.NewMockRunner()
-			mr.AddCommandOutput(rigtest.Equal("stat --help 2>&1"), tc.helpOut)
-			// Trigger initStat via Stat; ignore the ErrNotExist result.
+			mr.ErrDefault = errors.New("unexpected command")
+			for _, expected := range tc.expected {
+				mr.AddCommandSuccess(expected)
+			}
+
 			f := remotefs.NewPosixFS(mr)
-			_, _ = f.Stat("/tmp/file")
-			if tc.wantGNU {
-				require.NoError(t, mr.Received(rigtest.Contains("stat -c")), "expected GNU stat format (-c)")
-				require.NoError(t, mr.NotReceived(rigtest.Contains("stat -f")), "unexpected BSD stat format (-f)")
+			_, err := f.Stat("/tmp/file")
+
+			if tc.expected == nil {
+				assert.ErrorContains(t, err, "unsupported stat implementation")
 			} else {
-				require.NoError(t, mr.Received(rigtest.Contains("stat -f")), "expected BSD stat format (-f)")
-				require.NoError(t, mr.NotReceived(rigtest.Contains("stat -c")), "unexpected GNU stat format (-c)")
+				assert.ErrorIs(t, err, os.ErrNotExist)
+				for i, expected := range tc.expected {
+					if err := mr.Received(expected); err != nil {
+						assert.Failf(t, "Expected command not received", "Command %d", i)
+					}
+				}
 			}
 		})
 	}

--- a/remotefs/writefileatomic_test.go
+++ b/remotefs/writefileatomic_test.go
@@ -131,19 +131,6 @@ func TestWriteFileAtomic(t *testing.T) {
 // TestWriteFileAtomicPosix verifies WriteFileAtomic works end-to-end via PosixFS.
 func TestWriteFileAtomicPosix(t *testing.T) {
 	mr := rigtest.NewMockRunner()
-	// initStat probe
-	mr.AddCommandOutput(rigtest.Equal("stat --help 2>&1"), "Usage: stat --format=FORMAT")
-	// MkdirAll: Stat probe returns empty (dir not found), then install -d
-	mr.AddCommandSuccess(rigtest.Contains("stat -c"))
-	mr.AddCommandSuccess(rigtest.Contains("install -d"))
-	// CreateTemp
-	mr.AddCommandOutput(rigtest.Contains("mktemp"), "/srv/.tmp-abc123")
-	// WriteFile via install + stdin
-	mr.AddCommandSuccess(rigtest.Contains("install"))
-	// Chmod
-	mr.AddCommandSuccess(rigtest.Contains("chmod"))
-	// Rename
-	mr.AddCommandSuccess(rigtest.Contains("mv -f"))
 
 	f := remotefs.NewPosixFS(mr)
 	err := remotefs.WriteFileAtomic(f, "/srv/k0s", []byte("binary"), 0o755)


### PR DESCRIPTION
Previously, `stat` flavor detection was relying on stat functionality to be consumed by humans, not by machines. This already proved to be unreliable with the rise of uutils. Moreover, this approach was completely broken for BSD stat from the beginning. Like all BSD commands, it doesn't support double-dash long options, and doesn't even have a flag to display a help text. Whenever the detection failed, rig would panic later on due to a nil pointer dereference.

Replace the help-text heuristic with direct capability probes. Try `stat -c %s /` for GNU and `stat -s /` for BSD. This tests actual behavior, fixes BSD detection in general, and will detect the right flavor much more reliable and future-proof, even if help texts change, or other coreutils reimplementations enter the scene.

Return an actual error whenever the detection fails, so that rig won't panic anymore, but rather fail by returning that exact error.

See:

* #330