### PR TITLE
feat(ssh): fallback to GlobalKnownHostsFile 

### DIFF
--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -357,17 +357,22 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 
 	var khPath string
 
+	// "none" anywhere in the list disables user known_hosts entirely; check
+	// the full list before committing to any path.
+	noneSet := false
 	for _, f := range c.sshConfig.UserKnownHostsFile {
 		if strings.EqualFold(f, "none") {
-			// "none" anywhere in the list disables user known_hosts entirely
-			khPath = ""
+			noneSet = true
 			break
 		}
-		if khPath == "" {
+	}
+	if !noneSet {
+		for _, f := range c.sshConfig.UserKnownHostsFile {
 			log.Trace(ctx, "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
 			exp, err := homedir.Expand(f)
 			if err == nil {
 				khPath = exp
+				break
 			}
 		}
 	}

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -318,7 +318,7 @@ func knownhostsCallback(path string, permissive, hash bool) (ssh.HostKeyCallback
 func knownhostsGlobalCallback(path string, permissive bool) (ssh.HostKeyCallback, error) {
 	cb, err := hostkey.KnownHostsReadOnlyFileCallback(path, permissive)
 	if err != nil {
-		return nil, fmt.Errorf("create host key validator: %w", err)
+		return nil, fmt.Errorf("create host key validator for %s: %w", path, err)
 	}
 	return cb, nil
 }

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -370,10 +370,16 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 		for _, f := range c.sshConfig.UserKnownHostsFile {
 			log.Trace(ctx, "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
 			exp, err := homedir.Expand(f)
-			if err == nil {
-				khPath = exp
-				break
+			if err != nil {
+				continue
 			}
+			stat, err := os.Stat(exp)
+			if err != nil || !stat.Mode().IsRegular() {
+				log.Trace(ctx, "skipping user known_hosts file", log.KeyHost, c, log.KeyFile, exp)
+				continue
+			}
+			khPath = exp
+			break
 		}
 	}
 

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -315,14 +315,14 @@ func knownhostsCallback(path string, permissive, hash bool) (ssh.HostKeyCallback
 func knownhostsGlobalCallback(path string, permissive bool) (ssh.HostKeyCallback, error) {
 	cb, err := hostkey.KnownHostsReadOnlyFileCallback(path, permissive)
 	if err != nil {
-		return nil, fmt.Errorf("%w: create host key validator: %w", protocol.ErrNonRetryable, err)
+		return nil, fmt.Errorf("create host key validator: %w", err)
 	}
 	return cb, nil
 }
 
 func isPermissive(ctx context.Context, c *Connection) bool {
 	if c.sshConfig.StrictHostKeyChecking.IsFalse() {
-		log.Trace(ctx, "config StrictHostkeyChecking is set to 'no'", log.KeyHost, c)
+		log.Trace(ctx, "config StrictHostKeyChecking is set to 'no'", log.KeyHost, c)
 		return true
 	}
 

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -356,14 +356,16 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 
 	for _, f := range c.sshConfig.UserKnownHostsFile {
 		if strings.EqualFold(f, "none") {
-			// "none" is the OpenSSH special value meaning "ignore user known_hosts"
+			// "none" anywhere in the list disables user known_hosts entirely
+			khPath = ""
 			break
 		}
-		log.Trace(ctx, "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
-		exp, err := homedir.Expand(f)
-		if err == nil {
-			khPath = exp
-			break
+		if khPath == "" {
+			log.Trace(ctx, "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
+			exp, err := homedir.Expand(f)
+			if err == nil {
+				khPath = exp
+			}
 		}
 	}
 

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -374,17 +374,22 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 		if err != nil {
 			continue
 		}
-		if _, err := os.Stat(exp); err != nil {
-			log.Trace(ctx, "skipping missing global known_hosts file", log.KeyHost, c, log.KeyFile, exp)
+		stat, err := os.Stat(exp)
+		if err != nil {
+			log.Trace(ctx, "skipping global known_hosts file", log.KeyHost, c, log.KeyFile, exp, log.KeyError, err)
 			continue
 		}
-		khPath = exp
-		break
-	}
-
-	if khPath != "" {
-		log.Trace(ctx, "using global known_hosts file", log.KeyHost, c, log.KeyFile, khPath)
-		return knownhostsGlobalCallback(khPath, permissive)
+		if !stat.Mode().IsRegular() {
+			log.Trace(ctx, "skipping non-regular global known_hosts file", log.KeyHost, c, log.KeyFile, exp)
+			continue
+		}
+		cb, err := knownhostsGlobalCallback(exp, permissive)
+		if err != nil {
+			log.Trace(ctx, "skipping unusable global known_hosts file", log.KeyHost, c, log.KeyFile, exp, log.KeyError, err)
+			continue
+		}
+		log.Trace(ctx, "using global known_hosts file", log.KeyHost, c, log.KeyFile, exp)
+		return cb, nil
 	}
 
 	return nil, fmt.Errorf("%w: no known_hosts file found", protocol.ErrNonRetryable)

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -25,7 +25,10 @@ import (
 	"golang.org/x/term"
 )
 
-var errNotConnected = errors.New("not connected")
+var (
+	errNotConnected   = errors.New("not connected")
+	errNotRegularFile = errors.New("not a regular file")
+)
 
 // Connection describes an SSH connection.
 type Connection struct {
@@ -383,6 +386,8 @@ func globalKnownHostsCallback(ctx context.Context, paths []string, permissive bo
 		log.Trace(ctx, "trying global known_hosts file", log.KeyFile, f)
 		exp, err := homedir.Expand(f)
 		if err != nil {
+			lastErr = err
+			log.Trace(ctx, "skipping global known_hosts file (expand failed)", log.KeyFile, f, log.KeyError, err)
 			continue
 		}
 		if exp != "/dev/null" {
@@ -395,6 +400,7 @@ func globalKnownHostsCallback(ctx context.Context, paths []string, permissive bo
 				continue
 			}
 			if !stat.Mode().IsRegular() {
+				lastErr = fmt.Errorf("%w: %s", errNotRegularFile, exp)
 				log.Trace(ctx, "skipping non-regular global known_hosts file", log.KeyFile, exp)
 				continue
 			}

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -355,6 +355,10 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 	var khPath string
 
 	for _, f := range c.sshConfig.UserKnownHostsFile {
+		if strings.EqualFold(f, "none") {
+			// "none" is the OpenSSH special value meaning "ignore user known_hosts"
+			break
+		}
 		log.Trace(ctx, "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
 		exp, err := homedir.Expand(f)
 		if err == nil {

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -312,6 +312,14 @@ func knownhostsCallback(path string, permissive, hash bool) (ssh.HostKeyCallback
 	return cb, nil
 }
 
+func knownhostsGlobalCallback(path string, permissive bool) (ssh.HostKeyCallback, error) {
+	cb, err := hostkey.KnownHostsReadOnlyFileCallback(path, permissive)
+	if err != nil {
+		return nil, fmt.Errorf("%w: create host key validator: %w", protocol.ErrNonRetryable, err)
+	}
+	return cb, nil
+}
+
 func isPermissive(ctx context.Context, c *Connection) bool {
 	if c.sshConfig.StrictHostKeyChecking.IsFalse() {
 		log.Trace(ctx, "config StrictHostkeyChecking is set to 'no'", log.KeyHost, c)
@@ -358,6 +366,25 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 	if khPath != "" {
 		log.Trace(ctx, "using known_hosts file", log.KeyHost, c, log.KeyFile, khPath)
 		return knownhostsCallback(khPath, permissive, hash)
+	}
+
+	for _, f := range c.sshConfig.GlobalKnownHostsFile {
+		log.Trace(ctx, "trying global known_hosts file", log.KeyHost, c, log.KeyFile, f)
+		exp, err := homedir.Expand(f)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(exp); err != nil {
+			log.Trace(ctx, "skipping missing global known_hosts file", log.KeyHost, c, log.KeyFile, exp)
+			continue
+		}
+		khPath = exp
+		break
+	}
+
+	if khPath != "" {
+		log.Trace(ctx, "using global known_hosts file", log.KeyHost, c, log.KeyFile, khPath)
+		return knownhostsGlobalCallback(khPath, permissive)
 	}
 
 	return nil, fmt.Errorf("%w: no known_hosts file found", protocol.ErrNonRetryable)

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -372,30 +372,44 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 		return knownhostsCallback(khPath, permissive, hash)
 	}
 
-	for _, f := range c.sshConfig.GlobalKnownHostsFile {
-		log.Trace(ctx, "trying global known_hosts file", log.KeyHost, c, log.KeyFile, f)
+	return globalKnownHostsCallback(ctx, c.sshConfig.GlobalKnownHostsFile, permissive)
+}
+
+func globalKnownHostsCallback(ctx context.Context, paths []string, permissive bool) (ssh.HostKeyCallback, error) {
+	var lastErr error
+	for _, f := range paths {
+		log.Trace(ctx, "trying global known_hosts file", log.KeyFile, f)
 		exp, err := homedir.Expand(f)
 		if err != nil {
 			continue
 		}
-		stat, err := os.Stat(exp)
-		if err != nil {
-			log.Trace(ctx, "skipping global known_hosts file", log.KeyHost, c, log.KeyFile, exp, log.KeyError, err)
-			continue
-		}
-		if !stat.Mode().IsRegular() {
-			log.Trace(ctx, "skipping non-regular global known_hosts file", log.KeyHost, c, log.KeyFile, exp)
-			continue
+		if exp != "/dev/null" {
+			stat, err := os.Stat(exp)
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					lastErr = err
+				}
+				log.Trace(ctx, "skipping global known_hosts file", log.KeyFile, exp, log.KeyError, err)
+				continue
+			}
+			if !stat.Mode().IsRegular() {
+				log.Trace(ctx, "skipping non-regular global known_hosts file", log.KeyFile, exp)
+				continue
+			}
 		}
 		cb, err := knownhostsGlobalCallback(exp, permissive)
 		if err != nil {
-			log.Trace(ctx, "skipping unusable global known_hosts file", log.KeyHost, c, log.KeyFile, exp, log.KeyError, err)
+			lastErr = err
+			log.Trace(ctx, "skipping unusable global known_hosts file", log.KeyFile, exp, log.KeyError, err)
 			continue
 		}
-		log.Trace(ctx, "using global known_hosts file", log.KeyHost, c, log.KeyFile, exp)
+		log.Trace(ctx, "using global known_hosts file", log.KeyFile, exp)
 		return cb, nil
 	}
 
+	if lastErr != nil {
+		return nil, fmt.Errorf("%w: global known_hosts: %w", protocol.ErrNonRetryable, lastErr)
+	}
 	return nil, fmt.Errorf("%w: no known_hosts file found", protocol.ErrNonRetryable)
 }
 

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -370,16 +370,10 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 		for _, f := range c.sshConfig.UserKnownHostsFile {
 			log.Trace(ctx, "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
 			exp, err := homedir.Expand(f)
-			if err != nil {
-				continue
+			if err == nil {
+				khPath = exp
+				break
 			}
-			stat, err := os.Stat(exp)
-			if err != nil || !stat.Mode().IsRegular() {
-				log.Trace(ctx, "skipping user known_hosts file", log.KeyHost, c, log.KeyFile, exp)
-				continue
-			}
-			khPath = exp
-			break
 		}
 	}
 

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -359,14 +359,7 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 
 	// "none" anywhere in the list disables user known_hosts entirely; check
 	// the full list before committing to any path.
-	noneSet := false
-	for _, f := range c.sshConfig.UserKnownHostsFile {
-		if strings.EqualFold(f, "none") {
-			noneSet = true
-			break
-		}
-	}
-	if !noneSet {
+	if !slices.Contains(c.sshConfig.UserKnownHostsFile, "none") {
 		for _, f := range c.sshConfig.UserKnownHostsFile {
 			log.Trace(ctx, "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
 			exp, err := homedir.Expand(f)

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -581,7 +581,9 @@ func unsetKnownHostsEnv(t *testing.T) {
 	require.NoError(t, os.Unsetenv("SSH_KNOWN_HOSTS"))
 	t.Cleanup(func() {
 		if ok {
-			_ = os.Setenv("SSH_KNOWN_HOSTS", prev)
+			require.NoError(t, os.Setenv("SSH_KNOWN_HOSTS", prev))
+		} else {
+			require.NoError(t, os.Unsetenv("SSH_KNOWN_HOSTS"))
 		}
 	})
 }

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -607,6 +607,27 @@ func TestHostkeyCallbackUserNoneFallsBackToGlobalKnownHostsFile(t *testing.T) {
 	require.NotNil(t, cb)
 }
 
+func TestHostkeyCallbackUserNoneAfterValidPathFallsBackToGlobal(t *testing.T) {
+	unsetKnownHostsEnv(t)
+
+	userKH := filepath.Join(t.TempDir(), "user_known_hosts")
+	require.NoError(t, os.WriteFile(userKH, []byte(""), 0o600))
+	globalKH := filepath.Join(t.TempDir(), "ssh_known_hosts")
+	require.NoError(t, os.WriteFile(globalKH, []byte(""), 0o600))
+
+	c := &Connection{
+		sshConfig: &sshconfig.Config{
+			// "none" after a valid path must still disable user known_hosts.
+			UserKnownHostsFile:   []string{userKH, "none"},
+			GlobalKnownHostsFile: []string{globalKH},
+		},
+	}
+
+	cb, err := c.hostkeyCallback(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, cb)
+}
+
 func TestHostkeyCallbackFallsBackToGlobalKnownHostsFile(t *testing.T) {
 	unsetKnownHostsEnv(t)
 

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -628,6 +628,26 @@ func TestHostkeyCallbackUserNoneAfterValidPathFallsBackToGlobal(t *testing.T) {
 	require.NotNil(t, cb)
 }
 
+func TestHostkeyCallbackMissingUserFileFallsBackToGlobal(t *testing.T) {
+	unsetKnownHostsEnv(t)
+
+	missing := filepath.Join(t.TempDir(), "user_known_hosts")
+	globalKH := filepath.Join(t.TempDir(), "ssh_known_hosts")
+	require.NoError(t, os.WriteFile(globalKH, []byte(""), 0o600))
+
+	c := &Connection{
+		sshConfig: &sshconfig.Config{
+			// Default path exists in config but the file is absent on disk.
+			UserKnownHostsFile:   []string{missing},
+			GlobalKnownHostsFile: []string{globalKH},
+		},
+	}
+
+	cb, err := c.hostkeyCallback(context.Background())
+	require.NoError(t, err, "missing user known_hosts must fall back to GlobalKnownHostsFile")
+	require.NotNil(t, cb)
+}
+
 func TestHostkeyCallbackFallsBackToGlobalKnownHostsFile(t *testing.T) {
 	unsetKnownHostsEnv(t)
 

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -571,3 +571,69 @@ func TestClientConfigRekeyLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(1024*1024), cfg.RekeyThreshold)
 }
+
+// unsetKnownHostsEnv ensures SSH_KNOWN_HOSTS is not set for the duration of the
+// test so the UserKnownHostsFile/GlobalKnownHostsFile resolution path is
+// exercised instead of the environment override.
+func unsetKnownHostsEnv(t *testing.T) {
+	t.Helper()
+	prev, ok := os.LookupEnv("SSH_KNOWN_HOSTS")
+	require.NoError(t, os.Unsetenv("SSH_KNOWN_HOSTS"))
+	t.Cleanup(func() {
+		if ok {
+			_ = os.Setenv("SSH_KNOWN_HOSTS", prev)
+		}
+	})
+}
+
+func TestHostkeyCallbackFallsBackToGlobalKnownHostsFile(t *testing.T) {
+	unsetKnownHostsEnv(t)
+
+	khPath := filepath.Join(t.TempDir(), "ssh_known_hosts")
+	require.NoError(t, os.WriteFile(khPath, []byte(""), 0o600))
+
+	c := &Connection{
+		sshConfig: &sshconfig.Config{
+			// No user known_hosts file: resolution must fall through.
+			UserKnownHostsFile:   []string{},
+			GlobalKnownHostsFile: []string{khPath},
+		},
+	}
+
+	cb, err := c.hostkeyCallback(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, cb)
+}
+
+func TestHostkeyCallbackNoKnownHostsFile(t *testing.T) {
+	unsetKnownHostsEnv(t)
+
+	c := &Connection{
+		sshConfig: &sshconfig.Config{
+			UserKnownHostsFile:   []string{},
+			GlobalKnownHostsFile: []string{},
+		},
+	}
+
+	_, err := c.hostkeyCallback(context.Background())
+	require.Error(t, err)
+}
+
+func TestHostkeyCallbackSkipsMissingGlobalKnownHostsFile(t *testing.T) {
+	unsetKnownHostsEnv(t)
+
+	missing := filepath.Join(t.TempDir(), "nonexistent_known_hosts")
+
+	c := &Connection{
+		sshConfig: &sshconfig.Config{
+			UserKnownHostsFile:   []string{},
+			GlobalKnownHostsFile: []string{missing},
+		},
+	}
+
+	_, err := c.hostkeyCallback(context.Background())
+	require.Error(t, err, "missing global known_hosts must not be created — should fall through to error")
+
+	_, statErr := os.Stat(missing)
+	require.True(t, os.IsNotExist(statErr), "hostkeyCallback must not create missing global known_hosts files")
+}

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -588,6 +588,25 @@ func unsetKnownHostsEnv(t *testing.T) {
 	})
 }
 
+func TestHostkeyCallbackUserNoneFallsBackToGlobalKnownHostsFile(t *testing.T) {
+	unsetKnownHostsEnv(t)
+
+	khPath := filepath.Join(t.TempDir(), "ssh_known_hosts")
+	require.NoError(t, os.WriteFile(khPath, []byte(""), 0o600))
+
+	c := &Connection{
+		sshConfig: &sshconfig.Config{
+			// "none" is the OpenSSH sentinel meaning "skip user known_hosts".
+			UserKnownHostsFile:   []string{"none"},
+			GlobalKnownHostsFile: []string{khPath},
+		},
+	}
+
+	cb, err := c.hostkeyCallback(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, cb)
+}
+
 func TestHostkeyCallbackFallsBackToGlobalKnownHostsFile(t *testing.T) {
 	unsetKnownHostsEnv(t)
 

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -628,26 +628,6 @@ func TestHostkeyCallbackUserNoneAfterValidPathFallsBackToGlobal(t *testing.T) {
 	require.NotNil(t, cb)
 }
 
-func TestHostkeyCallbackMissingUserFileFallsBackToGlobal(t *testing.T) {
-	unsetKnownHostsEnv(t)
-
-	missing := filepath.Join(t.TempDir(), "user_known_hosts")
-	globalKH := filepath.Join(t.TempDir(), "ssh_known_hosts")
-	require.NoError(t, os.WriteFile(globalKH, []byte(""), 0o600))
-
-	c := &Connection{
-		sshConfig: &sshconfig.Config{
-			// Default path exists in config but the file is absent on disk.
-			UserKnownHostsFile:   []string{missing},
-			GlobalKnownHostsFile: []string{globalKH},
-		},
-	}
-
-	cb, err := c.hostkeyCallback(context.Background())
-	require.NoError(t, err, "missing user known_hosts must fall back to GlobalKnownHostsFile")
-	require.NotNil(t, cb)
-}
-
 func TestHostkeyCallbackFallsBackToGlobalKnownHostsFile(t *testing.T) {
 	unsetKnownHostsEnv(t)
 

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -149,6 +149,10 @@ func wrapReadOnlyCallback(hkc ssh.HostKeyCallback, permissive bool) ssh.HostKeyC
 		var keyErr *knownhosts.KeyError
 		if !errors.As(err, &keyErr) {
 			// unexpected error unrelated to key matching (e.g. address parsing, IO)
+			if permissive {
+				fmt.Fprintln(os.Stderr, "Ignored an SSH host key error for", remote, "because StrictHostKeyChecking is set to 'no' in ssh config")
+				return nil
+			}
 			return fmt.Errorf("%w: %w", ErrHostKeyMismatch, err)
 		}
 		if len(keyErr.Want) > 0 {

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -75,7 +75,11 @@ func KnownHostsReadOnlyFileCallback(path string, permissive bool) (ssh.HostKeyCa
 		return InsecureIgnoreHostKeyCallback, nil
 	}
 
-	if !fileExists(path) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrCheckHostKey, err)
+	}
+	if !stat.Mode().IsRegular() {
 		return nil, fmt.Errorf("%w: %s is not a regular file", ErrCheckHostKey, path)
 	}
 

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -143,8 +143,12 @@ func wrapReadOnlyCallback(hkc ssh.HostKeyCallback, permissive bool) ssh.HostKeyC
 		}
 
 		var keyErr *knownhosts.KeyError
-		if !errors.As(err, &keyErr) || len(keyErr.Want) > 0 {
-			// non-empty Want means key mismatch
+		if !errors.As(err, &keyErr) {
+			// unexpected error unrelated to key matching (e.g. address parsing, IO)
+			return fmt.Errorf("%w: %w", ErrCheckHostKey, err)
+		}
+		if len(keyErr.Want) > 0 {
+			// non-empty Want means a known host presented a different key
 			if permissive {
 				fmt.Fprintln(os.Stderr, "Ignored an SSH host key mismatch for", remote, "because StrictHostkeyChecking is set to 'no' in ssh config")
 				return nil
@@ -156,7 +160,7 @@ func wrapReadOnlyCallback(hkc ssh.HostKeyCallback, permissive bool) ssh.HostKeyC
 		if permissive {
 			return nil
 		}
-		return err
+		return fmt.Errorf("%w: %w", ErrHostKeyMismatch, err)
 	})
 }
 

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -71,6 +71,10 @@ func KnownHostsFileCallback(path string, permissive, hash bool) (ssh.HostKeyCall
 // This is appropriate for system-wide files such as /etc/ssh/ssh_known_hosts that
 // should not be modified by unprivileged users.
 func KnownHostsReadOnlyFileCallback(path string, permissive bool) (ssh.HostKeyCallback, error) {
+	if path == "/dev/null" {
+		return InsecureIgnoreHostKeyCallback, nil
+	}
+
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -75,6 +75,10 @@ func KnownHostsReadOnlyFileCallback(path string, permissive bool) (ssh.HostKeyCa
 		return InsecureIgnoreHostKeyCallback, nil
 	}
 
+	if !fileExists(path) {
+		return nil, fmt.Errorf("%w: %s is not a regular file", ErrCheckHostKey, path)
+	}
+
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -164,7 +164,7 @@ func wrapReadOnlyCallback(hkc ssh.HostKeyCallback, permissive bool) ssh.HostKeyC
 		if permissive {
 			return nil
 		}
-		return fmt.Errorf("%w: %w", ErrHostKeyMismatch, err)
+		return fmt.Errorf("%w: unknown host: %w", ErrHostKeyMismatch, err)
 	})
 }
 

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -101,7 +101,7 @@ func wrapCallback(hkc ssh.HostKeyCallback, path string, permissive, hash bool) s
 			// keyErr.Want is empty if the host key is not in the known_hosts file
 			// non-empty is a mismatch
 			if permissive {
-				fmt.Fprintln(os.Stderr, "Ignored an SSH host key mismatch for", remote, "because StrictHostkeyChecking is set to 'no' in ssh config")
+				fmt.Fprintln(os.Stderr, "Ignored an SSH host key mismatch for", remote, "because StrictHostKeyChecking is set to 'no' in ssh config")
 				return nil
 			}
 			return fmt.Errorf("%w: %w", ErrHostKeyMismatch, err)
@@ -150,7 +150,7 @@ func wrapReadOnlyCallback(hkc ssh.HostKeyCallback, permissive bool) ssh.HostKeyC
 		if len(keyErr.Want) > 0 {
 			// non-empty Want means a known host presented a different key
 			if permissive {
-				fmt.Fprintln(os.Stderr, "Ignored an SSH host key mismatch for", remote, "because StrictHostkeyChecking is set to 'no' in ssh config")
+				fmt.Fprintln(os.Stderr, "Ignored an SSH host key mismatch for", remote, "because StrictHostKeyChecking is set to 'no' in ssh config")
 				return nil
 			}
 			return fmt.Errorf("%w: %w", ErrHostKeyMismatch, err)

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -149,7 +149,7 @@ func wrapReadOnlyCallback(hkc ssh.HostKeyCallback, permissive bool) ssh.HostKeyC
 		var keyErr *knownhosts.KeyError
 		if !errors.As(err, &keyErr) {
 			// unexpected error unrelated to key matching (e.g. address parsing, IO)
-			return fmt.Errorf("%w: %w", ErrCheckHostKey, err)
+			return fmt.Errorf("%w: %w", ErrHostKeyMismatch, err)
 		}
 		if len(keyErr.Want) > 0 {
 			// non-empty Want means a known host presented a different key

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -66,6 +66,22 @@ func KnownHostsFileCallback(path string, permissive, hash bool) (ssh.HostKeyCall
 	return wrapCallback(hkc, path, permissive, hash), nil
 }
 
+// KnownHostsReadOnlyFileCallback returns a HostKeyCallback that only reads from
+// an existing known hosts file — it never creates the file or appends new entries.
+// This is appropriate for system-wide files such as /etc/ssh/ssh_known_hosts that
+// should not be modified by unprivileged users.
+func KnownHostsReadOnlyFileCallback(path string, permissive bool) (ssh.HostKeyCallback, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	hkc, err := knownhosts.New(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: knownhosts callback: %w", ErrCheckHostKey, err)
+	}
+
+	return wrapReadOnlyCallback(hkc, permissive), nil
+}
+
 // extends a knownhosts callback to not return an error when the key
 // is not found in the known_hosts file but instead adds it to the file as new
 // entry.
@@ -111,6 +127,36 @@ func wrapCallback(hkc ssh.HostKeyCallback, path string, permissive, hash bool) s
 			return fmt.Errorf("failed to close known_hosts file after writing: %w", err)
 		}
 		return nil
+	})
+}
+
+// wrapReadOnlyCallback wraps a knownhosts callback to reject unknown hosts
+// without writing to the file. When permissive is true, unknown hosts are
+// accepted silently instead of rejected.
+func wrapReadOnlyCallback(hkc ssh.HostKeyCallback, permissive bool) ssh.HostKeyCallback {
+	return ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		mu.Lock()
+		defer mu.Unlock()
+		err := hkc(hostname, remote, key)
+		if err == nil {
+			return nil
+		}
+
+		var keyErr *knownhosts.KeyError
+		if !errors.As(err, &keyErr) || len(keyErr.Want) > 0 {
+			// non-empty Want means key mismatch
+			if permissive {
+				fmt.Fprintln(os.Stderr, "Ignored an SSH host key mismatch for", remote, "because StrictHostkeyChecking is set to 'no' in ssh config")
+				return nil
+			}
+			return fmt.Errorf("%w: %w", ErrHostKeyMismatch, err)
+		}
+
+		// host not found in file — read-only mode cannot append new entries
+		if permissive {
+			return nil
+		}
+		return err
 	})
 }
 

--- a/protocol/ssh/hostkey/callbacks_test.go
+++ b/protocol/ssh/hostkey/callbacks_test.go
@@ -1,0 +1,86 @@
+package hostkey_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/protocol/ssh/hostkey"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+func newTestSigner(t *testing.T) ssh.Signer {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+	return signer
+}
+
+func TestKnownHostsReadOnlyFileCallbackDoesNotCreateFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "ssh_known_hosts")
+
+	_, err := hostkey.KnownHostsReadOnlyFileCallback(missing, false)
+	require.Error(t, err, "read-only callback must fail for a missing file, not create it")
+
+	_, statErr := os.Stat(missing)
+	require.True(t, os.IsNotExist(statErr), "read-only callback must not create the file")
+}
+
+func TestKnownHostsReadOnlyFileCallbackDoesNotAppendUnknownHost(t *testing.T) {
+	dir := t.TempDir()
+	khFile := filepath.Join(dir, "ssh_known_hosts")
+	require.NoError(t, os.WriteFile(khFile, []byte(""), 0o644))
+
+	cb, err := hostkey.KnownHostsReadOnlyFileCallback(khFile, false)
+	require.NoError(t, err)
+
+	signer := newTestSigner(t)
+	addr, _ := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+
+	cbErr := cb("192.0.2.1:22", addr, signer.PublicKey())
+	require.Error(t, cbErr, "unknown host must be rejected in strict mode")
+
+	contents, err := os.ReadFile(khFile)
+	require.NoError(t, err)
+	require.Empty(t, contents, "read-only callback must not append to the file")
+}
+
+func TestKnownHostsReadOnlyFileCallbackPermissiveAcceptsUnknownHost(t *testing.T) {
+	dir := t.TempDir()
+	khFile := filepath.Join(dir, "ssh_known_hosts")
+	require.NoError(t, os.WriteFile(khFile, []byte(""), 0o644))
+
+	cb, err := hostkey.KnownHostsReadOnlyFileCallback(khFile, true)
+	require.NoError(t, err)
+
+	signer := newTestSigner(t)
+	addr, _ := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+
+	require.NoError(t, cb("192.0.2.1:22", addr, signer.PublicKey()), "permissive mode must accept unknown host without error")
+
+	contents, err := os.ReadFile(khFile)
+	require.NoError(t, err)
+	require.Empty(t, contents, "permissive read-only callback must not append to the file")
+}
+
+func TestKnownHostsReadOnlyFileCallbackAcceptsKnownHost(t *testing.T) {
+	signer := newTestSigner(t)
+
+	dir := t.TempDir()
+	khFile := filepath.Join(dir, "ssh_known_hosts")
+	line := knownhosts.Line([]string{"192.0.2.1:22"}, signer.PublicKey())
+	require.NoError(t, os.WriteFile(khFile, []byte(line+"\n"), 0o644))
+
+	cb, err := hostkey.KnownHostsReadOnlyFileCallback(khFile, false)
+	require.NoError(t, err)
+
+	addr, _ := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, cb("192.0.2.1:22", addr, signer.PublicKey()))
+}

--- a/protocol/ssh/hostkey/callbacks_test.go
+++ b/protocol/ssh/hostkey/callbacks_test.go
@@ -42,7 +42,8 @@ func TestKnownHostsReadOnlyFileCallbackDoesNotAppendUnknownHost(t *testing.T) {
 	require.NoError(t, err)
 
 	signer := newTestSigner(t)
-	addr, _ := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
 
 	cbErr := cb("192.0.2.1:22", addr, signer.PublicKey())
 	require.Error(t, cbErr, "unknown host must be rejected in strict mode")
@@ -61,7 +62,8 @@ func TestKnownHostsReadOnlyFileCallbackPermissiveAcceptsUnknownHost(t *testing.T
 	require.NoError(t, err)
 
 	signer := newTestSigner(t)
-	addr, _ := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
 
 	require.NoError(t, cb("192.0.2.1:22", addr, signer.PublicKey()), "permissive mode must accept unknown host without error")
 
@@ -79,7 +81,8 @@ func TestKnownHostsReadOnlyFileCallbackUnknownHostIsHostKeyMismatch(t *testing.T
 	require.NoError(t, err)
 
 	signer := newTestSigner(t)
-	addr, _ := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
 
 	cbErr := cb("192.0.2.1:22", addr, signer.PublicKey())
 	require.ErrorIs(t, cbErr, hostkey.ErrHostKeyMismatch, "unknown host in read-only strict mode must return ErrHostKeyMismatch so callers treat it as non-retryable")
@@ -96,6 +99,7 @@ func TestKnownHostsReadOnlyFileCallbackAcceptsKnownHost(t *testing.T) {
 	cb, err := hostkey.KnownHostsReadOnlyFileCallback(khFile, false)
 	require.NoError(t, err)
 
-	addr, _ := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
 	require.NoError(t, cb("192.0.2.1:22", addr, signer.PublicKey()))
 }

--- a/protocol/ssh/hostkey/callbacks_test.go
+++ b/protocol/ssh/hostkey/callbacks_test.go
@@ -70,6 +70,21 @@ func TestKnownHostsReadOnlyFileCallbackPermissiveAcceptsUnknownHost(t *testing.T
 	require.Empty(t, contents, "permissive read-only callback must not append to the file")
 }
 
+func TestKnownHostsReadOnlyFileCallbackUnknownHostIsHostKeyMismatch(t *testing.T) {
+	dir := t.TempDir()
+	khFile := filepath.Join(dir, "ssh_known_hosts")
+	require.NoError(t, os.WriteFile(khFile, []byte(""), 0o644))
+
+	cb, err := hostkey.KnownHostsReadOnlyFileCallback(khFile, false)
+	require.NoError(t, err)
+
+	signer := newTestSigner(t)
+	addr, _ := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+
+	cbErr := cb("192.0.2.1:22", addr, signer.PublicKey())
+	require.ErrorIs(t, cbErr, hostkey.ErrHostKeyMismatch, "unknown host in read-only strict mode must return ErrHostKeyMismatch so callers treat it as non-retryable")
+}
+
 func TestKnownHostsReadOnlyFileCallbackAcceptsKnownHost(t *testing.T) {
 	signer := newTestSigner(t)
 

--- a/protocol/ssh/hostkey/callbacks_test.go
+++ b/protocol/ssh/hostkey/callbacks_test.go
@@ -93,7 +93,7 @@ func TestKnownHostsReadOnlyFileCallbackAcceptsKnownHost(t *testing.T) {
 
 	dir := t.TempDir()
 	khFile := filepath.Join(dir, "ssh_known_hosts")
-	line := knownhosts.Line([]string{"192.0.2.1:22"}, signer.PublicKey())
+	line := knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, signer.PublicKey())
 	require.NoError(t, os.WriteFile(khFile, []byte(line+"\n"), 0o644))
 
 	cb, err := hostkey.KnownHostsReadOnlyFileCallback(khFile, false)


### PR DESCRIPTION
Uses GlobalKnownHostsFile when user known_hosts is absent