### PR TITLE
[Backport release-0.x] Probe stat capabilities instead of parsing help text

### DIFF
--- a/pkg/rigfs/posixfsys.go
+++ b/pkg/rigfs/posixfsys.go
@@ -17,11 +17,12 @@ import (
 )
 
 var (
-	_          fs.File        = (*PosixFile)(nil)
-	_          File           = (*PosixFile)(nil)
-	_          fs.ReadDirFile = (*PosixDir)(nil)
-	_          fs.FS          = (*PosixFsys)(nil)
-	errInvalid                = errors.New("invalid")
+	_                 fs.File        = (*PosixFile)(nil)
+	_                 File           = (*PosixFile)(nil)
+	_                 fs.ReadDirFile = (*PosixDir)(nil)
+	_                 fs.FS          = (*PosixFsys)(nil)
+	errInvalid                       = errors.New("invalid")
+	errStatInitFailed                = errors.New("stat command not found or unsupported stat implementation")
 )
 
 // PosixFsys implements fs.FS for a remote filesystem that uses POSIX commands for access
@@ -280,18 +281,17 @@ var (
 
 func (fsys *PosixFsys) initStat() error {
 	if fsys.statCmd == nil {
-		opts := make([]exec.Option, len(fsys.opts), len(fsys.opts)+1)
-		copy(opts, fsys.opts)
-		opts = append(opts, exec.HideOutput())
-		out, err := fsys.conn.ExecOutput("stat --help 2>&1", opts...)
-		if err != nil {
-			return fmt.Errorf("can't access stat command: %w", err)
-		}
-		if strings.Contains(out, "BusyBox") || strings.Contains(out, "--format") {
+		if err := fsys.conn.Exec("stat -c %n /", fsys.opts...); err == nil {
 			fsys.statCmd = &statCmdGNU
-		} else {
-			fsys.statCmd = &statCmdBSD
+			return nil
 		}
+
+		if err := fsys.conn.Exec("stat -s /", fsys.opts...); err == nil {
+			fsys.statCmd = &statCmdBSD
+			return nil
+		}
+
+		return errStatInitFailed
 	}
 	return nil
 }

--- a/pkg/rigfs/posixfsys_test.go
+++ b/pkg/rigfs/posixfsys_test.go
@@ -9,6 +9,7 @@ import (
 
 	"al.essio.dev/pkg/shellescape"
 	"github.com/k0sproject/rig/exec"
+	"github.com/stretchr/testify/assert"
 )
 
 // mockConn is a simple test double for the connection interface.
@@ -16,6 +17,7 @@ type mockConn struct {
 	outputs map[string]string // command → stdout output
 	errors  map[string]error  // command → error (takes precedence over outputs)
 	windows bool
+	strict  bool
 }
 
 func newMockConn() *mockConn {
@@ -30,6 +32,11 @@ func (m *mockConn) IsWindows() bool { return m.windows }
 func (m *mockConn) Exec(cmd string, _ ...exec.Option) error {
 	if err, ok := m.errors[cmd]; ok {
 		return err
+	}
+	if m.strict {
+		if _, ok := m.outputs[cmd]; !ok {
+			return fmt.Errorf("unexpected command: %s", cmd)
+		}
 	}
 	return nil
 }
@@ -53,9 +60,9 @@ func findCmd(name string) string {
 	return fmt.Sprintf("find %s -maxdepth 1 -print0", shellescape.Quote(name))
 }
 
-// stubStatHelp pre-warms initStat on fsys by registering a GNU stat help response.
-func stubStatHelp(conn *mockConn) {
-	conn.outputs["stat --help 2>&1"] = "--format"
+// stubInitStat pre-warms initStat on fsys by registering a GNU response.
+func stubInitStat(conn *mockConn) {
+	conn.outputs["stat -c %n /"] = "/"
 }
 
 func TestReadDirEmptyDirectory(t *testing.T) {
@@ -66,7 +73,7 @@ func TestReadDirEmptyDirectory(t *testing.T) {
 	const dirName = "testdir"
 
 	conn := newMockConn()
-	stubStatHelp(conn)
+	stubInitStat(conn)
 	// find -print0 output for an empty directory: just the directory name
 	// followed by the mandatory trailing NUL byte.
 	conn.outputs[findCmd(dirName)] = dirName + "\x00"
@@ -88,7 +95,7 @@ func TestReadDirNonExistentDirectory(t *testing.T) {
 	const dirName = "no-such-dir"
 
 	conn := newMockConn()
-	stubStatHelp(conn)
+	stubInitStat(conn)
 	// Simulate find producing only a trailing NUL (empty output).
 	conn.outputs[findCmd(dirName)] = "\x00"
 
@@ -104,5 +111,50 @@ func TestReadDirNonExistentDirectory(t *testing.T) {
 	var pe *fs.PathError
 	if !errors.As(err, &pe) || pe.Path != dirName {
 		t.Fatalf("ReadDir returned %v, want *fs.PathError with Path=%q", err, dirName)
+	}
+}
+
+func TestPosixInitStat(t *testing.T) {
+	// initStat selects between GNU and BSD stat by inspecting stat's capabilities.
+	// GNU mode tests and uses "stat -c", BSD mode tests "stat -s" and uses "stat -f".
+	cases := []struct {
+		name  string
+		probe string
+		query string
+	}{
+		{
+			"GNU",
+			"stat -c %n /",
+			`env -i PATH="$PATH" LC_ALL=C stat -c '%#f %s %.9Y //%n//' -- /tmp/file 2> /dev/null`,
+		},
+		{
+			"BSD",
+			"stat -s /",
+			`env -i PATH="$PATH" LC_ALL=C stat -f '%#p %z %Fm //%N//' -- /tmp/file 2> /dev/null`,
+		},
+		{"unknown", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := newMockConn()
+			conn.strict = true
+			if tc.probe != "" {
+				conn.outputs[tc.probe] = ""
+			}
+			if tc.query != "" {
+				conn.outputs[tc.query] = `0x81a4 0 0.0 ///tmp/file//`
+			}
+
+			fsys := NewPosixFsys(conn)
+			stat, err := fsys.Stat("/tmp/file")
+
+			if tc.probe == "" {
+				assert.ErrorContains(t, err, "unsupported stat implementation")
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, "file", stat.Name())
+				assert.True(t, stat.Mode().IsRegular())
+			}
+		})
 	}
 }


### PR DESCRIPTION
Backport to `release-0.x`:

* #356

See:

* #329