### PR TITLE
fix: atomic temp-file cleanup in Upload and initTouch

### DIFF
--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -131,12 +131,12 @@ func (s *PosixFS) initTouch() error {
 	if err != nil {
 		return fmt.Errorf("can't create temp file for touch test: %w", err)
 	}
-	if err := tmpF.Close(); err != nil {
-		return fmt.Errorf("can't close temp file for touch test: %w", err)
-	}
 	defer func() {
 		_ = s.Remove(tmpF.Name())
 	}()
+	if err := tmpF.Close(); err != nil {
+		return fmt.Errorf("can't close temp file for touch test: %w", err)
+	}
 	if err := s.nsecChtimes(tmpF.Name(), 0, 0); err != nil {
 		s.chtimesFn = s.secChtimes
 	} else {

--- a/remotefs/upload.go
+++ b/remotefs/upload.go
@@ -22,8 +22,7 @@ type uploadOptions struct {
 }
 
 // WithPermissions sets the file mode for the uploaded file. If not set, the local
-// file's mode is used. The mode is applied both at creation time and via Chmod after
-// a successful upload, so it takes effect even when the destination file already exists.
+// file's mode is used.
 func WithPermissions(mode fs.FileMode) UploadOption {
 	return func(o *uploadOptions) {
 		o.perm = mode
@@ -31,7 +30,43 @@ func WithPermissions(mode fs.FileMode) UploadOption {
 	}
 }
 
-// Upload a file to the remote host.
+// copyAndVerifyUpload copies src to tmpPath via a hash writer and verifies remote checksum.
+func copyAndVerifyUpload(fsys FS, tmpPath string, src io.Reader) error {
+	localHash := sha256.New()
+	reader := io.TeeReader(src, localHash)
+
+	remote, err := fsys.OpenFile(tmpPath, os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("open temp file for upload: %w", err)
+	}
+	if _, err := remote.CopyFrom(reader); err != nil {
+		_ = remote.Close()
+		return fmt.Errorf("copy file to remote host: %w", err)
+	}
+	if err := remote.Close(); err != nil {
+		return fmt.Errorf("close temp file after upload: %w", err)
+	}
+
+	remoteSum, err := fsys.Sha256(tmpPath)
+	if err != nil {
+		return fmt.Errorf("get checksum of uploaded file: %w", err)
+	}
+	expectedSum := hex.EncodeToString(localHash.Sum(nil))
+	if remoteSum != expectedSum {
+		return ErrChecksumMismatch
+	}
+	return nil
+}
+
+// Upload a file to the remote host atomically: the content is written to a
+// temporary file in the same directory as dst, verified via SHA-256, and then
+// renamed into place. The temporary file is removed on any failure.
+//
+// Permissions: the temporary file is created with mode 0o600 and then chmod'd
+// to perm before the rename. When WithPermissions is not given, perm is taken
+// from the local file's mode. This means that overwriting an existing remote
+// file always sets its mode to perm — unlike a direct truncating write, which
+// would leave the remote file's existing mode unchanged.
 func Upload(fsys FS, src, dst string, opts ...UploadOption) error {
 	options := &uploadOptions{}
 	for _, opt := range opts {
@@ -53,36 +88,22 @@ func Upload(fsys FS, src, dst string, opts ...UploadOption) error {
 		perm = stat.Mode()
 	}
 
-	shasum := sha256.New()
-
-	remote, err := fsys.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	dir := fsys.Dir(dst)
+	tmpPath, err := fsys.CreateTemp(dir, ".upload-")
 	if err != nil {
-		return fmt.Errorf("open remote file for upload: %w", err)
+		return fmt.Errorf("create temp file for upload: %w", err)
+	}
+	defer func() { _ = fsys.Remove(tmpPath) }()
+
+	if err := copyAndVerifyUpload(fsys, tmpPath, local); err != nil {
+		return err
 	}
 
-	localReader := io.TeeReader(local, shasum)
-	if _, err := remote.CopyFrom(localReader); err != nil {
-		_ = remote.Close()
-		return fmt.Errorf("copy file to remote host: %w", err)
+	if err := fsys.Chmod(tmpPath, perm); err != nil {
+		return fmt.Errorf("chmod uploaded file: %w", err)
 	}
-	if err := remote.Close(); err != nil {
-		return fmt.Errorf("close remote file after upload: %w", err)
+	if err := fsys.Rename(tmpPath, dst); err != nil {
+		return fmt.Errorf("rename uploaded file into place: %w", err)
 	}
-
-	remoteSum, err := fsys.Sha256(dst)
-	if err != nil {
-		return fmt.Errorf("get checksum of uploaded file: %w", err)
-	}
-
-	if remoteSum != hex.EncodeToString(shasum.Sum(nil)) {
-		return ErrChecksumMismatch
-	}
-
-	if options.hasPerm {
-		if err := fsys.Chmod(dst, options.perm); err != nil {
-			return fmt.Errorf("chmod uploaded file: %w", err)
-		}
-	}
-
 	return nil
 }

--- a/remotefs/upload_test.go
+++ b/remotefs/upload_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"io/fs"
 	"net/http"
 	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -18,26 +20,60 @@ import (
 // uploadFS is a minimal FS stub for Upload tests. Only the methods called by
 // Upload are implemented; everything else panics if called.
 type uploadFS struct {
-	capturedPerm  fs.FileMode
+	tmpPath       string
 	capturedChmod fs.FileMode
-	chmodCalled   bool
+	renamedFrom   string
+	renamedTo     string
+	removedPaths  []string
 	written       []byte
+
+	createTempErr error
+	openFileErr   error
+	copyFromErr   error
+	sha256Err     error
+	chmodErr      error
+	renameErr     error
 }
 
-func (f *uploadFS) OpenFile(_ string, _ int, perm fs.FileMode) (remotefs.File, error) {
-	f.capturedPerm = perm
-	return &uploadFile{buf: &f.written}, nil
+func (f *uploadFS) Dir(p string) string { return path.Dir(p) }
+
+func (f *uploadFS) CreateTemp(dir, prefix string) (string, error) {
+	if f.createTempErr != nil {
+		return "", f.createTempErr
+	}
+	f.tmpPath = dir + "/" + prefix + "tmp"
+	return f.tmpPath, nil
+}
+
+func (f *uploadFS) OpenFile(_ string, _ int, _ fs.FileMode) (remotefs.File, error) {
+	if f.openFileErr != nil {
+		return nil, f.openFileErr
+	}
+	return &uploadFile{buf: &f.written, copyFromErr: f.copyFromErr}, nil
 }
 
 func (f *uploadFS) Sha256(_ string) (string, error) {
+	if f.sha256Err != nil {
+		return "", f.sha256Err
+	}
 	h := sha256.New()
 	h.Write(f.written)
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func (f *uploadFS) Chmod(_ string, mode fs.FileMode) error {
-	f.chmodCalled = true
 	f.capturedChmod = mode
+	return f.chmodErr
+}
+
+func (f *uploadFS) Rename(from, to string) error {
+	f.renamedFrom = from
+	f.renamedTo = to
+	return f.renameErr
+}
+
+func (f *uploadFS) Remove(p string) error {
+	f.removedPaths = append(f.removedPaths, p)
 	return nil
 }
 
@@ -46,12 +82,10 @@ func (f *uploadFS) Open(_ string) (fs.File, error)                        { pani
 func (f *uploadFS) Stat(_ string) (fs.FileInfo, error)                    { panic("not implemented") }
 func (f *uploadFS) ReadFile(_ string) ([]byte, error)                     { panic("not implemented") }
 func (f *uploadFS) ReadDir(_ string) ([]fs.DirEntry, error)               { panic("not implemented") }
-func (f *uploadFS) Remove(_ string) error                                 { panic("not implemented") }
 func (f *uploadFS) RemoveAll(_ string) error                              { panic("not implemented") }
 func (f *uploadFS) Mkdir(_ string, _ fs.FileMode) error                   { panic("not implemented") }
 func (f *uploadFS) MkdirAll(_ string, _ fs.FileMode) error                { panic("not implemented") }
 func (f *uploadFS) MkdirTemp(_, _ string) (string, error)                 { panic("not implemented") }
-func (f *uploadFS) CreateTemp(_, _ string) (string, error)                { panic("not implemented") }
 func (f *uploadFS) WriteFile(_ string, _ []byte, _ fs.FileMode) error     { panic("not implemented") }
 func (f *uploadFS) FileExist(_ string) bool                               { panic("not implemented") }
 func (f *uploadFS) LookPath(_ string) (string, error)                     { panic("not implemented") }
@@ -64,7 +98,6 @@ func (f *uploadFS) Chtimes(_ string, _, _ int64) error                    { pani
 func (f *uploadFS) Touch(_ string, _ ...time.Time) error                  { panic("not implemented") }
 func (f *uploadFS) Truncate(_ string, _ int64) error                      { panic("not implemented") }
 func (f *uploadFS) Getenv(_ string) string                                { panic("not implemented") }
-func (f *uploadFS) Rename(_, _ string) error                              { panic("not implemented") }
 func (f *uploadFS) DownloadURL(_ string, _ string) error                  { panic("not implemented") }
 func (f *uploadFS) RoundTrip(_ *http.Request) (*http.Response, error)     { panic("not implemented") }
 func (f *uploadFS) FileContains(_ string, _ string) (bool, error)         { panic("not implemented") }
@@ -78,19 +111,22 @@ func (f *uploadFS) TempDir() string                                       { pani
 func (f *uploadFS) UserCacheDir() string                                  { panic("not implemented") }
 func (f *uploadFS) UserConfigDir() string                                 { panic("not implemented") }
 func (f *uploadFS) UserHomeDir() string                                   { panic("not implemented") }
-func (f *uploadFS) Dir(_ string) string                                   { panic("not implemented") }
 func (f *uploadFS) Base(_ string) string                                  { panic("not implemented") }
 func (f *uploadFS) CommandExist(_ string) bool                            { panic("not implemented") }
 func (f *uploadFS) Reboot(_ context.Context) error                        { panic("not implemented") }
 
 // uploadFile is a minimal File stub that captures written bytes.
 type uploadFile struct {
-	buf *[]byte
+	buf         *[]byte
+	copyFromErr error
 }
 
 func (f *uploadFile) CopyFrom(src io.Reader) (int64, error) {
 	data, err := io.ReadAll(src)
 	*f.buf = data
+	if f.copyFromErr != nil {
+		return int64(len(data)), f.copyFromErr
+	}
 	return int64(len(data)), err
 }
 
@@ -122,8 +158,9 @@ func TestUploadUsesLocalPermByDefault(t *testing.T) {
 
 	mfs := &uploadFS{}
 	require.NoError(t, remotefs.Upload(mfs, src, "/remote/dst"))
-	require.Equal(t, stat.Mode(), mfs.capturedPerm)
-	require.False(t, mfs.chmodCalled, "Chmod should not be called without WithPermissions")
+	require.Equal(t, stat.Mode(), mfs.capturedChmod, "Chmod must be called with local file's mode")
+	require.Equal(t, mfs.tmpPath, mfs.renamedFrom, "temp path must be renamed to dst")
+	require.Equal(t, "/remote/dst", mfs.renamedTo)
 }
 
 func TestUploadWithPermissions(t *testing.T) {
@@ -131,15 +168,44 @@ func TestUploadWithPermissions(t *testing.T) {
 	mfs := &uploadFS{}
 
 	require.NoError(t, remotefs.Upload(mfs, src, "/remote/dst", remotefs.WithPermissions(0o755)))
-	require.Equal(t, fs.FileMode(0o755), mfs.capturedPerm)
-	require.True(t, mfs.chmodCalled, "Chmod should be called with WithPermissions")
-	require.Equal(t, fs.FileMode(0o755), mfs.capturedChmod)
+	require.Equal(t, fs.FileMode(0o755), mfs.capturedChmod, "Chmod must be called with specified mode")
+	require.Equal(t, mfs.tmpPath, mfs.renamedFrom)
+	require.Equal(t, "/remote/dst", mfs.renamedTo)
 }
 
 func TestUploadChecksumMismatch(t *testing.T) {
 	src := writeTempFile(t, "hello", 0o644)
-	err := remotefs.Upload(&corruptUploadFS{uploadFS: uploadFS{}}, src, "/remote/dst")
+	corruptFS := &corruptUploadFS{}
+	err := remotefs.Upload(corruptFS, src, "/remote/dst")
 	require.ErrorIs(t, err, remotefs.ErrChecksumMismatch)
+	require.Contains(t, corruptFS.removedPaths, corruptFS.tmpPath, "temp file must be removed on checksum mismatch")
+}
+
+func TestUploadCopyFailureCleansTempFile(t *testing.T) {
+	src := writeTempFile(t, "hello", 0o644)
+	mfs := &uploadFS{copyFromErr: errors.New("network error")}
+
+	err := remotefs.Upload(mfs, src, "/remote/dst")
+	require.Error(t, err)
+	require.Contains(t, mfs.removedPaths, mfs.tmpPath, "temp file must be removed after copy failure")
+}
+
+func TestUploadRenameFailureCleansTempFile(t *testing.T) {
+	src := writeTempFile(t, "hello", 0o644)
+	mfs := &uploadFS{renameErr: errors.New("cross-device link")}
+
+	err := remotefs.Upload(mfs, src, "/remote/dst")
+	require.Error(t, err)
+	require.Contains(t, mfs.removedPaths, mfs.tmpPath, "temp file must be removed after rename failure")
+}
+
+func TestUploadCreateTempFailure(t *testing.T) {
+	src := writeTempFile(t, "hello", 0o644)
+	mfs := &uploadFS{createTempErr: errors.New("no space left on device")}
+
+	err := remotefs.Upload(mfs, src, "/remote/dst")
+	require.Error(t, err)
+	require.Empty(t, mfs.removedPaths, "no temp file created, nothing to remove")
 }
 
 // corruptUploadFS simulates a checksum mismatch by returning an incorrect sha256 digest.


### PR DESCRIPTION
Upload now writes to a temporary file in the same directory as dst, verifies the SHA-256 checksum, and renames it into place. The temp file is removed via defer on any failure, so a partial upload or checksum mismatch can no longer leave a corrupt or truncated dst file.

As a side-effect of the inode swap, Upload always chmods the temp file to the desired permissions (local file mode or WithPermissions) before rename. Overwriting an existing remote file therefore changes its mode to match the source, rather than preserving the remote mode.

Also fixes initTouch in PosixFS: the deferred Remove was registered after tmpF.Close(), so a close failure leaked the temp file. Moved the defer to immediately after CreateTemp.