### PR TITLE
feat(ssh): wire CertificateFile for certificate-based authentication

### DIFF
--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -559,21 +559,22 @@ func (c *Connection) certSignerFromFile(ctx context.Context, certPath string, si
 
 // certSignerForSigner tries to find a certificate for signer. Explicit
 // CertificateFile entries are tried first (skipping "none"), then the implicit
-// keyPath+"-cert.pub" as fallback unless "none" appears in CertificateFile,
-// which disables certificate loading entirely (matching sshconfig semantics).
-// keyPath must already be expanded (caller's responsibility). Each candidate is
-// expanded with homedir.Expand so that CertificateFile entries set
-// programmatically (without the parser's Finalize) also work. Returns nil when
-// no matching certificate is found.
+// keyPath+"-cert.pub" as fallback. When "none" appears in CertificateFile the
+// implicit fallback is suppressed; note that sshconfig.Setter.Finalize()
+// normalizes a lone ["none"] to nil, so this guard only takes effect for
+// programmatically-constructed configs that skip Finalize. keyPath must already
+// be expanded (caller's responsibility). Each candidate is expanded with
+// homedir.Expand so that CertificateFile entries set programmatically also work.
+// Returns nil when no matching certificate is found.
 func (c *Connection) certSignerForSigner(ctx context.Context, signer ssh.Signer, keyPath string) ssh.Signer {
-	disableImplicit := slices.Contains(c.sshConfig.CertificateFile, "none")
+	hasNone := slices.Contains(c.sshConfig.CertificateFile, "none")
 	candidates := make([]string, 0, len(c.sshConfig.CertificateFile)+1)
 	for _, p := range c.sshConfig.CertificateFile {
 		if p != "none" {
 			candidates = append(candidates, p)
 		}
 	}
-	if !disableImplicit {
+	if !hasNone {
 		candidates = append(candidates, keyPath+"-cert.pub")
 	}
 	for _, certPath := range candidates {

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -513,9 +513,64 @@ func (c *Connection) loadAgentSigners(ctx context.Context) ([]ssh.Signer, func()
 	return signers, closeAgent
 }
 
+// certSignerForSigner tries to find a certificate for signer. Explicit
+// CertificateFile entries are tried first (skipping "none"), then the implicit
+// keyPath+"-cert.pub" as fallback. keyPath must already be expanded (caller's
+// responsibility). Each candidate is expanded with homedir.Expand so that
+// CertificateFile entries set programmatically (without the parser's Finalize)
+// also work. Returns nil when no matching certificate is found.
+func (c *Connection) certSignerForSigner(ctx context.Context, signer ssh.Signer, keyPath string) ssh.Signer {
+	candidates := make([]string, 0, len(c.sshConfig.CertificateFile)+1)
+	for _, p := range c.sshConfig.CertificateFile {
+		if p != "none" {
+			candidates = append(candidates, p)
+		}
+	}
+	candidates = append(candidates, keyPath+"-cert.pub")
+	for _, certPath := range candidates {
+		expanded, err := homedir.Expand(certPath)
+		if err != nil {
+			log.Trace(ctx, "expand certificate file path failed", log.FileAttr(certPath), log.ErrorAttr(err))
+			continue
+		}
+		certPath = expanded
+		data, err := os.ReadFile(certPath)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				log.Trace(ctx, "read certificate file failed", log.FileAttr(certPath), log.ErrorAttr(err))
+			}
+			continue
+		}
+		pub, _, _, _, err := ssh.ParseAuthorizedKey(data)
+		if err != nil {
+			log.Trace(ctx, "parse certificate file failed", log.FileAttr(certPath), log.ErrorAttr(err))
+			continue
+		}
+		cert, ok := pub.(*ssh.Certificate)
+		if !ok {
+			log.Trace(ctx, "not a certificate", log.FileAttr(certPath))
+			continue
+		}
+		if !bytes.Equal(cert.Key.Marshal(), signer.PublicKey().Marshal()) {
+			log.Trace(ctx, "certificate key does not match identity", log.FileAttr(certPath))
+			continue
+		}
+		cs, err := ssh.NewCertSigner(cert, signer)
+		if err != nil {
+			log.Trace(ctx, "create cert signer failed", log.FileAttr(certPath), log.ErrorAttr(err))
+			continue
+		}
+		c.Log().Debug("using certificate for authentication", log.KeyFile, certPath)
+		return cs
+	}
+	return nil
+}
+
 // loadKeySigners loads signers for each configured key path, using signerCache
 // to avoid re-parsing keys. Agent-backed signers (for .pub files or encrypted
-// keys) are not cached because they require a live agent connection.
+// keys) are not cached because they require a live agent connection. When a
+// certificate is found for a key (implicit <path>-cert.pub or CertificateFile),
+// the cert signer is offered first and the plain signer is offered as fallback.
 func (c *Connection) loadKeySigners(ctx context.Context, agentSigners []ssh.Signer) []ssh.Signer {
 	var keySigners []ssh.Signer
 	for _, keyPath := range c.keyPaths {
@@ -528,6 +583,9 @@ func (c *Connection) loadKeySigners(ctx context.Context, agentSigners []ssh.Sign
 			switch v := cached.(type) {
 			case ssh.Signer:
 				log.Trace(ctx, "using cached signer", log.FileAttr(keyPath))
+				if cs := c.certSignerForSigner(ctx, v, keyPath); cs != nil {
+					keySigners = append(keySigners, cs)
+				}
 				keySigners = append(keySigners, v)
 			case error:
 				log.Trace(ctx, "already discarded key", log.FileAttr(keyPath), log.ErrorAttr(v))
@@ -545,6 +603,9 @@ func (c *Connection) loadKeySigners(ctx context.Context, agentSigners []ssh.Sign
 		} else {
 			if !fromAgent {
 				signerCache.Store(keyPath, signer)
+			}
+			if cs := c.certSignerForSigner(ctx, signer, keyPath); cs != nil {
+				keySigners = append(keySigners, cs)
 			}
 			keySigners = append(keySigners, signer)
 		}

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -513,55 +513,73 @@ func (c *Connection) loadAgentSigners(ctx context.Context) ([]ssh.Signer, func()
 	return signers, closeAgent
 }
 
+// certSignerFromFile loads a user certificate from certPath and combines it
+// with signer. Returns nil if the file is missing, not a user certificate, or
+// its key does not match signer.
+func (c *Connection) certSignerFromFile(ctx context.Context, certPath string, signer ssh.Signer) ssh.Signer {
+	expanded, err := homedir.Expand(certPath)
+	if err != nil {
+		log.Trace(ctx, "expand certificate file path failed", log.FileAttr(certPath), log.ErrorAttr(err))
+		return nil
+	}
+	certPath = expanded
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Trace(ctx, "read certificate file failed", log.FileAttr(certPath), log.ErrorAttr(err))
+		}
+		return nil
+	}
+	pub, _, _, _, err := ssh.ParseAuthorizedKey(data)
+	if err != nil {
+		log.Trace(ctx, "parse certificate file failed", log.FileAttr(certPath), log.ErrorAttr(err))
+		return nil
+	}
+	cert, ok := pub.(*ssh.Certificate)
+	if !ok {
+		log.Trace(ctx, "not a certificate", log.FileAttr(certPath))
+		return nil
+	}
+	if cert.CertType != ssh.UserCert {
+		log.Trace(ctx, "skipping non-user certificate", log.FileAttr(certPath))
+		return nil
+	}
+	if !bytes.Equal(cert.Key.Marshal(), signer.PublicKey().Marshal()) {
+		log.Trace(ctx, "certificate key does not match identity", log.FileAttr(certPath))
+		return nil
+	}
+	cs, err := ssh.NewCertSigner(cert, signer)
+	if err != nil {
+		log.Trace(ctx, "create cert signer failed", log.FileAttr(certPath), log.ErrorAttr(err))
+		return nil
+	}
+	c.Log().Debug("using certificate for authentication", log.KeyFile, certPath)
+	return cs
+}
+
 // certSignerForSigner tries to find a certificate for signer. Explicit
 // CertificateFile entries are tried first (skipping "none"), then the implicit
-// keyPath+"-cert.pub" as fallback. keyPath must already be expanded (caller's
-// responsibility). Each candidate is expanded with homedir.Expand so that
-// CertificateFile entries set programmatically (without the parser's Finalize)
-// also work. Returns nil when no matching certificate is found.
+// keyPath+"-cert.pub" as fallback unless "none" appears in CertificateFile,
+// which disables certificate loading entirely (matching sshconfig semantics).
+// keyPath must already be expanded (caller's responsibility). Each candidate is
+// expanded with homedir.Expand so that CertificateFile entries set
+// programmatically (without the parser's Finalize) also work. Returns nil when
+// no matching certificate is found.
 func (c *Connection) certSignerForSigner(ctx context.Context, signer ssh.Signer, keyPath string) ssh.Signer {
+	disableImplicit := slices.Contains(c.sshConfig.CertificateFile, "none")
 	candidates := make([]string, 0, len(c.sshConfig.CertificateFile)+1)
 	for _, p := range c.sshConfig.CertificateFile {
 		if p != "none" {
 			candidates = append(candidates, p)
 		}
 	}
-	candidates = append(candidates, keyPath+"-cert.pub")
+	if !disableImplicit {
+		candidates = append(candidates, keyPath+"-cert.pub")
+	}
 	for _, certPath := range candidates {
-		expanded, err := homedir.Expand(certPath)
-		if err != nil {
-			log.Trace(ctx, "expand certificate file path failed", log.FileAttr(certPath), log.ErrorAttr(err))
-			continue
+		if cs := c.certSignerFromFile(ctx, certPath, signer); cs != nil {
+			return cs
 		}
-		certPath = expanded
-		data, err := os.ReadFile(certPath)
-		if err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				log.Trace(ctx, "read certificate file failed", log.FileAttr(certPath), log.ErrorAttr(err))
-			}
-			continue
-		}
-		pub, _, _, _, err := ssh.ParseAuthorizedKey(data)
-		if err != nil {
-			log.Trace(ctx, "parse certificate file failed", log.FileAttr(certPath), log.ErrorAttr(err))
-			continue
-		}
-		cert, ok := pub.(*ssh.Certificate)
-		if !ok {
-			log.Trace(ctx, "not a certificate", log.FileAttr(certPath))
-			continue
-		}
-		if !bytes.Equal(cert.Key.Marshal(), signer.PublicKey().Marshal()) {
-			log.Trace(ctx, "certificate key does not match identity", log.FileAttr(certPath))
-			continue
-		}
-		cs, err := ssh.NewCertSigner(cert, signer)
-		if err != nil {
-			log.Trace(ctx, "create cert signer failed", log.FileAttr(certPath), log.ErrorAttr(err))
-			continue
-		}
-		c.Log().Debug("using certificate for authentication", log.KeyFile, certPath)
-		return cs
 	}
 	return nil
 }

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -321,9 +321,13 @@ func TestClientConfigIdentitiesOnlyAgentFiltering(t *testing.T) {
 	require.NoError(t, keyring.Add(agent.AddedKey{PrivateKey: privA}))
 	require.NoError(t, keyring.Add(agent.AddedKey{PrivateKey: privB}))
 
-	// Use /tmp directly: t.TempDir() produces paths exceeding the 104-byte
-	// unix socket path limit on macOS.
-	dir, err := os.MkdirTemp("/tmp", "rig")
+	// On darwin, os.TempDir() returns a long $TMPDIR path that exceeds the
+	// 104-byte unix socket path limit; use /tmp which is always short there.
+	baseDir := ""
+	if runtime.GOOS == "darwin" {
+		baseDir = "/tmp"
+	}
+	dir, err := os.MkdirTemp(baseDir, "rig")
 	require.NoError(t, err)
 	t.Cleanup(func() { os.RemoveAll(dir) })
 	socketPath := filepath.Join(dir, "agent.sock")
@@ -1037,9 +1041,11 @@ func TestCertSignerForSignerMissingFile(t *testing.T) {
 	require.Nil(t, cs, "missing cert file must return nil without error")
 }
 
-// TestCertSignerForSignerNoneDisablesImplicit verifies that "none" in
-// CertificateFile disables the implicit <keyPath>-cert.pub fallback so that
-// even a matching cert on disk is not offered.
+// TestCertSignerForSignerNoneDisablesImplicit verifies that a literal "none"
+// entry in CertificateFile disables the implicit <keyPath>-cert.pub fallback.
+// This covers the programmatic / pre-Finalize case: sshconfig.Setter.Finalize()
+// normalizes a lone ["none"] to nil, so parser-loaded configs reach this code
+// with a nil slice instead (and the implicit path is tried as normal).
 func TestCertSignerForSignerNoneDisablesImplicit(t *testing.T) {
 	ctx := context.Background()
 	_, priv, err := ed25519.GenerateKey(rand.Reader)

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -321,7 +321,11 @@ func TestClientConfigIdentitiesOnlyAgentFiltering(t *testing.T) {
 	require.NoError(t, keyring.Add(agent.AddedKey{PrivateKey: privA}))
 	require.NoError(t, keyring.Add(agent.AddedKey{PrivateKey: privB}))
 
-	dir := t.TempDir()
+	// Use /tmp directly: t.TempDir() produces paths exceeding the 104-byte
+	// unix socket path limit on macOS.
+	dir, err := os.MkdirTemp("/tmp", "rig")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
 	socketPath := filepath.Join(dir, "agent.sock")
 	ln, err := net.Listen("unix", socketPath)
 	require.NoError(t, err)
@@ -895,4 +899,173 @@ func TestLocalAddrBindInterface(t *testing.T) {
 		c := &Connection{sshConfig: &sshconfig.Config{BindAddress: "2001:db8::1", AddressFamily: "inet", BindInterface: "rig-no-such-iface"}}
 		require.Nil(t, c.localAddr(ctx))
 	})
+}
+
+// makeCertForSigner generates a CA-signed SSH user certificate for the given signer.
+func makeCertForSigner(t *testing.T, signer ssh.Signer) *ssh.Certificate {
+	t.Helper()
+	_, caPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	caSigner, err := ssh.NewSignerFromKey(caPriv)
+	require.NoError(t, err)
+	cert := &ssh.Certificate{
+		Key:         signer.PublicKey(),
+		CertType:    ssh.UserCert,
+		KeyId:       "test",
+		ValidAfter:  0,
+		ValidBefore: ssh.CertTimeInfinity,
+	}
+	require.NoError(t, cert.SignCert(rand.Reader, caSigner))
+	return cert
+}
+
+// writeCert marshals cert to authorized_keys format and writes it to path.
+func writeCert(t *testing.T, path string, cert *ssh.Certificate) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, ssh.MarshalAuthorizedKey(cert), 0o600))
+}
+
+// TestCertSignerForSignerImplicit verifies that the implicit <keypath>-cert.pub
+// path is loaded and produces a cert signer when the cert matches the key.
+func TestCertSignerForSignerImplicit(t *testing.T) {
+	ctx := context.Background()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519")
+	cert := makeCertForSigner(t, signer)
+	writeCert(t, keyPath+"-cert.pub", cert)
+
+	c := &Connection{sshConfig: &sshconfig.Config{}}
+	cs := c.certSignerForSigner(ctx, signer, keyPath)
+
+	require.NotNil(t, cs, "implicit cert path must produce a cert signer")
+	_, ok := cs.PublicKey().(*ssh.Certificate)
+	require.True(t, ok, "cert signer must present a certificate as its public key")
+}
+
+// TestCertSignerForSignerExplicit verifies that explicit CertificateFile entries
+// are tried when the implicit path is absent.
+func TestCertSignerForSignerExplicit(t *testing.T) {
+	ctx := context.Background()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519")
+	// no implicit cert
+	certPath := filepath.Join(dir, "explicit-cert.pub")
+	cert := makeCertForSigner(t, signer)
+	writeCert(t, certPath, cert)
+
+	c := &Connection{sshConfig: &sshconfig.Config{CertificateFile: []string{certPath}}}
+	cs := c.certSignerForSigner(ctx, signer, keyPath)
+
+	require.NotNil(t, cs, "explicit CertificateFile must produce a cert signer")
+	_, ok := cs.PublicKey().(*ssh.Certificate)
+	require.True(t, ok, "cert signer must present a certificate as its public key")
+}
+
+// TestCertSignerForSignerExplicitUnexpanded verifies that a CertificateFile entry
+// with a tilde prefix is expanded before use, covering configs constructed without
+// the sshconfig parser's Finalize step.
+func TestCertSignerForSignerExplicitUnexpanded(t *testing.T) {
+	ctx := context.Background()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	// Redirect HOME to a temp dir so ~ expansion is hermetic and never touches
+	// the real home directory.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
+
+	certPath := filepath.Join(fakeHome, "id_ed25519-cert.pub")
+	cert := makeCertForSigner(t, signer)
+	writeCert(t, certPath, cert)
+
+	// Pass the unexpanded tilde path as CertificateFile would be before Finalize.
+	c := &Connection{sshConfig: &sshconfig.Config{CertificateFile: []string{"~/id_ed25519-cert.pub"}}}
+	cs := c.certSignerForSigner(ctx, signer, filepath.Join(t.TempDir(), "id_ed25519"))
+
+	require.NotNil(t, cs, "unexpanded CertificateFile tilde path must still resolve")
+}
+
+// TestCertSignerForSignerMismatch verifies that a cert whose key does not match
+// the signer is silently skipped.
+func TestCertSignerForSignerMismatch(t *testing.T) {
+	ctx := context.Background()
+	_, privA, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signerA, err := ssh.NewSignerFromKey(privA)
+	require.NoError(t, err)
+
+	_, privB, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signerB, err := ssh.NewSignerFromKey(privB)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519")
+	// cert is for key B, but signer is A
+	cert := makeCertForSigner(t, signerB)
+	writeCert(t, keyPath+"-cert.pub", cert)
+
+	c := &Connection{sshConfig: &sshconfig.Config{}}
+	cs := c.certSignerForSigner(ctx, signerA, keyPath)
+	require.Nil(t, cs, "mismatched cert must be skipped")
+}
+
+// TestCertSignerForSignerMissingFile verifies that a missing cert file is
+// silently skipped without error.
+func TestCertSignerForSignerMissingFile(t *testing.T) {
+	ctx := context.Background()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	c := &Connection{sshConfig: &sshconfig.Config{}}
+	cs := c.certSignerForSigner(ctx, signer, filepath.Join(t.TempDir(), "id_ed25519"))
+	require.Nil(t, cs, "missing cert file must return nil without error")
+}
+
+// TestLoadKeySignersIncludesCertSigner verifies that loadKeySigners prepends
+// the cert signer before the plain signer when a certificate is available.
+func TestLoadKeySignersIncludesCertSigner(t *testing.T) {
+	ctx := context.Background()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519")
+
+	privBlock, err := ssh.MarshalPrivateKey(priv, "")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(privBlock), 0o600))
+
+	cert := makeCertForSigner(t, signer)
+	writeCert(t, keyPath+"-cert.pub", cert)
+
+	signerCache.Delete(keyPath)
+	t.Cleanup(func() { signerCache.Delete(keyPath) })
+
+	c := &Connection{sshConfig: &sshconfig.Config{}, keyPaths: []string{keyPath}}
+
+	signers := c.loadKeySigners(ctx, nil)
+	require.Len(t, signers, 2, "must have cert signer and plain signer")
+
+	_, isCert := signers[0].PublicKey().(*ssh.Certificate)
+	require.True(t, isCert, "first signer must be the cert signer (cert takes priority)")
+	_, isCert = signers[1].PublicKey().(*ssh.Certificate)
+	require.False(t, isCert, "second signer must be the plain signer")
 }

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -1037,6 +1037,58 @@ func TestCertSignerForSignerMissingFile(t *testing.T) {
 	require.Nil(t, cs, "missing cert file must return nil without error")
 }
 
+// TestCertSignerForSignerNoneDisablesImplicit verifies that "none" in
+// CertificateFile disables the implicit <keyPath>-cert.pub fallback so that
+// even a matching cert on disk is not offered.
+func TestCertSignerForSignerNoneDisablesImplicit(t *testing.T) {
+	ctx := context.Background()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519")
+	cert := makeCertForSigner(t, signer)
+	writeCert(t, keyPath+"-cert.pub", cert)
+
+	c := &Connection{sshConfig: &sshconfig.Config{CertificateFile: []string{"none"}}}
+	cs := c.certSignerForSigner(ctx, signer, keyPath)
+	require.Nil(t, cs, "CertificateFile=none must disable implicit cert loading")
+}
+
+// TestCertSignerForSignerSkipsHostCert verifies that host certificates are
+// skipped and not offered as user authentication.
+func TestCertSignerForSignerSkipsHostCert(t *testing.T) {
+	ctx := context.Background()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	_, caPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	caSigner, err := ssh.NewSignerFromKey(caPriv)
+	require.NoError(t, err)
+
+	hostCert := &ssh.Certificate{
+		Key:         signer.PublicKey(),
+		CertType:    ssh.HostCert,
+		KeyId:       "host",
+		ValidAfter:  0,
+		ValidBefore: ssh.CertTimeInfinity,
+	}
+	require.NoError(t, hostCert.SignCert(rand.Reader, caSigner))
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519")
+	writeCert(t, keyPath+"-cert.pub", hostCert)
+
+	c := &Connection{sshConfig: &sshconfig.Config{}}
+	cs := c.certSignerForSigner(ctx, signer, keyPath)
+	require.Nil(t, cs, "host certificate must be skipped")
+}
+
 // TestLoadKeySignersIncludesCertSigner verifies that loadKeySigners prepends
 // the cert signer before the plain signer when a certificate is available.
 func TestLoadKeySignersIncludesCertSigner(t *testing.T) {


### PR DESCRIPTION
For each identity file, also load the implicit <path>-cert.pub and any explicit CertificateFile entries from sshconfig. When a matching cert is found, a cert signer is offered before the plain key signer so certificate auth is tried first with the plain key as fallback.