### PR TITLE
feat(ssh): wire BindAddress and interface from sshconfig to net.Dialer

### DIFF
--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -26,6 +26,11 @@ import (
 	"golang.org/x/term"
 )
 
+const (
+	dialTCP4 = "tcp4"
+	dialTCP6 = "tcp6"
+)
+
 var (
 	errNotConnected   = errors.New("not connected")
 	errNotRegularFile = errors.New("not a regular file")
@@ -766,12 +771,96 @@ func (c *Connection) startKeepalive() {
 func (c *Connection) dialNetwork() string {
 	switch c.sshConfig.AddressFamily {
 	case "inet":
-		return "tcp4"
+		return dialTCP4
 	case "inet6":
-		return "tcp6"
+		return dialTCP6
 	default:
 		return "tcp"
 	}
+}
+
+// selectBindAddr picks the first global-unicast IP from addrs that matches the
+// dial family: IPv4-only for "tcp4", IPv6-only for "tcp6", either for "tcp".
+func selectBindAddr(addrs []net.Addr, family string) net.IP {
+	for _, addr := range addrs {
+		var candidate net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			candidate = v.IP
+		case *net.IPAddr:
+			candidate = v.IP
+		}
+		if candidate == nil || !candidate.IsGlobalUnicast() {
+			continue
+		}
+		switch family {
+		case dialTCP4:
+			if candidate.To4() == nil {
+				continue
+			}
+		case dialTCP6:
+			if candidate.To4() != nil {
+				continue
+			}
+		}
+		return candidate
+	}
+	return nil
+}
+
+// resolveBindAddress parses c.sshConfig.BindAddress and checks it is compatible
+// with the configured dial family. Returns nil (with a trace log) if the address
+// is invalid or incompatible, so localAddr can fall through to BindInterface.
+func (c *Connection) resolveBindAddress(ctx context.Context) net.IP {
+	bindIP := net.ParseIP(c.sshConfig.BindAddress)
+	if bindIP == nil {
+		log.Trace(ctx, "BindAddress is not a valid IP, ignoring", "bind_address", c.sshConfig.BindAddress)
+		return nil
+	}
+	switch c.dialNetwork() {
+	case dialTCP4:
+		if bindIP.To4() == nil {
+			log.Trace(ctx, "BindAddress is IPv6 but AddressFamily is inet, ignoring", "bind_address", c.sshConfig.BindAddress)
+			return nil
+		}
+	case dialTCP6:
+		if bindIP.To4() != nil {
+			log.Trace(ctx, "BindAddress is IPv4 but AddressFamily is inet6, ignoring", "bind_address", c.sshConfig.BindAddress)
+			return nil
+		}
+	}
+	log.Trace(ctx, "binding to BindAddress", "bind_address", c.sshConfig.BindAddress)
+	return bindIP
+}
+
+// localAddr returns the local address to bind for outgoing connections based on
+// BindAddress or BindInterface from the ssh config. Returns nil if neither is set.
+func (c *Connection) localAddr(ctx context.Context) net.Addr {
+	if c.sshConfig.BindAddress != "" {
+		if bindIP := c.resolveBindAddress(ctx); bindIP != nil {
+			return &net.TCPAddr{IP: bindIP}
+		}
+	}
+	if c.sshConfig.BindInterface != "" {
+		iface, err := net.InterfaceByName(c.sshConfig.BindInterface)
+		if err != nil {
+			log.Trace(ctx, "BindInterface not found, ignoring", "bind_interface", c.sshConfig.BindInterface, log.ErrorAttr(err))
+			return nil
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			log.Trace(ctx, "failed to list addresses for BindInterface, ignoring", "bind_interface", c.sshConfig.BindInterface, log.ErrorAttr(err))
+			return nil
+		}
+		ip := selectBindAddr(addrs, c.dialNetwork())
+		if ip == nil {
+			log.Trace(ctx, "no suitable address found for BindInterface, ignoring", "bind_interface", c.sshConfig.BindInterface)
+			return nil
+		}
+		log.Trace(ctx, "binding to BindInterface address", "bind_interface", c.sshConfig.BindInterface, "addr", ip)
+		return &net.TCPAddr{IP: ip}
+	}
+	return nil
 }
 
 // connectDeadline returns the earliest of the context deadline and the configured
@@ -810,7 +899,7 @@ func (c *Connection) Connect(ctx context.Context) error {
 	}
 
 	deadline := c.connectDeadline(ctx)
-	conn, err := (&net.Dialer{Deadline: deadline}).DialContext(ctx, c.dialNetwork(), dst)
+	conn, err := (&net.Dialer{Deadline: deadline, LocalAddr: c.localAddr(ctx)}).DialContext(ctx, c.dialNetwork(), dst)
 	if err != nil {
 		return fmt.Errorf("ssh dial: %w", err)
 	}

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -787,3 +787,112 @@ func TestHostkeyCallbackSkipsMissingGlobalKnownHostsFile(t *testing.T) {
 	_, statErr := os.Stat(missing)
 	require.True(t, os.IsNotExist(statErr), "hostkeyCallback must not create missing global known_hosts files")
 }
+
+func TestSelectBindAddr(t *testing.T) {
+	loopback4 := &net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)}
+	linkLocal4 := &net.IPNet{IP: net.ParseIP("169.254.1.1"), Mask: net.CIDRMask(16, 32)}
+	global4 := &net.IPNet{IP: net.ParseIP("192.168.1.10"), Mask: net.CIDRMask(24, 32)}
+	global6 := &net.IPNet{IP: net.ParseIP("2001:db8::1"), Mask: net.CIDRMask(32, 128)}
+
+	cases := []struct {
+		name   string
+		addrs  []net.Addr
+		family string
+		wantIP net.IP
+	}{
+		{"empty list returns nil", nil, "tcp", nil},
+		{"loopback excluded", []net.Addr{loopback4}, "tcp", nil},
+		{"link-local excluded", []net.Addr{linkLocal4}, "tcp", nil},
+		{"global IPv4 selected for tcp", []net.Addr{global4}, "tcp", global4.IP},
+		{"global IPv4 selected for tcp4", []net.Addr{global4}, "tcp4", global4.IP},
+		{"global IPv4 skipped for tcp6", []net.Addr{global4}, "tcp6", nil},
+		{"global IPv6 selected for tcp", []net.Addr{global6}, "tcp", global6.IP},
+		{"global IPv6 selected for tcp6", []net.Addr{global6}, "tcp6", global6.IP},
+		{"global IPv6 skipped for tcp4", []net.Addr{global6}, "tcp4", nil},
+		{"prefers first global in mixed list", []net.Addr{loopback4, global4, global6}, "tcp", global4.IP},
+		{"tcp4 skips leading IPv6 and picks IPv4", []net.Addr{global6, global4}, "tcp4", global4.IP},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := selectBindAddr(tc.addrs, tc.family)
+			if tc.wantIP == nil {
+				require.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				require.True(t, tc.wantIP.Equal(got), "got %v, want %v", got, tc.wantIP)
+			}
+		})
+	}
+}
+
+func TestLocalAddrBindAddress(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("valid IPv4 returns TCPAddr", func(t *testing.T) {
+		c := &Connection{sshConfig: &sshconfig.Config{BindAddress: "10.0.0.1"}}
+		addr := c.localAddr(ctx)
+		require.NotNil(t, addr)
+		tcp, ok := addr.(*net.TCPAddr)
+		require.True(t, ok)
+		require.True(t, net.ParseIP("10.0.0.1").Equal(tcp.IP))
+	})
+
+	t.Run("valid IPv6 returns TCPAddr", func(t *testing.T) {
+		c := &Connection{sshConfig: &sshconfig.Config{BindAddress: "::1"}}
+		addr := c.localAddr(ctx)
+		require.NotNil(t, addr)
+		tcp, ok := addr.(*net.TCPAddr)
+		require.True(t, ok)
+		require.True(t, net.ParseIP("::1").Equal(tcp.IP))
+	})
+
+	t.Run("invalid IP returns nil", func(t *testing.T) {
+		c := &Connection{sshConfig: &sshconfig.Config{BindAddress: "not-an-ip"}}
+		require.Nil(t, c.localAddr(ctx))
+	})
+
+	t.Run("IPv6 BindAddress with AddressFamily inet returns nil", func(t *testing.T) {
+		c := &Connection{sshConfig: &sshconfig.Config{BindAddress: "2001:db8::1", AddressFamily: "inet"}}
+		require.Nil(t, c.localAddr(ctx))
+	})
+
+	t.Run("IPv4 BindAddress with AddressFamily inet6 returns nil", func(t *testing.T) {
+		c := &Connection{sshConfig: &sshconfig.Config{BindAddress: "10.0.0.1", AddressFamily: "inet6"}}
+		require.Nil(t, c.localAddr(ctx))
+	})
+
+	t.Run("IPv4 BindAddress with AddressFamily inet returns TCPAddr", func(t *testing.T) {
+		c := &Connection{sshConfig: &sshconfig.Config{BindAddress: "10.0.0.1", AddressFamily: "inet"}}
+		addr := c.localAddr(ctx)
+		require.NotNil(t, addr)
+		tcp, ok := addr.(*net.TCPAddr)
+		require.True(t, ok)
+		require.True(t, net.ParseIP("10.0.0.1").Equal(tcp.IP))
+	})
+
+	t.Run("both fields unset returns nil", func(t *testing.T) {
+		c := &Connection{sshConfig: &sshconfig.Config{}}
+		require.Nil(t, c.localAddr(ctx))
+	})
+}
+
+func TestLocalAddrBindInterface(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nonexistent interface returns nil", func(t *testing.T) {
+		c := &Connection{sshConfig: &sshconfig.Config{BindInterface: "rig-no-such-iface"}}
+		require.Nil(t, c.localAddr(ctx))
+	})
+
+	t.Run("invalid BindAddress falls through to BindInterface", func(t *testing.T) {
+		// BindAddress is unusable; BindInterface is probed next (nonexistent → nil).
+		c := &Connection{sshConfig: &sshconfig.Config{BindAddress: "not-an-ip", BindInterface: "rig-no-such-iface"}}
+		require.Nil(t, c.localAddr(ctx))
+	})
+
+	t.Run("mismatched BindAddress falls through to BindInterface", func(t *testing.T) {
+		// BindAddress family conflicts with AddressFamily; BindInterface is probed next.
+		c := &Connection{sshConfig: &sshconfig.Config{BindAddress: "2001:db8::1", AddressFamily: "inet", BindInterface: "rig-no-such-iface"}}
+		require.Nil(t, c.localAddr(ctx))
+	})
+}


### PR DESCRIPTION
Sets LocalAddr on the net.Dialer in Connect() based on the ssh config BindAddress (parsed as IP) or BindInterface (first global-unicast address from the interface, respecting AddressFamily). Both are no-ops when unset.