### PR TITLE
feat(ssh): wire HostKeyAlias from sshconfig for known_hosts lookup

### DIFF
--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -388,7 +388,10 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 
 	permissive := isPermissive(ctx, c)
 	hash := shouldHash(ctx, c)
-	checkIP := c.sshConfig.CheckHostIP.IsTrue()
+	// CheckHostIP is skipped when HostKeyAlias is set: the alias may not resolve
+	// to the actual TCP address, so IP verification against known_hosts would
+	// give wrong results. This matches OpenSSH behaviour.
+	checkIP := c.sshConfig.CheckHostIP.IsTrue() && c.sshConfig.HostKeyAlias == ""
 
 	if checkIP {
 		log.Trace(ctx, "CheckHostIP enabled, IP verification active", log.KeyHost, c)
@@ -675,6 +678,10 @@ func (c *Connection) clientConfig(ctx context.Context) (*ssh.ClientConfig, func(
 	hkc, err := c.hostkeyCallback(ctx)
 	if err != nil {
 		return nil, func() {}, err
+	}
+	if c.sshConfig.HostKeyAlias != "" {
+		log.Trace(ctx, "using HostKeyAlias for known_hosts lookup", log.KeyHost, c, "alias", c.sshConfig.HostKeyAlias)
+		hkc = hostkey.WithAlias(hkc, c.sshConfig.HostKeyAlias)
 	}
 	config.HostKeyCallback = hkc
 

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -14,12 +14,14 @@ import (
 	"time"
 
 	"github.com/k0sproject/rig/v2/protocol"
+	"github.com/k0sproject/rig/v2/protocol/ssh/hostkey"
 	"github.com/k0sproject/rig/v2/sshconfig"
 	"github.com/k0sproject/rig/v2/sshconfig/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ssh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // withConfigParser temporarily installs a hermetic ssh config parser built from
@@ -826,6 +828,53 @@ func TestHostkeyCallbackCheckHostIPEnabled(t *testing.T) {
 	require.NotNil(t, cb)
 
 	// IP hostname: WithCheckHostIP must skip DNS and accept the known key.
+	require.NoError(t, cb("192.0.2.1:22", addr, signer.PublicKey()))
+}
+
+// TestHostkeyCallbackHostKeyAliasDisablesCheckHostIP verifies that when
+// HostKeyAlias is set, IP verification (CheckHostIP) is suppressed even when
+// CheckHostIP is also enabled. A mismatching key stored under the real IP
+// in known_hosts must not cause ErrHostKeyMismatch.
+func TestHostkeyCallbackHostKeyAliasDisablesCheckHostIP(t *testing.T) {
+	unsetKnownHostsEnv(t)
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	// spoofSigner represents a different key stored under the real IP address —
+	// the entry that CheckHostIP would flag as a mismatch when both are present.
+	_, spoofPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	spoofSigner, err := ssh.NewSignerFromKey(spoofPriv)
+	require.NoError(t, err)
+
+	// Populate known_hosts with the correct key under the alias and a DIFFERENT
+	// key under the actual TCP IP to simulate what CheckHostIP would detect.
+	aliasEntry := knownhosts.Line([]string{knownhosts.Normalize("alias-host:22")}, signer.PublicKey())
+	ipEntry := knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, spoofSigner.PublicKey())
+	khPath := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(khPath, []byte(aliasEntry+"\n"+ipEntry+"\n"), 0o600))
+
+	c := &Connection{
+		sshConfig: &sshconfig.Config{
+			UserKnownHostsFile: []string{khPath},
+			CheckHostIP:        options.BooleanOption("yes"),
+			HostKeyAlias:       "alias-host",
+		},
+	}
+
+	cb, err := c.hostkeyCallback(context.Background())
+	require.NoError(t, err)
+
+	// Wrap with alias as clientConfig does.
+	cb = hostkey.WithAlias(cb, "alias-host")
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	// Must succeed: alias lookup finds the correct key; IP check is suppressed.
 	require.NoError(t, cb("192.0.2.1:22", addr, signer.PublicKey()))
 }
 

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"unicode"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -158,8 +159,7 @@ func KnownHostsReadOnlyFileCallbackWithIPCheck(path string, permissive bool) (ss
 // is not found in the known_hosts file but instead adds it to the file as new
 // entry.
 func wrapCallback(hkc ssh.HostKeyCallback, path string, permissive, hash bool) ssh.HostKeyCallback {
-	// TODO this should use the HostKeyAlias from the ssh config. It should also support the
-	// "accept-new" of StrictHostNameChecking and possibly some other options.
+	// TODO this should also support the "accept-new" of StrictHostKeyChecking and possibly some other options.
 	return ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 		mu.Lock()
 		defer mu.Unlock()
@@ -385,6 +385,74 @@ func ensureFile(path string) error {
 		return fmt.Errorf("failed to close known_hosts file: %w", err)
 	}
 	return nil
+}
+
+// aliasAddr wraps a net.Addr but returns alias (with the pre-derived port) from String.
+// This lets the alias be used as the known_hosts entry instead of the real IP.
+// The port is carried explicitly so that non-TCP remote addresses (whose String()
+// may not include a port) produce a consistent entry.
+type aliasAddr struct {
+	alias string
+	port  string
+	orig  net.Addr
+}
+
+func (a aliasAddr) Network() string {
+	if a.orig == nil {
+		return "tcp"
+	}
+	return a.orig.Network()
+}
+
+func (a aliasAddr) String() string {
+	if a.port != "" {
+		return net.JoinHostPort(a.alias, a.port)
+	}
+	return a.alias
+}
+
+// WithAlias wraps callback so that alias replaces the actual hostname for all
+// known_hosts lookups and new-entry storage. This implements the HostKeyAlias
+// ssh_config option: connecting through a bastion or tunnel stores the entry
+// under the logical alias, not the TCP address.
+func WithAlias(callback ssh.HostKeyCallback, alias string) ssh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		if alias == "" {
+			return fmt.Errorf("%w: HostKeyAlias must not be empty", ErrHostKeyMismatch)
+		}
+		if strings.IndexFunc(alias, unicode.IsSpace) >= 0 {
+			return fmt.Errorf("%w: HostKeyAlias %q contains whitespace", ErrHostKeyMismatch, alias)
+		}
+		if strings.ContainsRune(alias, ',') {
+			return fmt.Errorf("%w: HostKeyAlias %q contains comma", ErrHostKeyMismatch, alias)
+		}
+		// Reject aliases that already embed a port — the port comes from the
+		// connection, not the alias.
+		if _, _, err := net.SplitHostPort(alias); err == nil {
+			return fmt.Errorf("%w: HostKeyAlias %q must not include a port", ErrHostKeyMismatch, alias)
+		}
+		// Unbracket IPv6 literals so net.JoinHostPort re-brackets correctly
+		// (e.g. "[2001:db8::1]" → "2001:db8::1" → "[2001:db8::1]:22").
+		bareAlias := alias
+		if len(alias) >= 2 && alias[0] == '[' && alias[len(alias)-1] == ']' {
+			bareAlias = alias[1 : len(alias)-1]
+		}
+		_, port, err := net.SplitHostPort(hostname)
+		if err != nil {
+			// hostname has no port — try to derive it from remote
+			port = ""
+			if tcp, ok := remote.(*net.TCPAddr); ok && tcp.Port > 0 {
+				port = strconv.Itoa(tcp.Port)
+			}
+		}
+		var aliasHostname string
+		if port != "" {
+			aliasHostname = net.JoinHostPort(bareAlias, port)
+		} else {
+			aliasHostname = bareAlias
+		}
+		return callback(aliasHostname, aliasAddr{alias: bareAlias, port: port, orig: remote}, key)
+	}
 }
 
 // create human-readable SSH-key strings e.g. "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTY....".

--- a/protocol/ssh/hostkey/callbacks_test.go
+++ b/protocol/ssh/hostkey/callbacks_test.go
@@ -237,6 +237,129 @@ func TestWithCheckHostIPDNSFailureIsNonFatal(t *testing.T) {
 	require.NoError(t, wrapped("example.com:22", addr, legit.PublicKey()), "DNS failure must be non-fatal")
 }
 
+func TestWithAliasStoresEntryUnderAlias(t *testing.T) {
+	signer := newTestSigner(t)
+	khFile := writeKnownHostsFile(t) // empty
+
+	base, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+
+	wrapped := hostkey.WithAlias(base, "my-alias")
+
+	addr, err := net.ResolveTCPAddr("tcp", "10.0.0.5:22")
+	require.NoError(t, err)
+
+	// First call: unknown host → appended under alias, not the IP.
+	require.NoError(t, wrapped("10.0.0.5:22", addr, signer.PublicKey()))
+
+	contents, err := os.ReadFile(khFile)
+	require.NoError(t, err)
+	require.Contains(t, string(contents), "my-alias", "entry must be stored under the alias")
+	require.NotContains(t, string(contents), "10.0.0.5", "real IP must not appear in known_hosts")
+
+	// Second call: now known under alias → accepted without error.
+	require.NoError(t, wrapped("10.0.0.5:22", addr, signer.PublicKey()), "aliased host must be accepted on second connection")
+}
+
+func TestWithAliasLookupByAlias(t *testing.T) {
+	signer := newTestSigner(t)
+
+	// Pre-populate known_hosts with the alias, not the IP.
+	line := knownhosts.Line([]string{knownhosts.Normalize("my-alias:22")}, signer.PublicKey())
+	khFile := writeKnownHostsFile(t, line)
+
+	base, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+
+	wrapped := hostkey.WithAlias(base, "my-alias")
+
+	addr, err := net.ResolveTCPAddr("tcp", "10.0.0.5:22")
+	require.NoError(t, err)
+
+	require.NoError(t, wrapped("10.0.0.5:22", addr, signer.PublicKey()), "pre-existing alias entry must match")
+}
+
+func TestWithAliasRejectsInvalidAliases(t *testing.T) {
+	signer := newTestSigner(t)
+	khFile := writeKnownHostsFile(t)
+
+	base, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+
+	addr, err := net.ResolveTCPAddr("tcp", "10.0.0.5:22")
+	require.NoError(t, err)
+
+	invalid := []string{
+		"",                  // empty — produces malformed host pattern
+		"my alias",          // space
+		"tab\there",         // tab
+		"newline\nhere",     // newline
+		"cr\rhere",          // carriage return
+		"host1,host2",       // comma — would inject multiple patterns
+		"example.com:2222",  // alias already contains a port
+		"[::1]:22",          // bracketed IPv6 with port
+	}
+	for _, alias := range invalid {
+		wrapped := hostkey.WithAlias(base, alias)
+		err := wrapped("10.0.0.5:22", addr, signer.PublicKey())
+		require.ErrorIs(t, err, hostkey.ErrHostKeyMismatch, "alias %q must be rejected", alias)
+	}
+}
+
+func TestWithAliasBracketedIPv6(t *testing.T) {
+	signer := newTestSigner(t)
+
+	// Pre-populate known_hosts using the bracketed host+port form that knownhosts.Normalize produces.
+	line := knownhosts.Line([]string{knownhosts.Normalize("[2001:db8::1]:22")}, signer.PublicKey())
+	khFile := writeKnownHostsFile(t, line)
+
+	base, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+
+	// Caller passes the bracketed form as the alias (as ssh_config may produce).
+	wrapped := hostkey.WithAlias(base, "[2001:db8::1]")
+
+	addr, err := net.ResolveTCPAddr("tcp", "10.0.0.5:22")
+	require.NoError(t, err)
+
+	require.NoError(t, wrapped("10.0.0.5:22", addr, signer.PublicKey()),
+		"bracketed IPv6 alias must be unbracketed before JoinHostPort and match the known_hosts entry")
+}
+
+func TestWithAliasNilRemoteDoesNotPanic(t *testing.T) {
+	signer := newTestSigner(t)
+	khFile := writeKnownHostsFile(t)
+
+	base, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+
+	wrapped := hostkey.WithAlias(base, "my-alias")
+
+	// nil remote must not panic; the new entry is appended under the alias.
+	require.NotPanics(t, func() {
+		_ = wrapped("10.0.0.5:22", nil, signer.PublicKey())
+	})
+}
+
+func TestWithAliasMismatchedKeyReturnsError(t *testing.T) {
+	right := newTestSigner(t)
+	wrong := newTestSigner(t)
+
+	line := knownhosts.Line([]string{knownhosts.Normalize("my-alias:22")}, right.PublicKey())
+	khFile := writeKnownHostsFile(t, line)
+
+	base, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+
+	wrapped := hostkey.WithAlias(base, "my-alias")
+
+	addr, err := net.ResolveTCPAddr("tcp", "10.0.0.5:22")
+	require.NoError(t, err)
+
+	err = wrapped("10.0.0.5:22", addr, wrong.PublicKey())
+	require.ErrorIs(t, err, hostkey.ErrHostKeyMismatch)
+}
+
 func TestWithCheckHostIPPermissiveDowngradesToWarning(t *testing.T) {
 	legit := newTestSigner(t)
 	spoof := newTestSigner(t)


### PR DESCRIPTION
When HostKeyAlias is set, known_hosts lookups and new-entry storage use the alias instead of the actual hostname/IP. CheckHostIP is suppressed when an alias is active, matching OpenSSH behaviour.