### PR TITLE
feat: add Client.Capabilities() for remote capability discovery

### DIFF
--- a/capabilities.go
+++ b/capabilities.go
@@ -1,0 +1,200 @@
+package rig
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/k0sproject/rig/v2/cmd"
+	"github.com/k0sproject/rig/v2/os"
+	"github.com/k0sproject/rig/v2/protocol"
+)
+
+var (
+	errNilOS             = errors.New("os release provider returned nil")
+	errNilFS             = errors.New("remote filesystem provider returned nil")
+	errNilPackageManager = errors.New("package manager provider returned nil")
+	errNilInitSystem     = errors.New("init system provider returned nil")
+	errNilSudoRunner     = errors.New("sudo runner provider returned nil")
+)
+
+// Capabilities summarizes what was detected about the remote host.
+// All detection results are memoized: the first call to Capabilities (or to any
+// of the individual accessor methods such as OS, FS, PackageManager, etc.) that
+// triggers a probe runs a remote command; every subsequent call returns the cached
+// result without additional network round-trips.
+type Capabilities struct {
+	// Protocol is the connection protocol implementation name (e.g. "SSH", "OpenSSH", "WinRM", "Local").
+	// OpenSSH and native SSH connections return distinct values ("OpenSSH" vs "SSH").
+	// Free: derived from the connection without a remote round-trip.
+	Protocol string
+
+	// OS is the detected operating system release information.
+	// Populated on the first call that resolves OS info; nil if detection failed.
+	OS *os.Release
+	// OSErr is the OS detection error, if any.
+	OSErr error
+
+	// RemoteFS indicates whether the remote filesystem is available via [Client.FS].
+	RemoteFS bool
+	// RemoteFSErr is the remote filesystem initialization error, if any.
+	RemoteFSErr error
+
+	// PackageManager is the name of the detected package manager (e.g. "apt", "yum",
+	// "dnf"). Empty if no package manager was detected.
+	PackageManager string
+	// PackageManagerErr is the package manager detection error, if any.
+	PackageManagerErr error
+
+	// InitSystem is the name of the detected init system (e.g. "systemd", "openrc").
+	// Empty if no init system was detected.
+	InitSystem string
+	// InitSystemErr is the init system detection error, if any.
+	InitSystemErr error
+
+	// Sudo indicates whether privileged command execution is available via [Client.Sudo].
+	// This is true both when already running as root/administrator (no escalation needed)
+	// and when a supported escalation mechanism (sudo, doas) was detected. False only when
+	// [Client.Sudo] would return an error (e.g. no sudo binary found and not root).
+	Sudo bool
+	// SudoErr is the sudo detection error, if any.
+	SudoErr error
+
+	// InteractiveExec indicates whether the underlying connection supports interactive
+	// command execution via [Client.ExecInteractive].
+	// Free: determined by a local interface check with no remote round-trip.
+	InteractiveExec bool
+}
+
+// sudoAvailable returns (true, nil) when runner is non-nil and err is nil,
+// or (false, err/errNilSudoRunner) otherwise.
+func sudoAvailable(runner cmd.Runner, err error) (bool, error) {
+	switch {
+	case err != nil:
+		return false, err
+	case runner == nil:
+		return false, errNilSudoRunner
+	default:
+		return true, nil
+	}
+}
+
+// String returns a human-readable summary of the detected capabilities.
+func (c Capabilities) String() string {
+	return fmt.Sprintf(
+		"protocol=%s os=%q fs=%s package-manager=%s init-system=%s sudo=%s interactive-exec=%s",
+		c.Protocol, c.osString(), c.fsString(), c.pmString(), c.isString(), c.sudoString(), c.interactiveExecString(),
+	)
+}
+
+func (c Capabilities) osString() string {
+	if c.OS != nil {
+		return c.OS.String()
+	}
+	if c.OSErr != nil {
+		return fmt.Sprintf("error: %v", c.OSErr)
+	}
+	return "unknown"
+}
+
+func (c Capabilities) fsString() string {
+	if c.RemoteFS {
+		return "available"
+	}
+	if c.RemoteFSErr != nil {
+		return fmt.Sprintf("%q", "error: "+c.RemoteFSErr.Error())
+	}
+	return "unknown"
+}
+
+func (c Capabilities) pmString() string {
+	if c.PackageManager != "" {
+		return c.PackageManager
+	}
+	if c.PackageManagerErr != nil {
+		return fmt.Sprintf("%q", "error: "+c.PackageManagerErr.Error())
+	}
+	return "none"
+}
+
+func (c Capabilities) isString() string {
+	if c.InitSystem != "" {
+		return c.InitSystem
+	}
+	if c.InitSystemErr != nil {
+		return fmt.Sprintf("%q", "error: "+c.InitSystemErr.Error())
+	}
+	return "none"
+}
+
+func (c Capabilities) sudoString() string {
+	if c.Sudo {
+		return "yes"
+	}
+	if c.SudoErr != nil {
+		return fmt.Sprintf("%q", "error: "+c.SudoErr.Error())
+	}
+	return "no"
+}
+
+func (c Capabilities) interactiveExecString() string {
+	if c.InteractiveExec {
+		return "yes"
+	}
+	return "no"
+}
+
+// Capabilities probes all detectable aspects of the remote host and returns a
+// summary. Aspects that have already been probed (for example by a prior call to
+// [Client.OS], [Client.FS], [Client.PackageManager], or [Client.Sudo]) return their
+// cached result without issuing additional remote commands.
+//
+// Some capabilities may run remote commands on first access (OS, PackageManager,
+// InitSystem, and Sudo); others are resolved locally without network round-trips
+// (Protocol, RemoteFS, and InteractiveExec). All results are memoized so repeated
+// calls or interleaved direct accessor calls remain cheap.
+func (c *Client) Capabilities() Capabilities {
+	caps := Capabilities{
+		Protocol: c.ProtocolName(),
+	}
+
+	caps.OS, caps.OSErr = c.OSRelease()
+	if caps.OS == nil && caps.OSErr == nil {
+		caps.OSErr = errNilOS
+	}
+
+	if fs, err := c.RemoteFSProvider.FS(); err != nil {
+		caps.RemoteFSErr = err
+	} else if fs == nil {
+		caps.RemoteFSErr = errNilFS
+	} else {
+		caps.RemoteFS = true
+	}
+
+	if pm, err := c.PackageManagerProvider.PackageManager(); err != nil {
+		caps.PackageManagerErr = err
+	} else if pm == nil {
+		caps.PackageManagerErr = errNilPackageManager
+	} else if s, ok := pm.(fmt.Stringer); ok {
+		caps.PackageManager = s.String()
+	} else {
+		caps.PackageManager = fmt.Sprintf("%T", pm)
+	}
+
+	if is, err := c.ServiceManager(); err != nil {
+		caps.InitSystemErr = err
+	} else if is == nil {
+		caps.InitSystemErr = errNilInitSystem
+	} else if s, ok := is.(fmt.Stringer); ok {
+		caps.InitSystem = s.String()
+	} else {
+		caps.InitSystem = fmt.Sprintf("%T", is)
+	}
+
+	caps.Sudo, caps.SudoErr = sudoAvailable(c.SudoRunner())
+
+	if c.connection != nil {
+		_, caps.InteractiveExec = c.connection.(protocol.InteractiveExecer)
+	}
+
+	return caps
+}

--- a/capabilities_test.go
+++ b/capabilities_test.go
@@ -1,0 +1,191 @@
+package rig_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/k0sproject/rig/v2"
+	"github.com/k0sproject/rig/v2/cmd"
+	"github.com/k0sproject/rig/v2/initsystem"
+	"github.com/k0sproject/rig/v2/os"
+	"github.com/k0sproject/rig/v2/packagemanager"
+	"github.com/k0sproject/rig/v2/remotefs"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientCapabilities(t *testing.T) {
+	detectedOS := &os.Release{ID: "alpine", Name: "Alpine Linux", Version: "3.18"}
+	mockErr := errors.New("mock error")
+
+	t.Run("all capabilities detected", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		client, err := rig.NewClient(
+			rig.WithConnection(conn),
+			rig.WithOSReleaseProvider(func(_ cmd.SimpleRunner) (*os.Release, error) {
+				return detectedOS, nil
+			}),
+			rig.WithRemoteFSProvider(func(_ cmd.Runner) (remotefs.FS, error) {
+				return remotefs.NewPosixFS(rigtest.NewMockRunner()), nil
+			}),
+			rig.WithPackageManagerProvider(func(_ cmd.ContextRunner) (packagemanager.PackageManager, error) {
+				return packagemanager.NewApt(rigtest.NewMockRunner()), nil
+			}),
+			rig.WithInitSystemProvider(func(_ cmd.ContextRunner) (initsystem.ServiceManager, error) {
+				return initsystem.Systemd{}, nil
+			}),
+			rig.WithSudoProvider(func(_ cmd.Runner) (cmd.Runner, error) {
+				return rigtest.NewMockRunner(), nil
+			}),
+		)
+		require.NoError(t, err)
+		require.NoError(t, client.Connect(context.Background()))
+
+		caps := client.Capabilities()
+
+		require.Equal(t, "mock", caps.Protocol)
+		require.Equal(t, detectedOS, caps.OS)
+		require.NoError(t, caps.OSErr)
+		require.True(t, caps.RemoteFS)
+		require.NoError(t, caps.RemoteFSErr)
+		require.Equal(t, "apt", caps.PackageManager)
+		require.NoError(t, caps.PackageManagerErr)
+		require.Equal(t, "systemd", caps.InitSystem)
+		require.NoError(t, caps.InitSystemErr)
+		require.True(t, caps.Sudo)
+		require.NoError(t, caps.SudoErr)
+		require.False(t, caps.InteractiveExec)
+	})
+
+	t.Run("all capabilities unavailable", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		client, err := rig.NewClient(
+			rig.WithConnection(conn),
+			rig.WithOSReleaseProvider(func(_ cmd.SimpleRunner) (*os.Release, error) {
+				return nil, mockErr
+			}),
+			rig.WithRemoteFSProvider(func(_ cmd.Runner) (remotefs.FS, error) {
+				return nil, mockErr
+			}),
+			rig.WithPackageManagerProvider(func(_ cmd.ContextRunner) (packagemanager.PackageManager, error) {
+				return nil, mockErr
+			}),
+			rig.WithInitSystemProvider(func(_ cmd.ContextRunner) (initsystem.ServiceManager, error) {
+				return nil, mockErr
+			}),
+			rig.WithSudoProvider(func(_ cmd.Runner) (cmd.Runner, error) {
+				return nil, mockErr
+			}),
+		)
+		require.NoError(t, err)
+		require.NoError(t, client.Connect(context.Background()))
+
+		caps := client.Capabilities()
+
+		require.Nil(t, caps.OS)
+		require.ErrorIs(t, caps.OSErr, mockErr)
+		require.False(t, caps.RemoteFS)
+		require.ErrorIs(t, caps.RemoteFSErr, mockErr)
+		require.Empty(t, caps.PackageManager)
+		require.ErrorIs(t, caps.PackageManagerErr, mockErr)
+		require.Empty(t, caps.InitSystem)
+		require.ErrorIs(t, caps.InitSystemErr, mockErr)
+		require.False(t, caps.Sudo)
+		require.ErrorIs(t, caps.SudoErr, mockErr)
+		require.False(t, caps.InteractiveExec)
+	})
+
+	t.Run("interactive exec detected", func(t *testing.T) {
+		conn := &interactiveConn{MockConnection: rigtest.NewMockConnection()}
+		client, err := rig.NewClient(rig.WithConnection(conn))
+		require.NoError(t, err)
+		require.NoError(t, client.Connect(context.Background()))
+
+		caps := client.Capabilities()
+
+		require.True(t, caps.InteractiveExec)
+	})
+
+	t.Run("String output contains expected fields", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		client, err := rig.NewClient(
+			rig.WithConnection(conn),
+			rig.WithOSReleaseProvider(func(_ cmd.SimpleRunner) (*os.Release, error) {
+				return detectedOS, nil
+			}),
+			rig.WithPackageManagerProvider(func(_ cmd.ContextRunner) (packagemanager.PackageManager, error) {
+				return packagemanager.NewApt(rigtest.NewMockRunner()), nil
+			}),
+			rig.WithInitSystemProvider(func(_ cmd.ContextRunner) (initsystem.ServiceManager, error) {
+				return initsystem.OpenRC{}, nil
+			}),
+		)
+		require.NoError(t, err)
+		require.NoError(t, client.Connect(context.Background()))
+
+		s := client.Capabilities().String()
+
+		require.Contains(t, s, "protocol=mock")
+		require.Contains(t, s, "package-manager=apt")
+		require.Contains(t, s, "init-system=openrc")
+	})
+
+	t.Run("caching: provider called once on double Capabilities call", func(t *testing.T) {
+		calls := 0
+		conn := rigtest.NewMockConnection()
+		client, err := rig.NewClient(
+			rig.WithConnection(conn),
+			rig.WithOSReleaseProvider(func(_ cmd.SimpleRunner) (*os.Release, error) {
+				calls++
+				return detectedOS, nil
+			}),
+		)
+		require.NoError(t, err)
+		require.NoError(t, client.Connect(context.Background()))
+
+		client.Capabilities()
+		client.Capabilities()
+
+		require.Equal(t, 1, calls, "OS provider should only be called once across multiple Capabilities calls")
+	})
+}
+
+func TestInitSystemString(t *testing.T) {
+	cases := []struct {
+		want string
+		is   fmt.Stringer
+	}{
+		{"systemd", initsystem.Systemd{}},
+		{"openrc", initsystem.OpenRC{}},
+		{"launchd", initsystem.Launchd{}},
+		{"winscm", initsystem.WinSCM{}},
+		{"upstart", initsystem.Upstart{}},
+		{"sysvinit", initsystem.SysVinit{}},
+		{"runit", initsystem.Runit{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.is.String())
+		})
+	}
+}
+
+func TestPackageManagerString(t *testing.T) {
+	runner := rigtest.NewMockRunner()
+	cases := []struct {
+		want string
+		pm   packagemanager.PackageManager
+	}{
+		{"apt", packagemanager.NewApt(runner)},
+		{"yum", packagemanager.NewYum(runner)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			s, ok := tc.pm.(fmt.Stringer)
+			require.True(t, ok, "package manager %T should implement fmt.Stringer", tc.pm)
+			require.Equal(t, tc.want, s.String())
+		})
+	}
+}

--- a/docs/capability-discovery.md
+++ b/docs/capability-discovery.md
@@ -1,0 +1,123 @@
+# Capability Discovery
+
+`Client.Capabilities()` returns a snapshot of everything rig can detect about a connected
+remote host: OS, filesystem, package manager, init system, sudo access, and protocol features.
+
+## Quick start
+
+```go
+if err := client.Connect(ctx); err != nil {
+    log.Fatal(err)
+}
+
+caps := client.Capabilities()
+fmt.Println(caps)
+// protocol=SSH os="Alpine Linux" fs=available package-manager=apk init-system=openrc sudo=yes interactive-exec=yes
+```
+
+## The Capabilities struct
+
+| Field | Type | Description |
+|---|---|---|
+| `Protocol` | `string` | Connection protocol name (`"SSH"`, `"OpenSSH"`, `"WinRM"`, `"Local"`) |
+| `OS` | `*os.Release` | Detected OS release info, or nil on failure |
+| `OSErr` | `error` | OS detection error |
+| `RemoteFS` | `bool` | True if the remote filesystem is available via `client.FS()` |
+| `RemoteFSErr` | `error` | Remote filesystem init error; nil means `client.FS()` is usable |
+| `PackageManager` | `string` | Detected package manager name (e.g. `"apt"`, `"yum"`, `"dnf"`, `"apk"`) |
+| `PackageManagerErr` | `error` | Package manager detection error |
+| `InitSystem` | `string` | Detected init system name (e.g. `"systemd"`, `"openrc"`, `"launchd"`) |
+| `InitSystemErr` | `error` | Init system detection error |
+| `Sudo` | `bool` | True if `client.Sudo()` will work — either already root/admin or sudo/doas detected |
+| `SudoErr` | `error` | Sudo detection error |
+| `InteractiveExec` | `bool` | True if the connection supports `ExecInteractive` |
+
+`Capabilities.String()` returns a one-line human-readable summary for logging.
+
+## Caching and remote commands
+
+Detection is lazy and memoized. The table below shows when each probe first runs a
+remote command, and what triggers it.
+
+| Capability | Runs remote commands | When first probed |
+|---|---|---|
+| `OS` | Yes — reads `/etc/os-release` (Linux), `sw_vers` (macOS), or CIM query via PowerShell (Windows) | First call to `client.OS()` or `client.Capabilities()` |
+| `RemoteFS` | No — selects a filesystem implementation locally (POSIX or Windows); remote commands occur only on the first filesystem operation | First call to `client.FS()` or `client.Capabilities()` |
+| `PackageManager` | Yes — probes for package manager binaries | First call to `client.PackageManager()` or `client.Capabilities()` |
+| `InitSystem` | Yes — probes for init system binaries/processes | First call to `client.ServiceManager()` or `client.Capabilities()` |
+| `Sudo` | Yes — tests the preferred escalation method (`sudo`, `doas`, etc.) | First call to `client.Sudo()` or `client.Capabilities()` |
+| `InteractiveExec` | No — local interface check on the connection object | Every call (free) |
+| `Protocol` | No — returns cached value from the connection object | Every call (free) |
+
+Once a probe has run, subsequent `Capabilities()` calls return the memoized result
+for that field with no additional remote commands. Interleaved direct accessor calls
+(e.g. `client.OS()` followed by `client.Capabilities()`) share the same cache — OS
+is only resolved once regardless of call order.
+
+## Partial availability
+
+Every capability has an independent error field. A failure to detect one capability
+(e.g. the remote host has no known package manager) does not affect the others.
+You can check individual errors:
+
+```go
+caps := client.Capabilities()
+
+if caps.OSErr != nil {
+    log.Printf("OS detection failed: %v", caps.OSErr)
+}
+
+if caps.PackageManagerErr != nil {
+    log.Printf("no supported package manager: %v", caps.PackageManagerErr)
+}
+
+if !caps.Sudo {
+    log.Printf("sudo unavailable — some operations may require elevated access")
+}
+```
+
+## Protocol optional features
+
+`InteractiveExec` reflects whether the underlying protocol connection implements
+`protocol.InteractiveExecer`. This controls whether `client.ExecInteractive` can be
+used for interactive sessions (e.g. shells, editors).
+
+Built-in protocol support:
+
+| Protocol | `InteractiveExec` |
+|---|---|
+| SSH (native) | Yes |
+| OpenSSH | Yes |
+| WinRM | Yes |
+| Local | Yes |
+
+Custom protocol implementations can opt in by implementing `protocol.InteractiveExecer`.
+
+## Detected init system names
+
+| Name | Init system |
+|---|---|
+| `"systemd"` | systemd (most Linux distributions) |
+| `"openrc"` | OpenRC (Alpine Linux, Gentoo) |
+| `"launchd"` | launchd (macOS) |
+| `"upstart"` | Upstart (Ubuntu 14.04 and older) |
+| `"sysvinit"` | SysVinit (legacy Linux) |
+| `"runit"` | runit |
+| `"winscm"` | Windows SCM |
+
+## Detected package manager names
+
+| Name | Package manager |
+|---|---|
+| `"apt"` | APT (Debian, Ubuntu) |
+| `"dnf"` | DNF (Fedora, RHEL 8+) |
+| `"yum"` | YUM (RHEL 7 and older, CentOS) |
+| `"apk"` | APK (Alpine Linux) |
+| `"pacman"` | Pacman (Arch Linux) |
+| `"zypper"` | Zypper (openSUSE) |
+| `"homebrew"` | Homebrew (macOS) |
+| `"macports"` | MacPorts (macOS) |
+| `"chocolatey"` | Chocolatey (Windows) |
+| `"winget"` | WinGet (Windows) |
+| `"scoop"` | Scoop (Windows) |
+| `"windows-multi"` | Windows multi-manager (tries all detected Windows managers) |

--- a/initsystem/launchd.go
+++ b/initsystem/launchd.go
@@ -15,6 +15,9 @@ import (
 // Launchd is the init system for macOS (and darwin), the implementation is very basic and doesn't handle services in user space.
 type Launchd struct{}
 
+// String returns the name of the init system.
+func (Launchd) String() string { return "launchd" }
+
 const launchctl = sh.CommandBuilder("launchctl")
 
 var launchctlCmd = launchctl.Args

--- a/initsystem/openrc.go
+++ b/initsystem/openrc.go
@@ -15,6 +15,9 @@ import (
 // OpenRC is found on some linux systems, often installed on Alpine for example.
 type OpenRC struct{}
 
+// String returns the name of the init system.
+func (OpenRC) String() string { return "openrc" }
+
 const rcservice = sh.CommandBuilder("rc-service")
 
 var rcserviceCmd = rcservice.Args

--- a/initsystem/runit.go
+++ b/initsystem/runit.go
@@ -16,6 +16,9 @@ import (
 // Runit is an init system implementation for runit.
 type Runit struct{}
 
+// String returns the name of the init system.
+func (Runit) String() string { return "runit" }
+
 const sv = sh.CommandBuilder("sv")
 
 var svCmd = sv.Args

--- a/initsystem/systemd.go
+++ b/initsystem/systemd.go
@@ -16,6 +16,9 @@ import (
 // Systemd is found by default on most linux distributions today.
 type Systemd struct{}
 
+// String returns the name of the init system.
+func (Systemd) String() string { return "systemd" }
+
 const systemctl = sh.CommandBuilder("systemctl")
 
 var systemctlCmd = systemctl.Args

--- a/initsystem/sysvinit.go
+++ b/initsystem/sysvinit.go
@@ -13,6 +13,9 @@ const initd = "/etc/init.d/"
 // SysVinit is the service manager for SysVinit.
 type SysVinit struct{}
 
+// String returns the name of the init system.
+func (SysVinit) String() string { return "sysvinit" }
+
 // StartService starts a service.
 func (i SysVinit) StartService(ctx context.Context, h cmd.ContextRunner, s string) error {
 	if err := h.ExecContext(ctx, sh.Command(initd+s, "start")); err != nil {

--- a/initsystem/upstart.go
+++ b/initsystem/upstart.go
@@ -14,6 +14,9 @@ import (
 // Upstart is the init system used by Ubuntu 14.04 and older.
 type Upstart struct{}
 
+// String returns the name of the init system.
+func (Upstart) String() string { return "upstart" }
+
 const initctl = sh.CommandBuilder("initctl")
 
 var initctlCmd = initctl.Args

--- a/initsystem/winscm.go
+++ b/initsystem/winscm.go
@@ -15,6 +15,9 @@ var errNotSupported = errors.New("not supported on windows")
 // WinSCM is a struct that implements the InitSystem interface for Windows Service Control Manager.
 type WinSCM struct{}
 
+// String returns the name of the init system.
+func (WinSCM) String() string { return "winscm" }
+
 // StartService starts a service.
 func (c WinSCM) StartService(ctx context.Context, h cmd.ContextRunner, s string) error {
 	if err := h.ExecContext(ctx, "$ErrorActionPreference='Stop'\nStart-Service "+ps.SingleQuote(s)+" -ErrorAction Stop", cmd.PS()); err != nil {

--- a/packagemanager/universal.go
+++ b/packagemanager/universal.go
@@ -22,6 +22,9 @@ type universalPackageManager struct {
 	update  string
 }
 
+// String returns the package manager name.
+func (u universalPackageManager) String() string { return u.name }
+
 func (u universalPackageManager) buildAndExec(ctx context.Context, kw string, packageNames ...string) error {
 	if err := u.ExecContext(ctx, buildCommand(u.command, kw, packageNames...)); err != nil {
 		return fmt.Errorf("failed to %s %s packages: %w", kw, u.name, err)

--- a/packagemanager/windowsmulti.go
+++ b/packagemanager/windowsmulti.go
@@ -18,6 +18,9 @@ type WindowsMultiManager struct {
 // ErrNoWindowsPackageManager is returned when no windows package manager is found.
 var ErrNoWindowsPackageManager = errors.New("no windows package manager found")
 
+// String returns the package manager name.
+func (w *WindowsMultiManager) String() string { return "windows-multi" }
+
 // Install the given packages.
 func (w *WindowsMultiManager) Install(ctx context.Context, packageNames ...string) error {
 	if len(w.managers) == 0 {


### PR DESCRIPTION
Adds a Capabilities struct and Client.Capabilities() method that probes all detectable aspects of a connected host in one call: OS, remote FS, package manager, init system, sudo availability, and protocol features.

All detection is lazy and memoized via the existing provider chain — the first call per capability runs a remote command; subsequent calls return the cached result with no additional round-trips. Interleaved direct accessor calls (e.g. OS() before Capabilities()) share the same cache.

Also adds String() methods to all concrete initsystem and packagemanager types so that Capabilities.InitSystem and Capabilities.PackageManager carry human-readable names (e.g. "systemd", "apt") rather than blank strings.

Docs added at docs/capability-discovery.md.