### PR TITLE
feat(ssh): add SSHConfigOptions to set sshconfig options

### DIFF
--- a/docs/ssh-config-precedence.md
+++ b/docs/ssh-config-precedence.md
@@ -3,8 +3,9 @@
 When the pure-Go SSH protocol establishes a connection it builds its effective
 configuration from three sources, in decreasing priority order:
 
-1. **Native fields** (`address`, `user`, `port`, `keyPath`, …)
-   Strongly-typed fields on `ssh.Config`. These always win.
+1. **Native fields** (`address`, `user`, `keyPath`, …)
+   Strongly-typed fields on `ssh.Config`. Once set to a non-empty/non-zero
+   value these win over all other sources.
 
 2. **`options`** (`ssh.Config.SSHConfigOptions`, YAML key `options`)
    A map of raw ssh_config directives, e.g. `{"Ciphers": "aes128-ctr"}`.
@@ -26,14 +27,19 @@ ssh:
   # for this host if not already provided above
 ```
 
-## Native field defaults
+## Native field defaults and port handling
 
-Native fields carry Go struct defaults (e.g. `user` defaults to `root`,
-`port` defaults to `22`). Because native fields have the highest priority,
-these defaults also win over `options` and `~/.ssh/config`. If you need
-`~/.ssh/config` or `options` to control a value that has a native
-equivalent, set the native field explicitly to its zero/empty value in your
-configuration.
+Several native fields carry Go struct defaults applied before precedence is
+evaluated (e.g. `user` defaults to `root`). Once defaults are applied the
+field is no longer empty, so it wins over `options` and `~/.ssh/config`
+just like an explicitly set value would.
+
+`port` is a special case: a port of `22` (the SSH default, whether explicit
+or filled in by the Go zero value) is intentionally treated as "not
+explicitly set" and does **not** propagate into the ssh_config layer. This
+means `~/.ssh/config` can still supply a per-host port when the rig
+configuration leaves `port` at `22` or omits it entirely. Set `port` to any
+other value to have it take precedence over `~/.ssh/config`.
 
 ## OpenSSH protocol
 

--- a/docs/ssh-config-precedence.md
+++ b/docs/ssh-config-precedence.md
@@ -1,0 +1,42 @@
+# SSH Configuration Precedence
+
+When the pure-Go SSH protocol establishes a connection it builds its effective
+configuration from three sources, in decreasing priority order:
+
+1. **Native fields** (`address`, `user`, `port`, `keyPath`, …)
+   Strongly-typed fields on `ssh.Config`. These always win.
+
+2. **`options`** (`ssh.Config.SSHConfigOptions`, YAML key `options`)
+   A map of raw ssh_config directives, e.g. `{"Ciphers": "aes128-ctr"}`.
+   Applied after native fields; fills gaps they leave.
+
+3. **`~/.ssh/config`** (read by `sshconfig.ConfigParser` when enabled)
+   Applied last, filling whatever the two sources above did not set.
+
+## Example
+
+```yaml
+ssh:
+  address: 192.0.2.1
+  user: deploy          # native field — highest priority
+  options:
+    ServerAliveInterval: 30   # fills a gap; no native equivalent
+    Ciphers: aes128-ctr
+  # ~/.ssh/config may supply IdentityFile, KnownHostsFile, etc.
+  # for this host if not already provided above
+```
+
+## Native field defaults
+
+Native fields carry Go struct defaults (e.g. `user` defaults to `root`,
+`port` defaults to `22`). Because native fields have the highest priority,
+these defaults also win over `options` and `~/.ssh/config`. If you need
+`~/.ssh/config` or `options` to control a value that has a native
+equivalent, set the native field explicitly to its zero/empty value in your
+configuration.
+
+## OpenSSH protocol
+
+The OpenSSH (`protocol/openssh`) variant passes options directly to the
+`ssh` binary as `-o Key=Value` flags, so the precedence rules are those of
+OpenSSH itself. The `options` YAML key is the same (`openssh.Config.Options`).

--- a/protocol/openssh/config.go
+++ b/protocol/openssh/config.go
@@ -60,8 +60,3 @@ func (c *Config) Validate() error {
 
 	return nil
 }
-
-// OptionArguments is an alias for [sshconfig.OptionArguments].
-//
-// Deprecated: Use [sshconfig.OptionArguments] directly.
-type OptionArguments = sshconfig.OptionArguments

--- a/protocol/openssh/config.go
+++ b/protocol/openssh/config.go
@@ -2,23 +2,23 @@ package openssh
 
 import (
 	"fmt"
-	"maps"
 	"net"
 	"strconv"
 
 	"github.com/k0sproject/rig/v2/homedir"
 	"github.com/k0sproject/rig/v2/protocol"
+	"github.com/k0sproject/rig/v2/sshconfig"
 )
 
 // Config describes the configuration options for an OpenSSH connection.
 type Config struct {
-	Address             string          `yaml:"address" validate:"required"`
-	User                *string         `yaml:"user"`
-	Port                *int            `yaml:"port"`
-	KeyPath             *string         `yaml:"keyPath,omitempty"`
-	ConfigPath          *string         `yaml:"configPath,omitempty"`
-	Options             OptionArguments `yaml:"options,omitempty"`
-	DisableMultiplexing bool            `yaml:"disableMultiplexing,omitempty"`
+	Address             string                    `yaml:"address" validate:"required"`
+	User                *string                   `yaml:"user"`
+	Port                *int                      `yaml:"port"`
+	KeyPath             *string                   `yaml:"keyPath,omitempty"`
+	ConfigPath          *string                   `yaml:"configPath,omitempty"`
+	Options             sshconfig.OptionArguments `yaml:"options,omitempty"`
+	DisableMultiplexing bool                      `yaml:"disableMultiplexing,omitempty"`
 }
 
 // Connection returns a new OpenSSH connection based on the configuration.
@@ -61,48 +61,7 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// OptionArguments are options for the OpenSSH client. For example StrictHostkeyChecking: false becomes -o StrictHostKeyChecking=no.
-type OptionArguments map[string]any
-
-// Copy returns a copy of the options.
-func (o OptionArguments) Copy() OptionArguments {
-	dup := make(OptionArguments, len(o))
-	maps.Copy(dup, o)
-	return dup
-}
-
-// Set sets an option key to value.
-func (o OptionArguments) Set(key string, value any) {
-	o[key] = value
-}
-
-// SetIfUnset sets the option if it's not already set.
-func (o OptionArguments) SetIfUnset(key string, value any) {
-	if o.IsSet(key) {
-		return
-	}
-	o.Set(key, value)
-}
-
-// IsSet returns true if the option is set.
-func (o OptionArguments) IsSet(key string) bool {
-	_, ok := o[key]
-	return ok
-}
-
-// ToArgs converts the options to command line arguments.
-func (o OptionArguments) ToArgs() []string {
-	args := make([]string, 0, len(o)*2)
-	for k, v := range o {
-		if b, ok := v.(bool); ok {
-			if b {
-				args = append(args, "-o", k+"=yes")
-			} else {
-				args = append(args, "-o", k+"=no")
-			}
-			continue
-		}
-		args = append(args, "-o", fmt.Sprintf("%s=%v", k, v))
-	}
-	return args
-}
+// OptionArguments is an alias for [sshconfig.OptionArguments].
+//
+// Deprecated: Use [sshconfig.OptionArguments] directly.
+type OptionArguments = sshconfig.OptionArguments

--- a/protocol/openssh/connection.go
+++ b/protocol/openssh/connection.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/k0sproject/rig/v2/log"
 	"github.com/k0sproject/rig/v2/protocol"
+	"github.com/k0sproject/rig/v2/sshconfig"
 )
 
 var (
@@ -110,7 +111,7 @@ func (c *Connection) IsWindows() bool {
 }
 
 // DefaultOptionArguments are the default options for the OpenSSH client.
-var DefaultOptionArguments = OptionArguments{
+var DefaultOptionArguments = sshconfig.OptionArguments{
 	// It's easy to end up with control paths that are too long for unix sockets (104 chars?)
 	// with the default ~/.ssh/master-%r@%h:%p, for example something like:
 	// /Users/user/.ssh/master-ec2-xx-xx-xx-xx.eu-central-1.compute.amazonaws.com-centos.AAZFTHkT5....
@@ -130,7 +131,7 @@ var DefaultOptionArguments = OptionArguments{
 // SetDefaults sets default values.
 func (c *Connection) SetDefaults() {
 	if c.Options == nil {
-		c.Options = make(OptionArguments)
+		c.Options = make(sshconfig.OptionArguments)
 	}
 	for k, v := range DefaultOptionArguments {
 		if v == nil {

--- a/protocol/openssh/connection.go
+++ b/protocol/openssh/connection.go
@@ -133,16 +133,23 @@ func (c *Connection) SetDefaults() {
 	if c.Options == nil {
 		c.Options = make(sshconfig.OptionArguments)
 	}
-	for k, v := range DefaultOptionArguments {
-		if v == nil {
-			delete(c.Options, k)
+	for key, val := range DefaultOptionArguments {
+		if val == nil {
+			delete(c.Options, key)
+			c.Log().Debug("removing option (default is nil/delete)", "key", key)
 			continue
 		}
-		c.Options.SetIfUnset(k, v)
+		if c.Options.IsSet(key) {
+			c.Log().Debug("keeping user-supplied option (skipping default)", "key", key, "value", c.Options[key])
+			continue
+		}
+		c.Options.SetIfUnset(key, val)
+		c.Log().Debug("applied default option", "key", key, "value", val)
 	}
 	if c.DisableMultiplexing {
 		delete(c.Options, "ControlMaster")
 		delete(c.Options, "ControlPath")
+		c.Log().Debug("multiplexing disabled — removed ControlMaster and ControlPath")
 	}
 }
 

--- a/protocol/openssh/connection.go
+++ b/protocol/openssh/connection.go
@@ -140,11 +140,11 @@ func (c *Connection) SetDefaults() {
 			continue
 		}
 		if c.Options.IsSet(key) {
-			c.Log().Debug("keeping user-supplied option (skipping default)", "key", key, "value", c.Options[key])
+			c.Log().Debug("keeping user-supplied option (skipping default)", "key", key)
 			continue
 		}
 		c.Options.SetIfUnset(key, val)
-		c.Log().Debug("applied default option", "key", key, "value", val)
+		c.Log().Debug("applied default option", "key", key)
 	}
 	if c.DisableMultiplexing {
 		delete(c.Options, "ControlMaster")

--- a/protocol/ssh/config.go
+++ b/protocol/ssh/config.go
@@ -25,13 +25,16 @@ type Config struct {
 	Bastion              *Config          `yaml:"bastion,omitempty"`
 	PasswordCallback     PasswordCallback `yaml:"-"`
 
-	// SSHConfigOptions sets ssh_config options that take effect before the user's
-	// ~/.ssh/config is applied. Keys are ssh_config directive names (case-insensitive),
-	// e.g. {"Ciphers": "aes128-ctr", "StrictHostKeyChecking": false}. Booleans are
-	// accepted for options that take yes/no values. Only options that rig reads from the
-	// config are acted upon; others are stored but silently ignored at connection time.
-	// An unknown key name is an error.
-	SSHConfigOptions sshconfig.OptionArguments `yaml:"sshConfigOptions,omitempty"`
+	// SSHConfigOptions provides supplementary ssh_config options that fill gaps not
+	// covered by the native fields above. They take priority over ~/.ssh/config but
+	// yield to any native field that is explicitly set. Keys are ssh_config directive
+	// names (case-insensitive), e.g. {"Ciphers": "aes128-ctr", "StrictHostKeyChecking": false}.
+	// Booleans are accepted for options that take yes/no values. Only options that rig
+	// reads from the config are acted upon; others are stored but silently ignored at
+	// connection time. An unknown key name is an error.
+	// See docs/ssh-config-precedence.md for the full precedence rules.
+	// YAML key: options.
+	SSHConfigOptions sshconfig.OptionArguments `yaml:"options,omitempty"`
 
 	// AuthMethods can be used to pass in a list of crypto/ssh.AuthMethod objects
 	// for example to use a private key from memory:

--- a/protocol/ssh/config.go
+++ b/protocol/ssh/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/k0sproject/rig/v2/homedir"
 	"github.com/k0sproject/rig/v2/log"
 	"github.com/k0sproject/rig/v2/protocol"
+	"github.com/k0sproject/rig/v2/sshconfig"
 	ssh "golang.org/x/crypto/ssh"
 )
 
@@ -23,6 +24,14 @@ type Config struct {
 	KeyPath              *string          `yaml:"keyPath" validate:"omitempty"`
 	Bastion              *Config          `yaml:"bastion,omitempty"`
 	PasswordCallback     PasswordCallback `yaml:"-"`
+
+	// SSHConfigOptions sets ssh_config options that take effect before the user's
+	// ~/.ssh/config is applied. Keys are ssh_config directive names (case-insensitive),
+	// e.g. {"Ciphers": "aes128-ctr", "StrictHostKeyChecking": false}. Booleans are
+	// accepted for options that take yes/no values. Only options that rig reads from the
+	// config are acted upon; others are stored but silently ignored at connection time.
+	// An unknown key name is an error.
+	SSHConfigOptions sshconfig.OptionArguments `yaml:"sshConfigOptions,omitempty"`
 
 	// AuthMethods can be used to pass in a list of crypto/ssh.AuthMethod objects
 	// for example to use a private key from memory:

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -72,6 +72,17 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 		c.sshConfig.IdentityFile = []string{*c.KeyPath}
 	}
 
+	if len(c.SSHConfigOptions) > 0 {
+		setter, err := sshconfig.NewSetter(c.sshConfig)
+		if err != nil {
+			return nil, fmt.Errorf("create sshconfig setter: %w", err)
+		}
+		setter.ErrorOnUnknownFields = true
+		if err := c.SSHConfigOptions.ApplyTo(setter); err != nil {
+			return nil, fmt.Errorf("%w: %w", protocol.ErrValidationFailed, err)
+		}
+	}
+
 	if ConfigParser != nil {
 		if err := ConfigParser.Apply(c.sshConfig, c.Address); err != nil {
 			return nil, fmt.Errorf("failed to apply ssh config: %w", err)

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -180,7 +180,9 @@ func (c *Connection) keypathsFromConfig(ctx context.Context) []string {
 // SetDefaults sets various default values.
 func (c *Connection) SetDefaults(ctx context.Context) {
 	c.once.Do(func() {
-		c.Port = c.sshConfig.Port
+		if c.sshConfig.Port != 0 {
+			c.Port = c.sshConfig.Port
+		}
 
 		if c.sshConfig.Hostname != "" {
 			c.alias = c.Address

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -63,16 +63,22 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 		User: c.User,
 		Host: c.Address,
 	}
+	c.Log().Debug("building ssh config", "user", c.User, "host", c.Address)
 
 	if c.Port != 0 && c.Port != 22 {
 		c.sshConfig.Port = c.Port
+		c.Log().Debug("propagating explicit port to ssh config", "port", c.Port)
+	} else {
+		c.Log().Debug("port is default (22) — deferring to ssh config / ~/.ssh/config", "port", c.Port)
 	}
 
 	if c.KeyPath != nil {
 		c.sshConfig.IdentityFile = []string{*c.KeyPath}
+		c.Log().Debug("propagating key path to ssh config", "key_path", *c.KeyPath)
 	}
 
 	if len(c.SSHConfigOptions) > 0 {
+		c.Log().Debug("applying options to ssh config", "count", len(c.SSHConfigOptions))
 		setter, err := sshconfig.NewSetter(c.sshConfig)
 		if err != nil {
 			return nil, fmt.Errorf("create sshconfig setter: %w", err)
@@ -84,12 +90,14 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 	}
 
 	if ConfigParser != nil {
+		c.Log().Debug("applying ~/.ssh/config")
 		if err := ConfigParser.Apply(c.sshConfig, c.Address); err != nil {
 			return nil, fmt.Errorf("failed to apply ssh config: %w", err)
 		}
 	}
 
 	c.Port = c.sshConfig.Port
+	c.Log().Debug("resolved final port", "port", c.Port)
 
 	// If no explicit keepalive option was provided, honor ServerAliveInterval from the ssh config.
 	// Note: platform-embedded defaults are included (e.g. macOS defaults to 30s), so a rig binary
@@ -98,6 +106,7 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 	if options.KeepAliveInterval == nil && c.sshConfig.ServerAliveInterval > 0 {
 		d := c.sshConfig.ServerAliveInterval
 		options.KeepAliveInterval = &d
+		c.Log().Debug("enabling keepalive from ssh config ServerAliveInterval", "interval", d)
 	}
 
 	return c, nil

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -96,7 +96,9 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 		}
 	}
 
-	c.Port = c.sshConfig.Port
+	if c.sshConfig.Port != 0 {
+		c.Port = c.sshConfig.Port
+	}
 	c.Log().Debug("resolved final port", "port", c.Port)
 
 	// If no explicit keepalive option was provided, honor ServerAliveInterval from the ssh config.

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -553,6 +553,38 @@ func TestConnectDeadline(t *testing.T) {
 	})
 }
 
+func TestNewConnectionSSHConfigOptions(t *testing.T) {
+	t.Setenv("SSH_KNOWN_HOSTS", "")
+
+	prev := ConfigParser
+	ConfigParser = nil
+	t.Cleanup(func() { ConfigParser = prev })
+
+	t.Run("unknown option returns ErrValidationFailed", func(t *testing.T) {
+		_, err := NewConnection(Config{
+			Address:          "host.example.com",
+			Port:             22,
+			User:             "user",
+			SSHConfigOptions: sshconfig.OptionArguments{"NoSuchOption": "value"},
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, protocol.ErrValidationFailed)
+	})
+
+	t.Run("valid option is applied before ConfigParser", func(t *testing.T) {
+		withConfigParser(t, "Host *\n  Compression no\n")
+		conn, err := NewConnection(Config{
+			Address:          "host.example.com",
+			Port:             22,
+			User:             "user",
+			SSHConfigOptions: sshconfig.OptionArguments{"Compression": true},
+		})
+		require.NoError(t, err)
+		require.True(t, conn.sshConfig.Compression.IsTrue(),
+			"SSHConfigOptions must take precedence over ConfigParser")
+	})
+}
+
 func TestClientConfigRekeyLimit(t *testing.T) {
 	t.Setenv("SSH_KNOWN_HOSTS", "")
 

--- a/sshconfig/keys.go
+++ b/sshconfig/keys.go
@@ -1,6 +1,33 @@
 package sshconfig
 
-import "github.com/k0sproject/rig/v2/sshconfig/options"
+import (
+	"reflect"
+	"strings"
+
+	"github.com/k0sproject/rig/v2/sshconfig/options"
+)
+
+// csvKeyNames is the set of lowercase ssh_config key names whose values use
+// commas as the multi-value separator. Derived at init time from knownKeys by
+// matching keys whose printFunc is stringercsv.
+var csvKeyNames map[string]struct{}
+
+func init() {
+	target := reflect.ValueOf((*printer).stringercsv).Pointer()
+	csvKeyNames = make(map[string]struct{}, len(knownKeys))
+	for k, info := range knownKeys {
+		if info.printFunc != nil && reflect.ValueOf(info.printFunc).Pointer() == target {
+			csvKeyNames[k] = struct{}{}
+		}
+	}
+}
+
+// isCSVKey reports whether the named ssh_config directive uses comma as its
+// multi-value separator (e.g. Ciphers, KexAlgorithms, MACs, ProxyJump).
+func isCSVKey(key string) bool {
+	_, ok := csvKeyNames[strings.ToLower(key)]
+	return ok
+}
 
 type setterFunc func(setter *Setter, key string, values ...string) error
 

--- a/sshconfig/option_arguments.go
+++ b/sshconfig/option_arguments.go
@@ -6,8 +6,9 @@ import (
 )
 
 // OptionArguments holds ssh_config options as key-value pairs. Values may be
-// strings, booleans, or integers; booleans are rendered as "yes"/"no" when
-// converted to command-line arguments or applied to a Setter.
+// strings, booleans, integers, or other fmt-printable types. Booleans are
+// rendered as "yes"/"no" when converted to command-line arguments or applied
+// to a Setter. Setting a key to nil deletes it.
 //
 // It is used by both the OpenSSH and the pure-Go SSH protocol implementations:
 // the OpenSSH path renders options as "-o Key=Value" arguments via [OptionArguments.ToArgs];
@@ -21,8 +22,12 @@ func (o OptionArguments) Copy() OptionArguments {
 	return dup
 }
 
-// Set sets an option key to value.
+// Set sets an option key to value. A nil value deletes the key.
 func (o OptionArguments) Set(key string, value any) {
+	if value == nil {
+		delete(o, key)
+		return
+	}
 	o[key] = value
 }
 
@@ -44,16 +49,19 @@ func (o OptionArguments) IsSet(key string) bool {
 // suitable for passing to the openssh binary.
 func (o OptionArguments) ToArgs() []string {
 	args := make([]string, 0, len(o)*2)
-	for k, v := range o {
-		if b, ok := v.(bool); ok {
+	for key, val := range o {
+		if val == nil {
+			continue
+		}
+		if b, ok := val.(bool); ok {
 			if b {
-				args = append(args, "-o", k+"=yes")
+				args = append(args, "-o", key+"=yes")
 			} else {
-				args = append(args, "-o", k+"=no")
+				args = append(args, "-o", key+"=no")
 			}
 			continue
 		}
-		args = append(args, "-o", fmt.Sprintf("%s=%v", k, v))
+		args = append(args, "-o", fmt.Sprintf("%s=%v", key, val))
 	}
 	return args
 }
@@ -63,7 +71,13 @@ func (o OptionArguments) ToArgs() []string {
 // Returns an error if the setter rejects a value (e.g. bad format, or unknown
 // key when [Setter.ErrorOnUnknownFields] is set).
 func (o OptionArguments) ApplyTo(setter *Setter) error {
+	if setter == nil {
+		return nil
+	}
 	for key, v := range o {
+		if v == nil {
+			continue
+		}
 		var strVal string
 		switch tv := v.(type) {
 		case bool:

--- a/sshconfig/option_arguments.go
+++ b/sshconfig/option_arguments.go
@@ -3,6 +3,7 @@ package sshconfig
 import (
 	"fmt"
 	"maps"
+	"reflect"
 	"strings"
 )
 
@@ -62,10 +63,11 @@ func valToString(v any) string {
 	return fmt.Sprint(v)
 }
 
-// sliceToStrings converts a []string or []any value to a []string, returning
-// (nil, false) if v is not a slice type.
-func sliceToStrings(v any) ([]string, bool) {
-	switch tv := v.(type) {
+// sliceToStrings converts a slice value to a []string, returning (nil, false)
+// if val is not a slice type. Handles []string, []any, and any other slice type
+// by reflecting over the elements and converting each via [valToString].
+func sliceToStrings(val any) ([]string, bool) {
+	switch tv := val.(type) {
 	case []string:
 		out := make([]string, len(tv))
 		copy(out, tv)
@@ -77,7 +79,15 @@ func sliceToStrings(v any) ([]string, bool) {
 		}
 		return out, true
 	default:
-		return nil, false
+		rv := reflect.ValueOf(val)
+		if rv.Kind() != reflect.Slice {
+			return nil, false
+		}
+		out := make([]string, rv.Len())
+		for i := range rv.Len() {
+			out[i] = valToString(rv.Index(i).Interface())
+		}
+		return out, true
 	}
 }
 

--- a/sshconfig/option_arguments.go
+++ b/sshconfig/option_arguments.go
@@ -79,7 +79,8 @@ func sliceToStrings(v any) ([]string, bool) {
 
 // ToArgs converts the options to a list of "-o Key=Value" command-line arguments
 // suitable for passing to the openssh binary. Slice values are rendered as
-// space-separated tokens (e.g. []string{"/a", "/b"} → "Key=/a /b").
+// space-separated tokens for space-delimited directives (e.g. IdentityFile) and
+// comma-separated tokens for CSV directives (e.g. Ciphers, KexAlgorithms, MACs).
 func (o OptionArguments) ToArgs() []string {
 	args := make([]string, 0, len(o)*2)
 	for key, val := range o {
@@ -87,7 +88,11 @@ func (o OptionArguments) ToArgs() []string {
 			continue
 		}
 		if strs, ok := sliceToStrings(val); ok {
-			args = append(args, "-o", key+"="+strings.Join(strs, " "))
+			sep := " "
+			if isCSVKey(key) {
+				sep = ","
+			}
+			args = append(args, "-o", key+"="+strings.Join(strs, sep))
 			continue
 		}
 		args = append(args, "-o", key+"="+valToString(val))
@@ -96,23 +101,29 @@ func (o OptionArguments) ToArgs() []string {
 }
 
 // ApplyTo feeds each option into setter using [Setter.Set]. Booleans are
-// converted to "yes"/"no"; slice values are expanded into variadic arguments
-// so multi-valued directives (IdentityFile, SendEnv, etc.) work correctly.
+// converted to "yes"/"no"; for space-delimited directives (e.g. IdentityFile,
+// SendEnv) slice values are expanded into variadic arguments; for CSV
+// directives (e.g. Ciphers, KexAlgorithms, MACs) slice values are joined with
+// commas and passed as a single argument, matching what the setter expects.
 // Returns an error if the setter rejects a value (e.g. bad format, or unknown
 // key when [Setter.ErrorOnUnknownFields] is set).
 func (o OptionArguments) ApplyTo(setter *Setter) error {
 	if setter == nil {
 		return nil
 	}
-	for key, v := range o {
-		if v == nil {
+	for key, val := range o {
+		if val == nil {
 			continue
 		}
 		var err error
-		if strs, ok := sliceToStrings(v); ok {
-			err = setter.Set(key, strs...)
+		if strs, ok := sliceToStrings(val); ok {
+			if isCSVKey(key) {
+				err = setter.Set(key, strings.Join(strs, ","))
+			} else {
+				err = setter.Set(key, strs...)
+			}
 		} else {
-			err = setter.Set(key, valToString(v))
+			err = setter.Set(key, valToString(val))
 		}
 		if err != nil {
 			return fmt.Errorf("ssh option %q: %w", key, err)

--- a/sshconfig/option_arguments.go
+++ b/sshconfig/option_arguments.go
@@ -1,0 +1,85 @@
+package sshconfig
+
+import (
+	"fmt"
+	"maps"
+)
+
+// OptionArguments holds ssh_config options as key-value pairs. Values may be
+// strings, booleans, or integers; booleans are rendered as "yes"/"no" when
+// converted to command-line arguments or applied to a Setter.
+//
+// It is used by both the OpenSSH and the pure-Go SSH protocol implementations:
+// the OpenSSH path renders options as "-o Key=Value" arguments via [OptionArguments.ToArgs];
+// the pure-Go path applies them directly to a [Setter] via [OptionArguments.ApplyTo].
+type OptionArguments map[string]any
+
+// Copy returns a shallow copy of the options.
+func (o OptionArguments) Copy() OptionArguments {
+	dup := make(OptionArguments, len(o))
+	maps.Copy(dup, o)
+	return dup
+}
+
+// Set sets an option key to value.
+func (o OptionArguments) Set(key string, value any) {
+	o[key] = value
+}
+
+// SetIfUnset sets the option only if it has not already been set.
+func (o OptionArguments) SetIfUnset(key string, value any) {
+	if o.IsSet(key) {
+		return
+	}
+	o.Set(key, value)
+}
+
+// IsSet reports whether the option has been set.
+func (o OptionArguments) IsSet(key string) bool {
+	_, ok := o[key]
+	return ok
+}
+
+// ToArgs converts the options to a list of "-o Key=Value" command-line arguments
+// suitable for passing to the openssh binary.
+func (o OptionArguments) ToArgs() []string {
+	args := make([]string, 0, len(o)*2)
+	for k, v := range o {
+		if b, ok := v.(bool); ok {
+			if b {
+				args = append(args, "-o", k+"=yes")
+			} else {
+				args = append(args, "-o", k+"=no")
+			}
+			continue
+		}
+		args = append(args, "-o", fmt.Sprintf("%s=%v", k, v))
+	}
+	return args
+}
+
+// ApplyTo feeds each option into setter using [Setter.Set]. Booleans are
+// converted to "yes"/"no"; all other values are formatted with fmt.Sprint.
+// Returns an error if any key is unknown to the sshconfig package or if the
+// value cannot be parsed.
+func (o OptionArguments) ApplyTo(setter *Setter) error {
+	for key, v := range o {
+		var strVal string
+		switch tv := v.(type) {
+		case bool:
+			if tv {
+				strVal = "yes"
+			} else {
+				strVal = "no"
+			}
+		case string:
+			strVal = tv
+		default:
+			strVal = fmt.Sprint(tv)
+		}
+		if err := setter.Set(key, strVal); err != nil {
+			return fmt.Errorf("ssh option %q: %w", key, err)
+		}
+	}
+	return nil
+}

--- a/sshconfig/option_arguments.go
+++ b/sshconfig/option_arguments.go
@@ -40,11 +40,14 @@ func (o OptionArguments) SetIfUnset(key string, value any) {
 	o.Set(key, value)
 }
 
-// IsSet reports whether the option has been set to a non-nil value.
-// A nil value is treated as unset, consistent with [OptionArguments.Set] deleting nil-valued keys.
+// IsSet reports whether the option key is present in the map.
+// A key with a nil value (e.g. from YAML "key: null") is treated as set,
+// so that nil can act as an explicit delete sentinel that prevents
+// [OptionArguments.SetIfUnset] from applying defaults. Use [OptionArguments.Set]
+// with a nil value to remove a key entirely (making it unset again).
 func (o OptionArguments) IsSet(key string) bool {
-	v, ok := o[key]
-	return ok && v != nil
+	_, ok := o[key]
+	return ok
 }
 
 // valToString converts a single ssh_config value to its string representation.

--- a/sshconfig/option_arguments.go
+++ b/sshconfig/option_arguments.go
@@ -1,11 +1,15 @@
 package sshconfig
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"reflect"
 	"strings"
 )
+
+// ErrEmptySlice is returned when a slice option value is empty.
+var ErrEmptySlice = errors.New("empty slice is not a valid value")
 
 // OptionArguments holds ssh_config options as key-value pairs. Values may be
 // strings, booleans, integers, or other fmt-printable types. Booleans are
@@ -102,6 +106,9 @@ func (o OptionArguments) ToArgs() []string {
 			continue
 		}
 		if strs, ok := sliceToStrings(val); ok {
+			if len(strs) == 0 {
+				continue
+			}
 			sep := " "
 			if isCSVKey(key) {
 				sep = ","
@@ -131,6 +138,9 @@ func (o OptionArguments) ApplyTo(setter *Setter) error {
 		}
 		var err error
 		if strs, ok := sliceToStrings(val); ok {
+			if len(strs) == 0 {
+				return fmt.Errorf("ssh option %q: %w", key, ErrEmptySlice)
+			}
 			if isCSVKey(key) {
 				err = setter.Set(key, strings.Join(strs, ","))
 			} else {

--- a/sshconfig/option_arguments.go
+++ b/sshconfig/option_arguments.go
@@ -60,8 +60,8 @@ func (o OptionArguments) ToArgs() []string {
 
 // ApplyTo feeds each option into setter using [Setter.Set]. Booleans are
 // converted to "yes"/"no"; all other values are formatted with fmt.Sprint.
-// Returns an error if any key is unknown to the sshconfig package or if the
-// value cannot be parsed.
+// Returns an error if the setter rejects a value (e.g. bad format, or unknown
+// key when [Setter.ErrorOnUnknownFields] is set).
 func (o OptionArguments) ApplyTo(setter *Setter) error {
 	for key, v := range o {
 		var strVal string

--- a/sshconfig/option_arguments.go
+++ b/sshconfig/option_arguments.go
@@ -3,6 +3,7 @@ package sshconfig
 import (
 	"fmt"
 	"maps"
+	"strings"
 )
 
 // OptionArguments holds ssh_config options as key-value pairs. Values may be
@@ -45,29 +46,58 @@ func (o OptionArguments) IsSet(key string) bool {
 	return ok
 }
 
+// valToString converts a single ssh_config value to its string representation.
+// Booleans become "yes"/"no"; all other types use fmt.Sprint.
+func valToString(v any) string {
+	if b, ok := v.(bool); ok {
+		if b {
+			return "yes"
+		}
+		return "no"
+	}
+	return fmt.Sprint(v)
+}
+
+// sliceToStrings converts a []string or []any value to a []string, returning
+// (nil, false) if v is not a slice type.
+func sliceToStrings(v any) ([]string, bool) {
+	switch tv := v.(type) {
+	case []string:
+		out := make([]string, len(tv))
+		copy(out, tv)
+		return out, true
+	case []any:
+		out := make([]string, len(tv))
+		for i, elem := range tv {
+			out[i] = valToString(elem)
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
 // ToArgs converts the options to a list of "-o Key=Value" command-line arguments
-// suitable for passing to the openssh binary.
+// suitable for passing to the openssh binary. Slice values are rendered as
+// space-separated tokens (e.g. []string{"/a", "/b"} → "Key=/a /b").
 func (o OptionArguments) ToArgs() []string {
 	args := make([]string, 0, len(o)*2)
 	for key, val := range o {
 		if val == nil {
 			continue
 		}
-		if b, ok := val.(bool); ok {
-			if b {
-				args = append(args, "-o", key+"=yes")
-			} else {
-				args = append(args, "-o", key+"=no")
-			}
+		if strs, ok := sliceToStrings(val); ok {
+			args = append(args, "-o", key+"="+strings.Join(strs, " "))
 			continue
 		}
-		args = append(args, "-o", fmt.Sprintf("%s=%v", key, val))
+		args = append(args, "-o", key+"="+valToString(val))
 	}
 	return args
 }
 
 // ApplyTo feeds each option into setter using [Setter.Set]. Booleans are
-// converted to "yes"/"no"; all other values are formatted with fmt.Sprint.
+// converted to "yes"/"no"; slice values are expanded into variadic arguments
+// so multi-valued directives (IdentityFile, SendEnv, etc.) work correctly.
 // Returns an error if the setter rejects a value (e.g. bad format, or unknown
 // key when [Setter.ErrorOnUnknownFields] is set).
 func (o OptionArguments) ApplyTo(setter *Setter) error {
@@ -78,20 +108,13 @@ func (o OptionArguments) ApplyTo(setter *Setter) error {
 		if v == nil {
 			continue
 		}
-		var strVal string
-		switch tv := v.(type) {
-		case bool:
-			if tv {
-				strVal = "yes"
-			} else {
-				strVal = "no"
-			}
-		case string:
-			strVal = tv
-		default:
-			strVal = fmt.Sprint(tv)
+		var err error
+		if strs, ok := sliceToStrings(v); ok {
+			err = setter.Set(key, strs...)
+		} else {
+			err = setter.Set(key, valToString(v))
 		}
-		if err := setter.Set(key, strVal); err != nil {
+		if err != nil {
 			return fmt.Errorf("ssh option %q: %w", key, err)
 		}
 	}

--- a/sshconfig/option_arguments.go
+++ b/sshconfig/option_arguments.go
@@ -9,7 +9,7 @@ import (
 // OptionArguments holds ssh_config options as key-value pairs. Values may be
 // strings, booleans, integers, or other fmt-printable types. Booleans are
 // rendered as "yes"/"no" when converted to command-line arguments or applied
-// to a Setter. Setting a key to nil deletes it.
+// to a Setter. Use [OptionArguments.Set] with a nil value to delete a key.
 //
 // It is used by both the OpenSSH and the pure-Go SSH protocol implementations:
 // the OpenSSH path renders options as "-o Key=Value" arguments via [OptionArguments.ToArgs];

--- a/sshconfig/option_arguments.go
+++ b/sshconfig/option_arguments.go
@@ -40,10 +40,11 @@ func (o OptionArguments) SetIfUnset(key string, value any) {
 	o.Set(key, value)
 }
 
-// IsSet reports whether the option has been set.
+// IsSet reports whether the option has been set to a non-nil value.
+// A nil value is treated as unset, consistent with [OptionArguments.Set] deleting nil-valued keys.
 func (o OptionArguments) IsSet(key string) bool {
-	_, ok := o[key]
-	return ok
+	v, ok := o[key]
+	return ok && v != nil
 }
 
 // valToString converts a single ssh_config value to its string representation.

--- a/sshconfig/option_arguments_test.go
+++ b/sshconfig/option_arguments_test.go
@@ -31,6 +31,19 @@ func TestOptionArgumentsSetIsSet(t *testing.T) {
 	}
 }
 
+func TestOptionArgumentsNilValueIsSentinel(t *testing.T) {
+	// A map constructed with an explicit nil value (e.g. from YAML "key: null")
+	// must be treated as set so that SetIfUnset does not override it.
+	o := sshconfig.OptionArguments{"BatchMode": nil}
+	if !o.IsSet("BatchMode") {
+		t.Error("IsSet(BatchMode) = false for explicit nil value, want true")
+	}
+	o.SetIfUnset("BatchMode", true)
+	if o["BatchMode"] != nil {
+		t.Errorf("SetIfUnset overwrote nil sentinel; got %v, want nil", o["BatchMode"])
+	}
+}
+
 func TestOptionArgumentsSetNilDeletes(t *testing.T) {
 	o := sshconfig.OptionArguments{"Port": 22, "User": "alice"}
 	o.Set("Port", nil)

--- a/sshconfig/option_arguments_test.go
+++ b/sshconfig/option_arguments_test.go
@@ -88,6 +88,16 @@ func TestOptionArgumentsToArgs(t *testing.T) {
 			opts:      sshconfig.OptionArguments{"Port": 2222},
 			wantPairs: map[string]string{"Port": "2222"},
 		},
+		{
+			name:      "string slice renders space-separated",
+			opts:      sshconfig.OptionArguments{"IdentityFile": []string{"/a/id_rsa", "/b/id_ecdsa"}},
+			wantPairs: map[string]string{"IdentityFile": "/a/id_rsa /b/id_ecdsa"},
+		},
+		{
+			name:      "any slice renders space-separated",
+			opts:      sshconfig.OptionArguments{"SendEnv": []any{"LC_ALL", "LC_LANG"}},
+			wantPairs: map[string]string{"SendEnv": "LC_ALL LC_LANG"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -156,6 +166,46 @@ func TestOptionArgumentsApplyTo(t *testing.T) {
 		opts := sshconfig.OptionArguments{"NoSuchOption": "value"}
 		if err := opts.ApplyTo(setter); err == nil {
 			t.Error("ApplyTo() with unknown key: got nil error, want error")
+		}
+	})
+
+	t.Run("slice value expands into multiple setter args", func(t *testing.T) {
+		cfg := &sshconfig.Config{}
+		setter, err := sshconfig.NewSetter(cfg)
+		if err != nil {
+			t.Fatalf("NewSetter() error: %v", err)
+		}
+		opts := sshconfig.OptionArguments{
+			"SendEnv": []string{"LC_ALL", "LC_LANG"},
+		}
+		if err := opts.ApplyTo(setter); err != nil {
+			t.Fatalf("ApplyTo() error: %v", err)
+		}
+		if len(cfg.SendEnv) < 2 {
+			t.Fatalf("cfg.SendEnv = %v, want at least 2 entries", cfg.SendEnv)
+		}
+		if cfg.SendEnv[0] != "LC_ALL" || cfg.SendEnv[1] != "LC_LANG" {
+			t.Errorf("cfg.SendEnv = %v, want [LC_ALL LC_LANG]", cfg.SendEnv)
+		}
+	})
+
+	t.Run("any slice value expands into multiple setter args", func(t *testing.T) {
+		cfg := &sshconfig.Config{}
+		setter, err := sshconfig.NewSetter(cfg)
+		if err != nil {
+			t.Fatalf("NewSetter() error: %v", err)
+		}
+		opts := sshconfig.OptionArguments{
+			"SendEnv": []any{"LC_ALL", "LC_LANG"},
+		}
+		if err := opts.ApplyTo(setter); err != nil {
+			t.Fatalf("ApplyTo() error: %v", err)
+		}
+		if len(cfg.SendEnv) < 2 {
+			t.Fatalf("cfg.SendEnv = %v, want at least 2 entries", cfg.SendEnv)
+		}
+		if cfg.SendEnv[0] != "LC_ALL" || cfg.SendEnv[1] != "LC_LANG" {
+			t.Errorf("cfg.SendEnv = %v, want [LC_ALL LC_LANG]", cfg.SendEnv)
 		}
 	})
 }

--- a/sshconfig/option_arguments_test.go
+++ b/sshconfig/option_arguments_test.go
@@ -25,6 +25,29 @@ func TestOptionArgumentsSetIsSet(t *testing.T) {
 	if !o.IsSet("Compression") {
 		t.Error("IsSet(Compression) = false after Set, want true")
 	}
+	o.Set("Compression", nil)
+	if o.IsSet("Compression") {
+		t.Error("IsSet(Compression) = true after Set(nil), want false")
+	}
+}
+
+func TestOptionArgumentsSetNilDeletes(t *testing.T) {
+	o := sshconfig.OptionArguments{"Port": 22, "User": "alice"}
+	o.Set("Port", nil)
+	if o.IsSet("Port") {
+		t.Error("IsSet(Port) = true after Set(nil), want false")
+	}
+	args := o.ToArgs()
+	for i := 0; i+1 < len(args); i += 2 {
+		if args[i] == "-o" && strings.HasPrefix(args[i+1], "Port=") {
+			t.Errorf("ToArgs() emitted deleted key Port: %v", args[i+1])
+		}
+	}
+	// SetIfUnset can now fill in a deleted key
+	o.SetIfUnset("Port", 2222)
+	if o["Port"] != 2222 {
+		t.Errorf("SetIfUnset after nil-delete: got %v, want 2222", o["Port"])
+	}
 }
 
 func TestOptionArgumentsSetIfUnset(t *testing.T) {
@@ -113,6 +136,13 @@ func TestOptionArgumentsApplyTo(t *testing.T) {
 		}
 		if !cfg.Compression.IsTrue() {
 			t.Errorf("cfg.Compression = %q, want yes", cfg.Compression)
+		}
+	})
+
+	t.Run("nil setter returns nil error", func(t *testing.T) {
+		opts := sshconfig.OptionArguments{"User": "alice"}
+		if err := opts.ApplyTo(nil); err != nil {
+			t.Errorf("ApplyTo(nil) error: %v, want nil", err)
 		}
 	})
 

--- a/sshconfig/option_arguments_test.go
+++ b/sshconfig/option_arguments_test.go
@@ -1,0 +1,131 @@
+package sshconfig_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/sshconfig"
+)
+
+func TestOptionArgumentsCopy(t *testing.T) {
+	orig := sshconfig.OptionArguments{"Key": "val"}
+	dup := orig.Copy()
+	dup["Key"] = "changed"
+	if orig["Key"] != "val" {
+		t.Errorf("Copy() shares map with original; orig[Key] = %v, want %q", orig["Key"], "val")
+	}
+}
+
+func TestOptionArgumentsSetIsSet(t *testing.T) {
+	o := sshconfig.OptionArguments{}
+	if o.IsSet("Compression") {
+		t.Error("IsSet(Compression) = true on empty map, want false")
+	}
+	o.Set("Compression", true)
+	if !o.IsSet("Compression") {
+		t.Error("IsSet(Compression) = false after Set, want true")
+	}
+}
+
+func TestOptionArgumentsSetIfUnset(t *testing.T) {
+	o := sshconfig.OptionArguments{"Port": 22}
+	o.SetIfUnset("Port", 2222)
+	if o["Port"] != 22 {
+		t.Errorf("SetIfUnset overwrote existing value; got %v, want %v", o["Port"], 22)
+	}
+	o.SetIfUnset("User", "root")
+	if o["User"] != "root" {
+		t.Errorf("SetIfUnset(User) = %v, want %q", o["User"], "root")
+	}
+}
+
+func TestOptionArgumentsToArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      sshconfig.OptionArguments
+		wantPairs map[string]string
+	}{
+		{
+			name:      "bool true renders yes",
+			opts:      sshconfig.OptionArguments{"Compression": true},
+			wantPairs: map[string]string{"Compression": "yes"},
+		},
+		{
+			name:      "bool false renders no",
+			opts:      sshconfig.OptionArguments{"Compression": false},
+			wantPairs: map[string]string{"Compression": "no"},
+		},
+		{
+			name:      "string value",
+			opts:      sshconfig.OptionArguments{"User": "alice"},
+			wantPairs: map[string]string{"User": "alice"},
+		},
+		{
+			name:      "integer value",
+			opts:      sshconfig.OptionArguments{"Port": 2222},
+			wantPairs: map[string]string{"Port": "2222"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := tt.opts.ToArgs()
+			if len(args)%2 != 0 {
+				t.Fatalf("ToArgs() returned odd-length slice: %v", args)
+			}
+			got := map[string]string{}
+			for i := 0; i < len(args); i += 2 {
+				if args[i] != "-o" {
+					t.Errorf("ToArgs()[%d] = %q, want %q", i, args[i], "-o")
+				}
+				key, val, ok := strings.Cut(args[i+1], "=")
+				if !ok {
+					t.Errorf("ToArgs()[%d] = %q, want Key=Value form", i+1, args[i+1])
+					continue
+				}
+				got[key] = val
+			}
+			for k, wantVal := range tt.wantPairs {
+				if got[k] != wantVal {
+					t.Errorf("ToArgs() option %q = %q, want %q", k, got[k], wantVal)
+				}
+			}
+		})
+	}
+}
+
+func TestOptionArgumentsApplyTo(t *testing.T) {
+	t.Run("valid options are applied", func(t *testing.T) {
+		cfg := &sshconfig.Config{}
+		setter, err := sshconfig.NewSetter(cfg)
+		if err != nil {
+			t.Fatalf("NewSetter() error: %v", err)
+		}
+		opts := sshconfig.OptionArguments{
+			"User":        "alice",
+			"Compression": true,
+		}
+		if err := opts.ApplyTo(setter); err != nil {
+			t.Fatalf("ApplyTo() error: %v", err)
+		}
+		if cfg.User != "alice" {
+			t.Errorf("cfg.User = %q, want %q", cfg.User, "alice")
+		}
+		if !cfg.Compression.IsTrue() {
+			t.Errorf("cfg.Compression = %q, want yes", cfg.Compression)
+		}
+	})
+
+	t.Run("unknown key with ErrorOnUnknownFields returns error", func(t *testing.T) {
+		cfg := &sshconfig.Config{}
+		setter, err := sshconfig.NewSetter(cfg)
+		if err != nil {
+			t.Fatalf("NewSetter() error: %v", err)
+		}
+		setter.ErrorOnUnknownFields = true
+		opts := sshconfig.OptionArguments{"NoSuchOption": "value"}
+		if err := opts.ApplyTo(setter); err == nil {
+			t.Error("ApplyTo() with unknown key: got nil error, want error")
+		}
+	})
+}

--- a/sshconfig/option_arguments_test.go
+++ b/sshconfig/option_arguments_test.go
@@ -98,6 +98,16 @@ func TestOptionArgumentsToArgs(t *testing.T) {
 			opts:      sshconfig.OptionArguments{"SendEnv": []any{"LC_ALL", "LC_LANG"}},
 			wantPairs: map[string]string{"SendEnv": "LC_ALL LC_LANG"},
 		},
+		{
+			name:      "CSV string slice renders comma-separated",
+			opts:      sshconfig.OptionArguments{"Ciphers": []string{"aes128-ctr", "aes256-ctr"}},
+			wantPairs: map[string]string{"Ciphers": "aes128-ctr,aes256-ctr"},
+		},
+		{
+			name:      "CSV any slice renders comma-separated",
+			opts:      sshconfig.OptionArguments{"KexAlgorithms": []any{"curve25519-sha256", "diffie-hellman-group14-sha256"}},
+			wantPairs: map[string]string{"KexAlgorithms": "curve25519-sha256,diffie-hellman-group14-sha256"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -206,6 +216,46 @@ func TestOptionArgumentsApplyTo(t *testing.T) {
 		}
 		if cfg.SendEnv[0] != "LC_ALL" || cfg.SendEnv[1] != "LC_LANG" {
 			t.Errorf("cfg.SendEnv = %v, want [LC_ALL LC_LANG]", cfg.SendEnv)
+		}
+	})
+
+	t.Run("CSV string slice is accepted for comma-separated directives", func(t *testing.T) {
+		cfg := &sshconfig.Config{}
+		setter, err := sshconfig.NewSetter(cfg)
+		if err != nil {
+			t.Fatalf("NewSetter() error: %v", err)
+		}
+		opts := sshconfig.OptionArguments{
+			"Ciphers": []string{"aes128-ctr", "aes256-ctr"},
+		}
+		if err := opts.ApplyTo(setter); err != nil {
+			t.Fatalf("ApplyTo() error: %v", err)
+		}
+		if len(cfg.Ciphers) < 2 {
+			t.Fatalf("cfg.Ciphers = %v, want at least 2 entries", cfg.Ciphers)
+		}
+		if cfg.Ciphers[0] != "aes128-ctr" || cfg.Ciphers[1] != "aes256-ctr" {
+			t.Errorf("cfg.Ciphers = %v, want [aes128-ctr aes256-ctr]", cfg.Ciphers)
+		}
+	})
+
+	t.Run("CSV any slice is accepted for comma-separated directives", func(t *testing.T) {
+		cfg := &sshconfig.Config{}
+		setter, err := sshconfig.NewSetter(cfg)
+		if err != nil {
+			t.Fatalf("NewSetter() error: %v", err)
+		}
+		opts := sshconfig.OptionArguments{
+			"KexAlgorithms": []any{"curve25519-sha256", "diffie-hellman-group14-sha256"},
+		}
+		if err := opts.ApplyTo(setter); err != nil {
+			t.Fatalf("ApplyTo() error: %v", err)
+		}
+		if len(cfg.KexAlgorithms) < 2 {
+			t.Fatalf("cfg.KexAlgorithms = %v, want at least 2 entries", cfg.KexAlgorithms)
+		}
+		if cfg.KexAlgorithms[0] != "curve25519-sha256" || cfg.KexAlgorithms[1] != "diffie-hellman-group14-sha256" {
+			t.Errorf("cfg.KexAlgorithms = %v, want [curve25519-sha256 diffie-hellman-group14-sha256]", cfg.KexAlgorithms)
 		}
 	})
 }


### PR DESCRIPTION
Allows setting the more "exotic" ssh options through the rig config like `ServerAliveInterval` via `ssh.options.ServerAliveInterval` instead of modifying the ~/.ssh/config. 

Moves OptionArguments from protocol/openssh to sshconfig so both the pure-Go SSH and OpenSSH protocol implementations share the same type. Add ApplyTo(*Setter) to feed options into the sshconfig setter with bool→yes/no conversion.

Breaking API is not an issue as rig v2 is not released yet.
