### PR TITLE
feat(ssh): wire CheckHostIP from sshconfig for DNS-spoofing detection

### DIFF
--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -337,20 +337,32 @@ func (c *Connection) IsWindows() bool {
 	return c.detectWindows(ctx)
 }
 
-func knownhostsCallback(path string, permissive, hash bool) (ssh.HostKeyCallback, error) {
-	cb, err := hostkey.KnownHostsFileCallback(path, permissive, hash)
+func knownhostsCallback(path string, permissive, hash, checkIP bool) (ssh.HostKeyCallback, error) {
+	var err error
+	var callback ssh.HostKeyCallback
+	if checkIP {
+		callback, err = hostkey.KnownHostsFileCallbackWithIPCheck(path, permissive, hash)
+	} else {
+		callback, err = hostkey.KnownHostsFileCallback(path, permissive, hash)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("%w: create host key validator: %w", protocol.ErrNonRetryable, err)
 	}
-	return cb, nil
+	return callback, nil
 }
 
-func knownhostsGlobalCallback(path string, permissive bool) (ssh.HostKeyCallback, error) {
-	cb, err := hostkey.KnownHostsReadOnlyFileCallback(path, permissive)
+func knownhostsGlobalCallback(path string, permissive, checkIP bool) (ssh.HostKeyCallback, error) {
+	var err error
+	var callback ssh.HostKeyCallback
+	if checkIP {
+		callback, err = hostkey.KnownHostsReadOnlyFileCallbackWithIPCheck(path, permissive)
+	} else {
+		callback, err = hostkey.KnownHostsReadOnlyFileCallback(path, permissive)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("create host key validator for %s: %w", path, err)
 	}
-	return cb, nil
+	return callback, nil
 }
 
 func isPermissive(ctx context.Context, c *Connection) bool {
@@ -376,13 +388,18 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 
 	permissive := isPermissive(ctx, c)
 	hash := shouldHash(ctx, c)
+	checkIP := c.sshConfig.CheckHostIP.IsTrue()
+
+	if checkIP {
+		log.Trace(ctx, "CheckHostIP enabled, IP verification active", log.KeyHost, c)
+	}
 
 	if path, ok := hostkey.KnownHostsPathFromEnv(); ok {
 		if path == "" {
 			return hostkey.InsecureIgnoreHostKeyCallback, nil
 		}
 		c.Log().Debug("using known_hosts file from SSH_KNOWN_HOSTS", log.KeyHost, c, log.KeyFile, path)
-		return knownhostsCallback(path, permissive, hash)
+		return knownhostsCallback(path, permissive, hash, checkIP)
 	}
 
 	var khPath string
@@ -402,13 +419,13 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 
 	if khPath != "" {
 		log.Trace(ctx, "using known_hosts file", log.KeyHost, c, log.KeyFile, khPath)
-		return knownhostsCallback(khPath, permissive, hash)
+		return knownhostsCallback(khPath, permissive, hash, checkIP)
 	}
 
-	return globalKnownHostsCallback(ctx, c.sshConfig.GlobalKnownHostsFile, permissive)
+	return globalKnownHostsCallback(ctx, c.sshConfig.GlobalKnownHostsFile, permissive, checkIP)
 }
 
-func globalKnownHostsCallback(ctx context.Context, paths []string, permissive bool) (ssh.HostKeyCallback, error) {
+func globalKnownHostsCallback(ctx context.Context, paths []string, permissive, checkIP bool) (ssh.HostKeyCallback, error) {
 	var lastErr error
 	for _, f := range paths {
 		log.Trace(ctx, "trying global known_hosts file", log.KeyFile, f)
@@ -433,7 +450,7 @@ func globalKnownHostsCallback(ctx context.Context, paths []string, permissive bo
 				continue
 			}
 		}
-		cb, err := knownhostsGlobalCallback(exp, permissive)
+		cb, err := knownhostsGlobalCallback(exp, permissive, checkIP)
 		if err != nil {
 			lastErr = err
 			log.Trace(ctx, "skipping unusable global known_hosts file", log.KeyFile, exp, log.KeyError, err)

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -796,6 +796,39 @@ func TestHostkeyCallbackSkipsMissingGlobalKnownHostsFile(t *testing.T) {
 	require.True(t, os.IsNotExist(statErr), "hostkeyCallback must not create missing global known_hosts files")
 }
 
+func TestHostkeyCallbackCheckHostIPEnabled(t *testing.T) {
+	unsetKnownHostsEnv(t)
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	// Write known_hosts with a single IP entry — the callback is exercised
+	// with that IP as hostname so WithCheckHostIP skips the DNS lookup.
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+	line := string(ssh.MarshalAuthorizedKey(signer.PublicKey()))
+	khPath := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(khPath,
+		[]byte("[192.0.2.1]:22 "+line),
+		0o600))
+
+	c := &Connection{
+		sshConfig: &sshconfig.Config{
+			UserKnownHostsFile: []string{khPath},
+			CheckHostIP:        options.BooleanOption("yes"),
+		},
+	}
+
+	cb, err := c.hostkeyCallback(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, cb)
+
+	// IP hostname: WithCheckHostIP must skip DNS and accept the known key.
+	require.NoError(t, cb("192.0.2.1:22", addr, signer.PublicKey()))
+}
+
 func TestSelectBindAddr(t *testing.T) {
 	loopback4 := &net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)}
 	linkLocal4 := &net.IPNet{IP: net.ParseIP("169.254.1.1"), Mask: net.CIDRMask(16, 32)}

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -8,12 +8,18 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 )
+
+// lookupHost resolves a hostname to IP addresses. Overridable in tests.
+var lookupHost = net.LookupHost
+
+const devNull = "/dev/null"
 
 var (
 	// ErrHostKeyMismatch is returned when the host key does not match the host key or a key in known_hosts file.
@@ -47,7 +53,7 @@ var KnownHostsPathFromEnv = func() (string, bool) {
 
 // KnownHostsFileCallback returns a HostKeyCallback that uses a known hosts file to verify host keys.
 func KnownHostsFileCallback(path string, permissive, hash bool) (ssh.HostKeyCallback, error) {
-	if path == "/dev/null" {
+	if path == devNull {
 		return InsecureIgnoreHostKeyCallback, nil
 	}
 
@@ -71,7 +77,7 @@ func KnownHostsFileCallback(path string, permissive, hash bool) (ssh.HostKeyCall
 // This is appropriate for system-wide files such as /etc/ssh/ssh_known_hosts that
 // should not be modified by unprivileged users.
 func KnownHostsReadOnlyFileCallback(path string, permissive bool) (ssh.HostKeyCallback, error) {
-	if path == "/dev/null" {
+	if path == devNull {
 		return InsecureIgnoreHostKeyCallback, nil
 	}
 
@@ -92,6 +98,56 @@ func KnownHostsReadOnlyFileCallback(path string, permissive bool) (ssh.HostKeyCa
 	}
 
 	return wrapReadOnlyCallback(hkc, permissive), nil
+}
+
+// KnownHostsFileCallbackWithIPCheck is like KnownHostsFileCallback but also
+// verifies the connecting IP address. It parses the known_hosts file once,
+// sharing the checker between hostname and IP verification.
+func KnownHostsFileCallbackWithIPCheck(path string, permissive, hash bool) (ssh.HostKeyCallback, error) {
+	if path == devNull {
+		return InsecureIgnoreHostKeyCallback, nil
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if err := ensureFile(path); err != nil {
+		return nil, err
+	}
+
+	hkc, err := knownhosts.New(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: knownhosts callback: %w", ErrCheckHostKey, err)
+	}
+
+	return wrapCheckHostIP(wrapCallback(hkc, path, permissive, hash), hkc, permissive), nil
+}
+
+// KnownHostsReadOnlyFileCallbackWithIPCheck is like KnownHostsReadOnlyFileCallback
+// but also verifies the connecting IP address. It parses the known_hosts file once,
+// sharing the checker between hostname and IP verification.
+func KnownHostsReadOnlyFileCallbackWithIPCheck(path string, permissive bool) (ssh.HostKeyCallback, error) {
+	if path == devNull {
+		return InsecureIgnoreHostKeyCallback, nil
+	}
+
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrCheckHostKey, err)
+	}
+	if !stat.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: %s is not a regular file", ErrCheckHostKey, path)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	hkc, err := knownhosts.New(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: knownhosts callback: %w", ErrCheckHostKey, err)
+	}
+
+	return wrapCheckHostIP(wrapReadOnlyCallback(hkc, permissive), hkc, permissive), nil
 }
 
 // extends a knownhosts callback to not return an error when the key
@@ -178,6 +234,116 @@ func wrapReadOnlyCallback(hkc ssh.HostKeyCallback, permissive bool) ssh.HostKeyC
 		}
 		return fmt.Errorf("%w: unknown host: %w", ErrHostKeyMismatch, err)
 	})
+}
+
+// WithCheckHostIP wraps cb to also verify the connecting IP address in
+// known_hosts. When the remote address is a TCP connection the actual connected
+// IP is checked directly; otherwise all DNS-resolved addresses are checked.
+// If the IP is found in known_hosts with a different key (potential DNS
+// spoofing), ErrHostKeyMismatch is returned. DNS resolution failures are
+// non-fatal. Skipped when hostname is already an IP address. Unlike OpenSSH,
+// this implementation never writes IP addresses to known_hosts.
+func WithCheckHostIP(cb ssh.HostKeyCallback, path string, permissive bool) (ssh.HostKeyCallback, error) {
+	if path == devNull {
+		return cb, nil
+	}
+	mu.Lock()
+	rawChecker, err := knownhosts.New(path)
+	mu.Unlock()
+	if err != nil {
+		return nil, fmt.Errorf("%w: check-host-ip: %w", ErrCheckHostKey, err)
+	}
+	return wrapCheckHostIP(cb, rawChecker, permissive), nil
+}
+
+// checkResolvedIP checks a single resolved IP address against rawChecker.
+// Returns an error for a known key mismatch (potential DNS spoofing) and, in
+// strict mode, also for unexpected checker errors (IO, address parsing).
+// Must be called with mu held.
+func checkResolvedIP(rawChecker ssh.HostKeyCallback, addr, port string, remote net.Addr, key ssh.PublicKey, permissive bool) error {
+	effectivePort := port
+	ipAddr := &net.TCPAddr{IP: net.ParseIP(addr)}
+	if tcp, ok := remote.(*net.TCPAddr); ok {
+		ipAddr.Port = tcp.Port
+		effectivePort = strconv.Itoa(tcp.Port)
+	} else if p, err := strconv.Atoi(port); err == nil {
+		ipAddr.Port = p
+	}
+	ipHost := net.JoinHostPort(addr, effectivePort)
+	ipErr := rawChecker(ipHost, ipAddr, key)
+	if ipErr == nil {
+		return nil
+	}
+	var keyErr *knownhosts.KeyError
+	if !errors.As(ipErr, &keyErr) {
+		// unexpected error (e.g. IO, address parsing) — surface in strict mode
+		if permissive {
+			fmt.Fprintln(os.Stderr, "Ignored SSH host key check error for resolved IP", addr, "because StrictHostKeyChecking is set to 'no' in ssh config")
+			return nil
+		}
+		return fmt.Errorf("%w: resolved IP %s: %w", ErrHostKeyMismatch, addr, ipErr)
+	}
+	if len(keyErr.Want) == 0 {
+		return nil // unknown IP in detection-only mode is not an error
+	}
+	if permissive {
+		fmt.Fprintln(os.Stderr, "Ignored SSH host key mismatch for resolved IP", addr, "because StrictHostKeyChecking is set to 'no' in ssh config")
+		return nil
+	}
+	return fmt.Errorf("%w: resolved IP %s: %w", ErrHostKeyMismatch, addr, ipErr)
+}
+
+func wrapCheckHostIP(callback, rawChecker ssh.HostKeyCallback, permissive bool) ssh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		host, port, err := net.SplitHostPort(hostname)
+		if err != nil {
+			// hostname has no port — use it as-is and derive the port from the remote address
+			host = hostname
+			if tcp, ok := remote.(*net.TCPAddr); ok {
+				port = strconv.Itoa(tcp.Port)
+			}
+		}
+
+		// Perform the IP check before invoking callback so that a spoofed key is
+		// never written to known_hosts when a mismatch is detected.
+		if net.ParseIP(host) == nil && port != "" {
+			if ipErr := checkHostIP(rawChecker, host, port, remote, key, permissive); ipErr != nil {
+				return ipErr
+			}
+		}
+
+		return callback(hostname, remote, key)
+	}
+}
+
+// checkHostIP verifies the connecting IP address in known_hosts. When the
+// remote is a TCP connection the actual connected IP is checked directly;
+// otherwise all DNS-resolved addresses are checked. DNS resolution failures
+// are non-fatal.
+func checkHostIP(rawChecker ssh.HostKeyCallback, host, port string, remote net.Addr, key ssh.PublicKey, permissive bool) error {
+	// When the connected address is known, check only that IP to avoid
+	// false positives from multi-homed hostnames (round-robin/CDN).
+	if tcp, ok := remote.(*net.TCPAddr); ok && tcp.IP != nil {
+		mu.Lock()
+		err := checkResolvedIP(rawChecker, tcp.IP.String(), port, remote, key, permissive)
+		mu.Unlock()
+		return err
+	}
+
+	addrs, dnsErr := lookupHost(host)
+	if dnsErr != nil {
+		return nil //nolint:nilerr // DNS resolution failures are non-fatal per doc comment.
+	}
+
+	var loopErr error
+	mu.Lock()
+	for _, addr := range addrs {
+		if loopErr = checkResolvedIP(rawChecker, addr, port, remote, key, permissive); loopErr != nil {
+			break
+		}
+	}
+	mu.Unlock()
+	return loopErr
 }
 
 func fileExists(path string) bool {

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -17,7 +17,11 @@ import (
 )
 
 // lookupHost resolves a hostname to IP addresses. Overridable in tests.
-var lookupHost = net.LookupHost
+// Access must be serialized with lookupHostMu.
+var (
+	lookupHostMu sync.Mutex
+	lookupHost   = net.LookupHost
+)
 
 const devNull = "/dev/null"
 
@@ -330,7 +334,11 @@ func checkHostIP(rawChecker ssh.HostKeyCallback, host, port string, remote net.A
 		return err
 	}
 
-	addrs, dnsErr := lookupHost(host)
+	lookupHostMu.Lock()
+	resolve := lookupHost
+	lookupHostMu.Unlock()
+
+	addrs, dnsErr := resolve(host)
 	if dnsErr != nil {
 		return nil //nolint:nilerr // DNS resolution failures are non-fatal per doc comment.
 	}

--- a/protocol/ssh/hostkey/callbacks_test.go
+++ b/protocol/ssh/hostkey/callbacks_test.go
@@ -109,9 +109,15 @@ func TestKnownHostsReadOnlyFileCallbackAcceptsKnownHost(t *testing.T) {
 // restores the original on cleanup.
 func stubLookupHost(t *testing.T, fn func(string) ([]string, error)) {
 	t.Helper()
+	hostkey.LookupHostMu.Lock()
 	prev := *hostkey.LookupHostFunc
 	*hostkey.LookupHostFunc = fn
-	t.Cleanup(func() { *hostkey.LookupHostFunc = prev })
+	hostkey.LookupHostMu.Unlock()
+	t.Cleanup(func() {
+		hostkey.LookupHostMu.Lock()
+		*hostkey.LookupHostFunc = prev
+		hostkey.LookupHostMu.Unlock()
+	})
 }
 
 // writeKnownHostsFile writes the given lines to a temp known_hosts file and

--- a/protocol/ssh/hostkey/callbacks_test.go
+++ b/protocol/ssh/hostkey/callbacks_test.go
@@ -3,6 +3,7 @@ package hostkey_test
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -102,4 +103,154 @@ func TestKnownHostsReadOnlyFileCallbackAcceptsKnownHost(t *testing.T) {
 	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
 	require.NoError(t, err)
 	require.NoError(t, cb("192.0.2.1:22", addr, signer.PublicKey()))
+}
+
+// stubLookupHost overrides hostkey.LookupHostFunc for the duration of t and
+// restores the original on cleanup.
+func stubLookupHost(t *testing.T, fn func(string) ([]string, error)) {
+	t.Helper()
+	prev := *hostkey.LookupHostFunc
+	*hostkey.LookupHostFunc = fn
+	t.Cleanup(func() { *hostkey.LookupHostFunc = prev })
+}
+
+// writeKnownHostsFile writes the given lines to a temp known_hosts file and
+// returns its path.
+func writeKnownHostsFile(t *testing.T, lines ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "known_hosts")
+	content := ""
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestWithCheckHostIPMismatchDetected(t *testing.T) {
+	legit := newTestSigner(t) // key known_hosts records for the hostname
+	spoof := newTestSigner(t) // different key stored for the IP → DNS spoofing
+
+	khFile := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("example.com:22")}, legit.PublicKey()),
+		knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, spoof.PublicKey()),
+	)
+	stubLookupHost(t, func(host string) ([]string, error) {
+		if host == "example.com" {
+			return []string{"192.0.2.1"}, nil
+		}
+		return nil, nil
+	})
+
+	inner, err := hostkey.KnownHostsReadOnlyFileCallback(khFile, false)
+	require.NoError(t, err)
+
+	wrapped, err := hostkey.WithCheckHostIP(inner, khFile, false)
+	require.NoError(t, err)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	cbErr := wrapped("example.com:22", addr, legit.PublicKey())
+	require.ErrorIs(t, cbErr, hostkey.ErrHostKeyMismatch, "IP with different key must be detected as spoofing")
+	require.Contains(t, cbErr.Error(), "192.0.2.1")
+}
+
+func TestWithCheckHostIPUnknownIPIsNonFatal(t *testing.T) {
+	legit := newTestSigner(t)
+
+	// known_hosts only has the hostname, not the IP
+	khFile := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("example.com:22")}, legit.PublicKey()),
+	)
+	stubLookupHost(t, func(host string) ([]string, error) {
+		return []string{"192.0.2.1"}, nil
+	})
+
+	inner, err := hostkey.KnownHostsReadOnlyFileCallback(khFile, false)
+	require.NoError(t, err)
+
+	wrapped, err := hostkey.WithCheckHostIP(inner, khFile, false)
+	require.NoError(t, err)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	require.NoError(t, wrapped("example.com:22", addr, legit.PublicKey()), "unknown IP must not be an error in detection-only mode")
+}
+
+func TestWithCheckHostIPSkipsWhenAlreadyIP(t *testing.T) {
+	legit := newTestSigner(t)
+
+	// Even if the IP has a different entry for another key, no lookup is done
+	spoof := newTestSigner(t)
+	khFile := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, spoof.PublicKey()),
+	)
+
+	lookupCalled := false
+	stubLookupHost(t, func(host string) ([]string, error) {
+		lookupCalled = true
+		return nil, nil
+	})
+
+	inner, err := hostkey.KnownHostsReadOnlyFileCallback(khFile, true) // permissive so unknown hostname passes
+	require.NoError(t, err)
+
+	wrapped, err := hostkey.WithCheckHostIP(inner, khFile, false)
+	require.NoError(t, err)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	require.NoError(t, wrapped("192.0.2.1:22", addr, legit.PublicKey()))
+	require.False(t, lookupCalled, "DNS lookup must be skipped when hostname is already an IP")
+}
+
+func TestWithCheckHostIPDNSFailureIsNonFatal(t *testing.T) {
+	legit := newTestSigner(t)
+
+	khFile := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("example.com:22")}, legit.PublicKey()),
+	)
+	stubLookupHost(t, func(host string) ([]string, error) {
+		return nil, fmt.Errorf("simulated DNS failure")
+	})
+
+	inner, err := hostkey.KnownHostsReadOnlyFileCallback(khFile, false)
+	require.NoError(t, err)
+
+	wrapped, err := hostkey.WithCheckHostIP(inner, khFile, false)
+	require.NoError(t, err)
+
+	// Use a TCPAddr with nil IP so the DNS-resolution fallback is exercised
+	// (a non-nil TCP IP would take the fast path and skip lookupHost).
+	addr := &net.TCPAddr{Port: 22}
+
+	require.NoError(t, wrapped("example.com:22", addr, legit.PublicKey()), "DNS failure must be non-fatal")
+}
+
+func TestWithCheckHostIPPermissiveDowngradesToWarning(t *testing.T) {
+	legit := newTestSigner(t)
+	spoof := newTestSigner(t)
+
+	khFile := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("example.com:22")}, legit.PublicKey()),
+		knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, spoof.PublicKey()),
+	)
+	stubLookupHost(t, func(host string) ([]string, error) {
+		return []string{"192.0.2.1"}, nil
+	})
+
+	inner, err := hostkey.KnownHostsReadOnlyFileCallback(khFile, true)
+	require.NoError(t, err)
+
+	wrapped, err := hostkey.WithCheckHostIP(inner, khFile, true)
+	require.NoError(t, err)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	require.NoError(t, wrapped("example.com:22", addr, legit.PublicKey()), "permissive mode must not return error on IP mismatch")
 }

--- a/protocol/ssh/hostkey/export_test.go
+++ b/protocol/ssh/hostkey/export_test.go
@@ -1,0 +1,4 @@
+package hostkey
+
+// LookupHostFunc exposes the package-level lookupHost for override in tests.
+var LookupHostFunc = &lookupHost

--- a/protocol/ssh/hostkey/export_test.go
+++ b/protocol/ssh/hostkey/export_test.go
@@ -2,3 +2,6 @@ package hostkey
 
 // LookupHostFunc exposes the package-level lookupHost for override in tests.
 var LookupHostFunc = &lookupHost
+
+// LookupHostMu exposes the mutex that guards lookupHost.
+var LookupHostMu = &lookupHostMu

--- a/sshconfig/config.go
+++ b/sshconfig/config.go
@@ -478,11 +478,11 @@ type Config struct {
 
 	// If set to yes, ssh(1) will additionally check the host IP
 	// address in the known_hosts file.  This allows it to
-	// detect if a host key changed due to DNS spoofing and will
-	// add addresses of destination hosts to ~/.ssh/known_hosts
-	// in the process, regardless of the setting of
-	// StrictHostKeyChecking.  If the option is set to no (the
-	// default), the check will not be executed.
+	// detect if a host key changed due to DNS spoofing.
+	// Note: unlike OpenSSH, enabling this option does not add
+	// additional IP entries to known_hosts; the check is read-only.
+	// If the option is set to no (the default), the check will not
+	// be executed.
 	CheckHostIP options.BooleanOption
 
 	// Specifies the ciphers allowed and their order of


### PR DESCRIPTION
When CheckHostIP is enabled, the host key callback additionally resolves the connecting hostname to IP addresses and checks whether any of those IPs appear in known_hosts with a different key. A mismatch returns ErrHostKeyMismatch; unknown IPs and DNS failures are non-fatal.

The IP check is read-only — no new entries are written for resolved IPs (writing both hostname and IP on first connect is deferred as a follow-on).