### PR TITLE
feat(cmd): add command lifecycle tracing and dry-run explain

### DIFF
--- a/cmd/errorexec.go
+++ b/cmd/errorexec.go
@@ -29,6 +29,25 @@ func NewErrorExecutor(err error) *ErrorExecutor {
 // Format returns the command string as is.
 func (r *ErrorExecutor) Format(cmd string) string { return cmd }
 
+// Explain returns an [Explanation] with per-call decorators applied. ErrorExecutor has
+// no global decorators and no connection, so OS-specific wrapping is not applied.
+func (r *ErrorExecutor) Explain(command string, opts ...ExecOption) Explanation {
+	execOpts := Build(opts...)
+	formatted := execOpts.Format(command)
+	decoded := decodeEncoded(formatted)
+	logged := ""
+	if execOpts.LogCommand() {
+		logged = execOpts.Redact(decoded)
+	}
+	return Explanation{
+		Formatted:       formatted,
+		Decoded:         decoded,
+		Logged:          logged,
+		CommandLogged:   execOpts.LogCommand(),
+		OSWrappingKnown: false,
+	}
+}
+
 // Proc returns a Proc bound to this executor for the given command.
 func (r *ErrorExecutor) Proc(cmd string) *Proc {
 	return &Proc{runner: r, command: cmd}

--- a/cmd/execoptions.go
+++ b/cmd/execoptions.go
@@ -137,15 +137,18 @@ func (o *ExecOptions) Stdin() io.Reader {
 }
 
 func (o *ExecOptions) logWriter(stream string, logFn func(msg string, keysAndValues ...any)) io.WriteCloser {
-	wc := redact.Writer(iostream.NewScanWriter(func(s string) { logFn(s, "stream", stream) }), o.redactMask, o.redactStrings...)
-	o.outputClosers = append(o.outputClosers, wc)
-	return wc
+	sw := iostream.NewScanWriter(func(s string) { logFn(s, "stream", stream) })
+	rw := redact.Writer(sw, o.redactMask, o.redactStrings...)
+	// rw must be closed first so it flushes its partial-match buffer into sw,
+	// then sw must be closed to signal EOF to the scanner goroutine.
+	o.outputClosers = append(o.outputClosers, rw, sw)
+	return rw
 }
 
-// OutputClosers returns WriteClosers created by this ExecOptions that must be
-// closed after the process finishes to release their resources.
+// OutputClosers returns a copy of the WriteClosers created by this ExecOptions that must
+// be closed after the process finishes to release their resources.
 func (o *ExecOptions) OutputClosers() []io.Closer {
-	return o.outputClosers
+	return append([]io.Closer(nil), o.outputClosers...)
 }
 
 // Stdout returns the Stdout writer. If output logging is enabled, it will be a MultiWriter that writes to the log.

--- a/cmd/execoptions.go
+++ b/cmd/execoptions.go
@@ -46,6 +46,11 @@ type ExecOptions struct {
 	redactStrings []string
 	decorateFuncs []DecorateFunc
 	redactMask    string
+
+	tracer        Tracer
+	traceOut      io.Writer
+	traceErr      io.Writer
+	outputClosers []io.Closer
 }
 
 // Format returns the command string with all per-call decorators applied.
@@ -132,7 +137,15 @@ func (o *ExecOptions) Stdin() io.Reader {
 }
 
 func (o *ExecOptions) logWriter(stream string, logFn func(msg string, keysAndValues ...any)) io.WriteCloser {
-	return redact.Writer(iostream.NewScanWriter(func(s string) { logFn(s, "stream", stream) }), o.redactMask, o.redactStrings...)
+	wc := redact.Writer(iostream.NewScanWriter(func(s string) { logFn(s, "stream", stream) }), o.redactMask, o.redactStrings...)
+	o.outputClosers = append(o.outputClosers, wc)
+	return wc
+}
+
+// OutputClosers returns WriteClosers created by this ExecOptions that must be
+// closed after the process finishes to release their resources.
+func (o *ExecOptions) OutputClosers() []io.Closer {
+	return o.outputClosers
 }
 
 // Stdout returns the Stdout writer. If output logging is enabled, it will be a MultiWriter that writes to the log.
@@ -146,6 +159,9 @@ func (o *ExecOptions) Stdout() io.Writer {
 	}
 	if o.out != nil {
 		writers = append(writers, o.out)
+	}
+	if o.traceOut != nil {
+		writers = append(writers, o.traceOut)
 	}
 	return io.MultiWriter(writers...)
 }
@@ -163,7 +179,9 @@ func (o *ExecOptions) Stderr() io.Writer {
 	if o.errOut != nil {
 		writers = append(writers, o.errOut)
 	}
-
+	if o.traceErr != nil {
+		writers = append(writers, o.traceErr)
+	}
 	return io.MultiWriter(writers...)
 }
 
@@ -313,6 +331,15 @@ func Decorate(decorator DecorateFunc) ExecOption {
 func Logger(l log.Logger) ExecOption {
 	return func(o *ExecOptions) {
 		o.SetLogger(l)
+	}
+}
+
+// Trace exec option for attaching a [Tracer] to a single command execution.
+// If the Tracer also implements [OutputTracer], per-line stdout and stderr
+// hooks are enabled automatically.
+func Trace(t Tracer) ExecOption {
+	return func(o *ExecOptions) {
+		o.tracer = t
 	}
 }
 

--- a/cmd/executor.go
+++ b/cmd/executor.go
@@ -11,8 +11,11 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 	"unicode/utf16"
 
+	"github.com/k0sproject/rig/v2/iostream"
 	"github.com/k0sproject/rig/v2/log"
 	"github.com/k0sproject/rig/v2/protocol"
 )
@@ -45,6 +48,8 @@ type Executor struct {
 	connection protocol.ProcessStarter
 	decorators []DecorateFunc
 	isWin      func() bool
+	osKnown    atomic.Bool
+	tracer     Tracer
 }
 
 func isWinFunc(conn protocol.ProcessStarter) func() bool {
@@ -69,6 +74,56 @@ func NewExecutor(conn protocol.ProcessStarter, decorators ...DecorateFunc) *Exec
 	}
 }
 
+// SetTracer attaches a runner-wide [Tracer]. It fires for every command
+// unless overridden per-call via the [Trace] option.
+// SetTracer must not be called concurrently with Start, Exec, or any other
+// command-execution method.
+func (r *Executor) SetTracer(t Tracer) {
+	r.tracer = t
+}
+
+func (r *Executor) formatCommandForOS(command string, execOpts *ExecOptions, isWindows bool) string {
+	cmd := r.Format(execOpts.Format(command))
+	if isWindows && !isExe(cmd) {
+		cmd = "cmd.exe /C " + cmd
+	}
+	return cmd
+}
+
+// formatCommand returns the fully decorated command string.
+func (r *Executor) formatCommand(command string, execOpts *ExecOptions) string {
+	return r.formatCommandForOS(command, execOpts, r.IsWindows())
+}
+
+func (r *Executor) explainCommand(command string, execOpts *ExecOptions) (string, bool) {
+	if !r.osKnown.Load() {
+		return r.formatCommandForOS(command, execOpts, false), false
+	}
+	return r.formatCommandForOS(command, execOpts, r.IsWindows()), true
+}
+
+// Explain returns the formatted command without running it. Use this to
+// inspect the effect of decorators, sudo wrapping, PowerShell encoding,
+// and redaction without executing anything. Explain never probes the host
+// to determine OS-specific wrapping; wrapping is included only when the OS
+// has already been determined (see OSWrappingKnown in the returned Explanation).
+func (r *Executor) Explain(command string, opts ...ExecOption) Explanation {
+	execOpts := Build(opts...)
+	formatted, osWrappingKnown := r.explainCommand(command, execOpts)
+	decoded := decodeEncoded(formatted)
+	logged := ""
+	if execOpts.LogCommand() {
+		logged = execOpts.Redact(decoded)
+	}
+	return Explanation{
+		Formatted:       formatted,
+		Decoded:         decoded,
+		Logged:          logged,
+		CommandLogged:   execOpts.LogCommand(),
+		OSWrappingKnown: osWrappingKnown,
+	}
+}
+
 // Format returns the command string decorated with the runner's global decorators.
 func (r *Executor) Format(cmd string) string {
 	for _, decorator := range r.decorators {
@@ -85,7 +140,9 @@ func (r *Executor) Proc(cmd string) *Proc {
 
 // IsWindows returns true if the host is running Windows.
 func (r *Executor) IsWindows() bool {
-	return r.isWin()
+	result := r.isWin()
+	r.osKnown.Store(true)
+	return result
 }
 
 // String returns the client's string representation.
@@ -135,9 +192,14 @@ func findPrintfError(s string) error {
 }
 
 type waiterWrapper struct {
-	waiter    protocol.Waiter
-	opts      *ExecOptions
-	isWindows bool
+	waiter       protocol.Waiter
+	opts         *ExecOptions
+	isWindows    bool
+	tracer       Tracer
+	host         string
+	formatted    string
+	started      time.Time
+	traceClosers []io.Closer
 }
 
 var xmlTagRe = regexp.MustCompile(`<.+?>`)
@@ -160,17 +222,28 @@ func formatStderr(stderr string, isWindows bool) string {
 // Wait waits for the command to finish and returns an error if it fails or if it wrote to stderr.
 func (w *waiterWrapper) Wait() error {
 	waitErr := w.waiter.Wait()
+
+	// flush per-line trace writers before reading errBuf so all output is delivered
+	for _, c := range w.traceClosers {
+		_ = c.Close()
+	}
+
 	stderr := formatStderr(w.opts.ErrString(), w.isWindows)
 	if waitErr == nil && w.isWindows && !w.opts.AllowWinStderr() && len(stderr) > 0 {
 		waitErr = ErrWroteStderr
 	}
+	var result error
 	if waitErr != nil {
 		if len(stderr) > 0 {
-			return fmt.Errorf("process finished with error: %w (%s)", waitErr, stderr)
+			result = fmt.Errorf("process finished with error: %w (%s)", waitErr, stderr)
+		} else {
+			result = fmt.Errorf("process finished with error: %w", waitErr)
 		}
-		return fmt.Errorf("process finished with error: %w", waitErr)
 	}
-	return nil
+	if w.tracer != nil {
+		w.tracer.ProcessFinished(w.host, w.formatted, time.Since(w.started), result)
+	}
+	return result
 }
 
 func isExe(cmd string) bool {
@@ -225,35 +298,71 @@ func (r *Executor) Start(ctx context.Context, command string, opts ...ExecOption
 	execOpts := Build(opts...)
 	r.InjectLoggerTo(execOpts) //nolint:contextcheck // uses trace logger which takes context
 
-	cmd := r.Format(execOpts.Format(command))
-	if r.IsWindows() {
-		// we don't know if the default shell is cmd or powershell, so to make sure commands
-		// without a shell prefix go consistently go through the same shell, we default to running
-		// non-prefixed commands through cmd.exe.
-		if !isExe(cmd) {
-			cmd = "cmd.exe /C " + cmd
-		}
+	// resolve active tracer: per-call overrides runner-wide
+	tracer := execOpts.tracer
+	if tracer == nil {
+		tracer = r.tracer
 	}
+
+	// wire per-line output hooks for OutputTracer before computing final writers
+	var traceClosers []io.Closer //nolint:prealloc // OutputClosers length is unknown until Stdout/Stderr are called below
+	if ot, ok := tracer.(OutputTracer); ok {
+		host := r.String()
+		outSW := iostream.NewScanWriter(func(line string) { ot.StdoutLine(host, line) })
+		errSW := iostream.NewScanWriter(func(line string) { ot.StderrLine(host, line) })
+		traceClosers = []io.Closer{outSW, errSW}
+		execOpts.traceOut = outSW
+		execOpts.traceErr = errSW
+	}
+
+	// we don't know if the default shell is cmd or powershell, so to make sure commands
+	// without a shell prefix go consistently go through the same shell, we default to running
+	// non-prefixed commands through cmd.exe.
+	cmd := r.formatCommand(command, execOpts)
 
 	if execOpts.LogCommand() {
 		r.Log().Debug("executing command", log.KeyCommand, execOpts.Redact(decodeEncoded(cmd)))
 	}
 
-	waiter, err := r.connection.StartProcess(ctx, cmd, execOpts.Stdin(), execOpts.Stdout(), execOpts.Stderr()) //nolint:contextcheck // Stdin() uses trace logger which takes context
+	if tracer != nil {
+		tracer.CommandFormatted(r.String(), cmd)
+	}
+
+	stdout := execOpts.Stdout()
+	stderr := execOpts.Stderr()
+	traceClosers = append(traceClosers, execOpts.OutputClosers()...)
+
+	waiter, err := r.connection.StartProcess(ctx, cmd, execOpts.Stdin(), stdout, stderr) //nolint:contextcheck // Stdin() uses trace logger which takes context
 	if err != nil {
+		for _, c := range traceClosers {
+			_ = c.Close()
+		}
 		log.Trace(ctx, "start process failed", log.HostAttr(r), log.KeyCommand, cmd, log.KeyError, err)
 		return nil, fmt.Errorf("runner start command: %w", err)
 	}
 
 	if waiter == nil {
+		for _, c := range traceClosers {
+			_ = c.Close()
+		}
 		log.Trace(ctx, "start process returned nil waiter", log.HostAttr(r), log.KeyCommand, cmd, log.KeyError, err)
 		return nil, fmt.Errorf("%w: connection returned no error but a nil waiter", errInternal)
 	}
 
+	started := time.Now()
+	if tracer != nil {
+		tracer.ProcessStarted(r.String(), cmd)
+	}
+
 	return &waiterWrapper{
-		waiter:    waiter,
-		opts:      execOpts,
-		isWindows: r.IsWindows(),
+		waiter:       waiter,
+		opts:         execOpts,
+		isWindows:    r.IsWindows(),
+		tracer:       tracer,
+		host:         r.String(),
+		formatted:    cmd,
+		started:      started,
+		traceClosers: traceClosers,
 	}, nil
 }
 

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -60,6 +60,13 @@ type Runner interface {
 	SimpleRunner
 	ContextRunner
 	Proc(cmd string) *Proc
+	// Explain returns an [Explanation] describing how the command would be processed,
+	// without actually running it. The Explanation includes the fully decorated
+	// command string (Formatted), the decoded/human-readable form (Decoded), the
+	// redacted version that would appear in logs (Logged), and whether the OS
+	// wrapping decision was known (OSWrappingKnown). Use this to inspect the effect of
+	// decorators, sudo wrapping, PowerShell encoding, and redaction.
+	Explain(cmd string, opts ...ExecOption) Explanation
 	// ProcessStarter is included to allow runners to accept another runner as their connection for chaining.
 	protocol.ProcessStarter
 }

--- a/cmd/tracer.go
+++ b/cmd/tracer.go
@@ -1,0 +1,56 @@
+package cmd
+
+import "time"
+
+// Tracer observes command lifecycle events on an [Executor].
+// Register a Tracer via [Trace] (per-call) or [Executor.SetTracer] (runner-wide).
+type Tracer interface {
+	// CommandFormatted fires just before a process is started, with the final
+	// command string after all decorators and OS-specific wrapping.
+	CommandFormatted(host, formatted string)
+	// ProcessStarted fires after the underlying process starts successfully.
+	ProcessStarted(host, formatted string)
+	// ProcessFinished fires after the process exits.
+	// duration is the wall-clock time since ProcessStarted. err is nil on success.
+	ProcessFinished(host, formatted string, duration time.Duration, err error)
+}
+
+// OutputTracer extends [Tracer] with per-line stdout and stderr hooks.
+// Implement this alongside Tracer to receive output as individual lines.
+// Each line is delivered without the trailing newline. A partial final line
+// (not terminated by a newline) is flushed when the process exits.
+//
+// Concurrency: StdoutLine and StderrLine may be called concurrently with each
+// other and with [Tracer.ProcessFinished]. Implementations must be safe for
+// concurrent use.
+type OutputTracer interface {
+	Tracer
+	// StdoutLine fires for each line written to stdout. The line does not
+	// include a trailing newline character.
+	StdoutLine(host, line string)
+	// StderrLine fires for each line written to stderr. The line does not
+	// include a trailing newline character.
+	StderrLine(host, line string)
+}
+
+// Explanation holds the formatted representations of a command as it would
+// appear at each stage of the execution pipeline.
+type Explanation struct {
+	// Formatted is the command string after all global and per-call
+	// decorators, sudo wrapping, and any OS-specific prefixes that can be
+	// determined without probing the connection (e.g. "cmd.exe /C"). When
+	// OSWrappingKnown is false, OS-specific prefixes are omitted.
+	Formatted string
+	// Decoded is the human-readable form of Formatted. PowerShell
+	// EncodedCommand payloads are decoded so you can read the actual script.
+	Decoded string
+	// Logged is the command as it appears in debug log lines: Decoded with
+	// any strings registered via [Redact] replaced by the redact mask. It is
+	// empty when command logging is disabled.
+	Logged string
+	// CommandLogged reports whether Logged would be emitted by command logging.
+	CommandLogged bool
+	// OSWrappingKnown reports whether Formatted could include OS-specific
+	// command wrapping without probing the connection.
+	OSWrappingKnown bool
+}

--- a/cmd/tracer_test.go
+++ b/cmd/tracer_test.go
@@ -1,0 +1,281 @@
+package cmd_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/rig/v2/cmd"
+	"github.com/k0sproject/rig/v2/protocol"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tracerRecorder collects lifecycle events for assertions.
+type tracerRecorder struct {
+	events []string
+}
+
+func (r *tracerRecorder) CommandFormatted(host, formatted string) {
+	r.events = append(r.events, "formatted:"+formatted)
+}
+
+func (r *tracerRecorder) ProcessStarted(host, formatted string) {
+	r.events = append(r.events, "started:"+formatted)
+}
+
+func (r *tracerRecorder) ProcessFinished(host, formatted string, duration time.Duration, err error) {
+	if err != nil {
+		r.events = append(r.events, "finished-err:"+err.Error())
+	} else {
+		r.events = append(r.events, "finished-ok:"+formatted)
+	}
+}
+
+// outputTracerRecorder also captures per-line output.
+type outputTracerRecorder struct {
+	tracerRecorder
+	stdout []string
+	stderr []string
+}
+
+type explainOnlyStarter struct {
+	started []string
+}
+
+func (s *explainOnlyStarter) StartProcess(_ context.Context, command string, _ io.Reader, _ io.Writer, _ io.Writer) (protocol.Waiter, error) {
+	s.started = append(s.started, command)
+	return nil, errors.New("explain must not start a process")
+}
+
+func (r *outputTracerRecorder) StdoutLine(host, line string) {
+	r.stdout = append(r.stdout, line)
+}
+
+func (r *outputTracerRecorder) StderrLine(host, line string) {
+	r.stderr = append(r.stderr, line)
+}
+
+func TestTracerLifecycleOrder(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommand(rigtest.Equal("echo hi"), func(_ *rigtest.A) error { return nil })
+
+	tr := &tracerRecorder{}
+	err := mr.Exec("echo hi", cmd.Trace(tr))
+	require.NoError(t, err)
+
+	require.Len(t, tr.events, 3)
+	assert.Equal(t, "formatted:echo hi", tr.events[0])
+	assert.Equal(t, "started:echo hi", tr.events[1])
+	assert.Equal(t, "finished-ok:echo hi", tr.events[2])
+}
+
+func TestTracerRunnerWide(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	conn.AddCommand(rigtest.Equal("whoami"), func(_ *rigtest.A) error { return nil })
+	runner := cmd.NewExecutor(conn)
+
+	tr := &tracerRecorder{}
+	runner.SetTracer(tr)
+
+	require.NoError(t, runner.Exec("whoami"))
+	require.Len(t, tr.events, 3)
+	assert.Equal(t, "formatted:whoami", tr.events[0])
+}
+
+func TestTracerPerCallOverridesRunnerWide(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	conn.AddCommand(rigtest.Match("."), func(_ *rigtest.A) error { return nil })
+	runner := cmd.NewExecutor(conn)
+
+	runnerWide := &tracerRecorder{}
+	perCall := &tracerRecorder{}
+	runner.SetTracer(runnerWide)
+
+	require.NoError(t, runner.Exec("hello", cmd.Trace(perCall)))
+
+	assert.Empty(t, runnerWide.events, "runner-wide tracer should not fire when per-call overrides it")
+	assert.Len(t, perCall.events, 3)
+}
+
+func TestTracerProcessFinishedOnError(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	execErr := errors.New("boom")
+	mr.AddCommand(rigtest.Equal("fail"), func(_ *rigtest.A) error { return execErr })
+
+	tr := &tracerRecorder{}
+	err := mr.Exec("fail", cmd.Trace(tr))
+	require.Error(t, err)
+
+	require.Len(t, tr.events, 3)
+	assert.Equal(t, "formatted:fail", tr.events[0])
+	assert.Equal(t, "started:fail", tr.events[1])
+	assert.Equal(t, "finished-err:process finished with error: boom", tr.events[2])
+}
+
+func TestOutputTracerPerLine(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommand(rigtest.Equal("lines"), func(a *rigtest.A) error {
+		fmt.Fprintln(a.Stdout, "line1")
+		fmt.Fprintln(a.Stdout, "line2")
+		fmt.Fprintln(a.Stderr, "err1")
+		return nil
+	})
+
+	tr := &outputTracerRecorder{}
+	err := mr.Exec("lines", cmd.Trace(tr))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"line1", "line2"}, tr.stdout)
+	assert.Equal(t, []string{"err1"}, tr.stderr)
+}
+
+func TestTracerDecoratedCommand(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	conn.AddCommand(rigtest.Match("."), func(_ *rigtest.A) error { return nil })
+
+	globalDec := func(c string) string { return "sudo " + c }
+	runner := cmd.NewExecutor(conn, globalDec)
+
+	tr := &tracerRecorder{}
+	require.NoError(t, runner.Exec("whoami", cmd.Trace(tr)))
+
+	require.Len(t, tr.events, 3)
+	// CommandFormatted must receive the fully decorated string
+	assert.Equal(t, "formatted:sudo whoami", tr.events[0])
+}
+
+// --- Explain tests ---
+
+func TestExplainPlainCommand(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	ex := mr.Explain("ls -la")
+	assert.Equal(t, "ls -la", ex.Formatted)
+	assert.Equal(t, "ls -la", ex.Decoded)
+	assert.Equal(t, "ls -la", ex.Logged)
+	assert.True(t, ex.CommandLogged)
+	// OSWrappingKnown is false until IsWindows() has been called (OS not yet cached).
+	assert.False(t, ex.OSWrappingKnown)
+}
+
+func TestExplainWithGlobalDecorator(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	globalDec := func(c string) string { return "sudo " + c }
+	runner := cmd.NewExecutor(conn, globalDec)
+
+	ex := runner.Explain("whoami")
+	assert.Equal(t, "sudo whoami", ex.Formatted)
+	assert.Equal(t, "sudo whoami", ex.Decoded)
+}
+
+func TestExplainWithPerCallDecorator(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	runner := cmd.NewExecutor(conn)
+
+	callDec := func(c string) string { return "env X=1 " + c }
+	ex := runner.Explain("myapp", cmd.Decorate(callDec))
+	assert.Equal(t, "env X=1 myapp", ex.Formatted)
+}
+
+func TestExplainWindowsWrapping(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	conn.Windows = true
+	runner := cmd.NewExecutor(conn)
+
+	// Prime the OS cache so Explain can include OS-specific wrapping.
+	runner.IsWindows()
+
+	ex := runner.Explain("k0s version")
+	assert.Equal(t, "cmd.exe /C k0s version", ex.Formatted)
+	assert.True(t, ex.OSWrappingKnown)
+
+	exExe := runner.Explain("k0s.exe version")
+	assert.Equal(t, "k0s.exe version", exExe.Formatted, "*.exe commands must not be double-wrapped")
+}
+
+func TestExplainDoesNotProbeWindows(t *testing.T) {
+	starter := &explainOnlyStarter{}
+	runner := cmd.NewExecutor(starter)
+
+	ex := runner.Explain("k0s version")
+
+	assert.Equal(t, "k0s version", ex.Formatted)
+	assert.False(t, ex.OSWrappingKnown)
+	assert.Empty(t, starter.started, "Explain must not start a process to detect OS wrapping")
+}
+
+func TestExplainDoesNotProbeWindowsChecker(t *testing.T) {
+	// A WindowsChecker connection whose IsWindows() records calls — Explain must not call it.
+	conn := rigtest.NewMockConnection()
+	conn.Windows = true
+	runner := cmd.NewExecutor(conn)
+
+	// Do NOT call runner.IsWindows() — OS cache is empty.
+	ex := runner.Explain("k0s version")
+
+	assert.Equal(t, "k0s version", ex.Formatted, "OS wrapping must not be applied when OS is not yet cached")
+	assert.False(t, ex.OSWrappingKnown)
+	assert.Empty(t, conn.Commands(), "Explain must not start any process")
+}
+
+func TestOutputTracerNoOutputDoesNotDeadlock(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommand(rigtest.Equal("silent"), func(_ *rigtest.A) error { return nil })
+
+	tr := &outputTracerRecorder{}
+	done := make(chan error, 1)
+	go func() {
+		done <- mr.Exec("silent", cmd.Trace(tr))
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Exec with OutputTracer deadlocked on a command that produced no output")
+	}
+
+	assert.Empty(t, tr.stdout)
+	assert.Empty(t, tr.stderr)
+}
+
+func TestExplainCommandLogSuppression(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+
+	ex := mr.Explain("curl -H token", cmd.HideCommand())
+
+	assert.Equal(t, "curl -H token", ex.Formatted)
+	assert.False(t, ex.CommandLogged)
+	assert.Empty(t, ex.Logged)
+}
+
+func TestExplainRedaction(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	secret := "s3cr3t"
+	ex := mr.Explain("curl -u admin:"+secret, cmd.Redact(secret))
+
+	// Formatted is the wire command — secret must be present
+	assert.Contains(t, ex.Formatted, secret)
+	// Logged is the log view — secret must be masked
+	assert.NotContains(t, ex.Logged, secret)
+	assert.Contains(t, ex.Logged, cmd.DefaultRedactMask)
+}
+
+func TestExplainMatchesStart(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	conn.AddCommand(rigtest.Match("."), func(_ *rigtest.A) error { return nil })
+
+	globalDec := func(c string) string { return "env VAR=1 " + c }
+	runner := cmd.NewExecutor(conn, globalDec)
+
+	callDec := func(c string) string { return "sudo " + c }
+
+	ex := runner.Explain("myapp run", cmd.Decorate(callDec))
+	_ = runner.Exec("myapp run", cmd.Decorate(callDec))
+
+	rigtest.ReceivedEqual(t, conn, ex.Formatted)
+}

--- a/cmd/tracer_test.go
+++ b/cmd/tracer_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,18 +18,25 @@ import (
 
 // tracerRecorder collects lifecycle events for assertions.
 type tracerRecorder struct {
+	mu     sync.Mutex
 	events []string
 }
 
 func (r *tracerRecorder) CommandFormatted(host, formatted string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.events = append(r.events, "formatted:"+formatted)
 }
 
 func (r *tracerRecorder) ProcessStarted(host, formatted string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.events = append(r.events, "started:"+formatted)
 }
 
 func (r *tracerRecorder) ProcessFinished(host, formatted string, duration time.Duration, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if err != nil {
 		r.events = append(r.events, "finished-err:"+err.Error())
 	} else {
@@ -39,6 +47,7 @@ func (r *tracerRecorder) ProcessFinished(host, formatted string, duration time.D
 // outputTracerRecorder also captures per-line output.
 type outputTracerRecorder struct {
 	tracerRecorder
+	mu     sync.Mutex
 	stdout []string
 	stderr []string
 }
@@ -53,10 +62,14 @@ func (s *explainOnlyStarter) StartProcess(_ context.Context, command string, _ i
 }
 
 func (r *outputTracerRecorder) StdoutLine(host, line string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.stdout = append(r.stdout, line)
 }
 
 func (r *outputTracerRecorder) StderrLine(host, line string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.stderr = append(r.stderr, line)
 }
 
@@ -275,7 +288,7 @@ func TestExplainMatchesStart(t *testing.T) {
 	callDec := func(c string) string { return "sudo " + c }
 
 	ex := runner.Explain("myapp run", cmd.Decorate(callDec))
-	_ = runner.Exec("myapp run", cmd.Decorate(callDec))
+	require.NoError(t, runner.Exec("myapp run", cmd.Decorate(callDec)))
 
 	rigtest.ReceivedEqual(t, conn, ex.Formatted)
 }

--- a/iostream/scanwriter.go
+++ b/iostream/scanwriter.go
@@ -4,7 +4,6 @@ package iostream
 import (
 	"bufio"
 	"io"
-	"sync"
 )
 
 // ScanWriterMaxBufferSize is the maximum size of the ScanWriter buffer. If the buffer
@@ -23,7 +22,6 @@ type ScanWriter struct {
 	pipeR   *io.PipeReader
 	pipeW   *io.PipeWriter
 	scanner *bufio.Scanner
-	once    sync.Once
 	closed  bool
 	closeCh chan struct{}
 }
@@ -37,6 +35,12 @@ func NewScanWriter(fn CallbackFn) io.WriteCloser {
 	sw.pipeR, sw.pipeW = io.Pipe()
 	sw.scanner = bufio.NewScanner(sw.pipeR)
 	sw.scanner.Buffer(nil, ScanWriterMaxBufferSize)
+	go func() {
+		for sw.scanner.Scan() {
+			sw.fn(sw.scanner.Text())
+		}
+		close(sw.closeCh)
+	}()
 	return sw
 }
 
@@ -45,14 +49,6 @@ func (w *ScanWriter) Write(p []byte) (int, error) {
 	if w.closed {
 		return 0, io.ErrUnexpectedEOF
 	}
-	w.once.Do(func() {
-		go func() {
-			for w.scanner.Scan() {
-				w.fn(w.scanner.Text())
-			}
-			close(w.closeCh)
-		}()
-	})
 	return w.pipeW.Write(p) //nolint:wrapcheck
 }
 

--- a/iostream/scanwriter.go
+++ b/iostream/scanwriter.go
@@ -4,6 +4,7 @@ package iostream
 import (
 	"bufio"
 	"io"
+	"sync"
 )
 
 // ScanWriterMaxBufferSize is the maximum size of the ScanWriter buffer. If the buffer
@@ -22,6 +23,7 @@ type ScanWriter struct {
 	pipeR   *io.PipeReader
 	pipeW   *io.PipeWriter
 	scanner *bufio.Scanner
+	once    sync.Once
 	closed  bool
 	closeCh chan struct{}
 }
@@ -35,13 +37,18 @@ func NewScanWriter(fn CallbackFn) io.WriteCloser {
 	sw.pipeR, sw.pipeW = io.Pipe()
 	sw.scanner = bufio.NewScanner(sw.pipeR)
 	sw.scanner.Buffer(nil, ScanWriterMaxBufferSize)
-	go func() {
-		for sw.scanner.Scan() {
-			sw.fn(sw.scanner.Text())
-		}
-		close(sw.closeCh)
-	}()
 	return sw
+}
+
+func (w *ScanWriter) startScanner() {
+	w.once.Do(func() {
+		go func() {
+			for w.scanner.Scan() {
+				w.fn(w.scanner.Text())
+			}
+			close(w.closeCh)
+		}()
+	})
 }
 
 // Write writes the given bytes to the scanner.
@@ -49,6 +56,7 @@ func (w *ScanWriter) Write(p []byte) (int, error) {
 	if w.closed {
 		return 0, io.ErrUnexpectedEOF
 	}
+	w.startScanner()
 	return w.pipeW.Write(p) //nolint:wrapcheck
 }
 
@@ -67,6 +75,11 @@ func (w *ScanWriter) CloseWithError(reason error) error {
 	if err := w.pipeW.CloseWithError(reason); err != nil {
 		return err //nolint:wrapcheck
 	}
+
+	// Ensure the scanner goroutine is running before we wait for it.
+	// If Write was never called the goroutine hasn't started yet; starting it here
+	// lets it observe the closed pipe and exit cleanly without deadlocking.
+	w.startScanner()
 
 	<-w.closeCh
 

--- a/iostream/scanwriter_test.go
+++ b/iostream/scanwriter_test.go
@@ -15,8 +15,6 @@ func (c *collector) fn(token string) {
 	c.tokens = append(c.tokens, token)
 }
 
-const lf byte = '\n'
-
 func TestScanWriter(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/redact/writer.go
+++ b/redact/writer.go
@@ -70,16 +70,8 @@ func (rw *redactWriter) Close() error {
 
 	// Copy any remaining data from the buffer to the underlying writer.
 	// (should be just a partial match that didn't get to complete)
-	if _, err := io.Copy(rw.w, rw.buf); err != nil {
-		return err //nolint:wrapcheck
-	}
-
-	// Propagate close to the underlying writer so callers such as ScanWriter
-	// can signal EOF to their scanning goroutine.
-	if c, ok := rw.w.(io.Closer); ok {
-		return c.Close() //nolint:wrapcheck
-	}
-	return nil
+	_, err := io.Copy(rw.w, rw.buf)
+	return err //nolint:wrapcheck
 }
 
 type matchInfo struct {

--- a/redact/writer.go
+++ b/redact/writer.go
@@ -70,8 +70,16 @@ func (rw *redactWriter) Close() error {
 
 	// Copy any remaining data from the buffer to the underlying writer.
 	// (should be just a partial match that didn't get to complete)
-	_, err := io.Copy(rw.w, rw.buf)
-	return err //nolint:wrapcheck
+	if _, err := io.Copy(rw.w, rw.buf); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	// Propagate close to the underlying writer so callers such as ScanWriter
+	// can signal EOF to their scanning goroutine.
+	if c, ok := rw.w.(io.Closer); ok {
+		return c.Close() //nolint:wrapcheck
+	}
+	return nil
 }
 
 type matchInfo struct {


### PR DESCRIPTION
Adds two new features to the cmd package:

- Tracer/OutputTracer interfaces with CommandFormatted, ProcessStarted, ProcessFinished, StdoutLine, and StderrLine hooks. Register runner-wide via Executor.SetTracer or per-call via the Trace ExecOption.

- Executor.Explain returns the fully decorated command string (Formatted, PS-decoded, and log-redacted) without executing anything. Uses the same formatCommand helper as Start to guarantee the two never diverge.

Breaking v2 API is not a problem as v2 has not been released.
