### PR TITLE
feat(ssh): wire ProxyJump as bastion and ProxyCommand as transport

### DIFF
--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -306,8 +306,7 @@ func (c *Connection) disconnect() {
 	c.client = nil
 	if c.proxyCmd != nil {
 		if c.proxyCmd.Process != nil {
-			_ = c.proxyCmd.Process.Kill()
-			go c.proxyCmd.Wait() //nolint:errcheck
+			buildKillFunc(c.proxyCmd)()
 		}
 		c.proxyCmd = nil
 	}

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"slices"
 	"strconv"
 	"strings"
@@ -27,8 +28,9 @@ import (
 )
 
 const (
-	dialTCP4 = "tcp4"
-	dialTCP6 = "tcp6"
+	dialTCP4      = "tcp4"
+	dialTCP6      = "tcp6"
+	sshConfigNone = "none"
 )
 
 var (
@@ -52,12 +54,53 @@ type Connection struct {
 	once      sync.Once
 	mu        sync.Mutex
 
-	client  *ssh.Client
-	bastion *Connection
+	client               *ssh.Client
+	bastion              *Connection
+	proxyCmd             *exec.Cmd
+	bastionFromProxyJump bool
 
 	done chan struct{}
 
 	keyPaths []string
+}
+
+// wireProxyJumpBastion configures the bastion from ProxyJump when no explicit Bastion is set.
+// Only the first hop is used; multi-hop ProxyJump chains are not supported.
+func (c *Connection) wireProxyJumpBastion(options *Options) error {
+	if c.Bastion != nil || len(c.sshConfig.ProxyJump) == 0 {
+		return nil
+	}
+
+	jump := c.sshConfig.ProxyJump[0]
+	if jump == "" || jump == sshConfigNone {
+		return nil
+	}
+
+	bastionCfg, err := parseProxyJump(jump, c.User)
+	if err != nil {
+		return fmt.Errorf("ProxyJump: %w", err)
+	}
+	// Inherit explicit auth from the main connection so the bastion can
+	// authenticate with the same pre-loaded keys, key path, and passphrase callback.
+	// The bastion connection is established first (before any key is cached), so it
+	// needs the same PasswordCallback to decrypt encrypted identity files.
+	bastionCfg.AuthMethods = c.AuthMethods
+	bastionCfg.KeyPath = c.KeyPath
+	bastionCfg.PasswordCallback = c.PasswordCallback
+	options.InjectLoggerTo(bastionCfg, log.KeyProtocol, "ssh-bastion")
+	c.Bastion = bastionCfg
+	c.bastionFromProxyJump = true
+	c.Log().Debug("using ProxyJump as bastion", "jump", jump)
+	return nil
+}
+
+// configureKeepalive applies the ServerAliveInterval from ssh config if no explicit keepalive option was provided.
+func (c *Connection) configureKeepalive(options *Options) {
+	if options.KeepAliveInterval == nil && c.sshConfig.ServerAliveInterval > 0 {
+		d := c.sshConfig.ServerAliveInterval
+		options.KeepAliveInterval = &d
+		c.Log().Debug("enabling keepalive from ssh config ServerAliveInterval", "interval", d)
+	}
 }
 
 // NewConnection creates a new SSH connection. Error is currently always nil.
@@ -110,15 +153,15 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 	}
 	c.Log().Debug("resolved final port", "port", c.Port)
 
+	if err := c.wireProxyJumpBastion(options); err != nil {
+		return nil, err
+	}
+
 	// If no explicit keepalive option was provided, honor ServerAliveInterval from the ssh config.
 	// Note: platform-embedded defaults are included (e.g. macOS defaults to 30s), so a rig binary
 	// built on macOS will enable keepalive for all connections unless explicitly overridden.
 	// Pass WithKeepAlive(0) to disable keepalive regardless of the ssh config value.
-	if options.KeepAliveInterval == nil && c.sshConfig.ServerAliveInterval > 0 {
-		d := c.sshConfig.ServerAliveInterval
-		options.KeepAliveInterval = &d
-		c.Log().Debug("enabling keepalive from ssh config ServerAliveInterval", "interval", d)
-	}
+	c.configureKeepalive(options)
 
 	return c, nil
 }
@@ -261,6 +304,13 @@ func (c *Connection) disconnect() {
 	}
 	c.client.Close()
 	c.client = nil
+	if c.proxyCmd != nil {
+		if c.proxyCmd.Process != nil {
+			_ = c.proxyCmd.Process.Kill()
+			go c.proxyCmd.Wait() //nolint:errcheck
+		}
+		c.proxyCmd = nil
+	}
 	if c.bastion != nil {
 		c.bastion.Disconnect()
 		c.bastion = nil
@@ -382,16 +432,12 @@ func shouldHash(ctx context.Context, c *Connection) bool {
 	return false
 }
 
-func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, error) {
+func (c *Connection) hostkeyCallback(ctx context.Context, checkIP bool) (ssh.HostKeyCallback, error) {
 	knownHostsMU.Lock()
 	defer knownHostsMU.Unlock()
 
 	permissive := isPermissive(ctx, c)
 	hash := shouldHash(ctx, c)
-	// CheckHostIP is skipped when HostKeyAlias is set: the alias may not resolve
-	// to the actual TCP address, so IP verification against known_hosts would
-	// give wrong results. This matches OpenSSH behaviour.
-	checkIP := c.sshConfig.CheckHostIP.IsTrue() && c.sshConfig.HostKeyAlias == ""
 
 	if checkIP {
 		log.Trace(ctx, "CheckHostIP enabled, IP verification active", log.KeyHost, c)
@@ -401,7 +447,7 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 		if path == "" {
 			return hostkey.InsecureIgnoreHostKeyCallback, nil
 		}
-		c.Log().Debug("using known_hosts file from SSH_KNOWN_HOSTS", log.KeyHost, c, log.KeyFile, path)
+		c.Log().Debug("using known_hosts file from SSH_KNOWN_HOSTS", log.HostAttr(c), log.KeyFile, path)
 		return knownhostsCallback(path, permissive, hash, checkIP)
 	}
 
@@ -409,7 +455,7 @@ func (c *Connection) hostkeyCallback(ctx context.Context) (ssh.HostKeyCallback, 
 
 	// "none" anywhere in the list disables user known_hosts entirely; check
 	// the full list before committing to any path.
-	if !slices.Contains(c.sshConfig.UserKnownHostsFile, "none") {
+	if !slices.Contains(c.sshConfig.UserKnownHostsFile, sshConfigNone) {
 		for _, f := range c.sshConfig.UserKnownHostsFile {
 			log.Trace(ctx, "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
 			exp, err := homedir.Expand(f)
@@ -501,7 +547,7 @@ func mergeSigners(keySigners, agentSigners []ssh.Signer) []ssh.Signer {
 // nil signers with a no-op closer. A successful agent connection is logged at
 // debug level.
 func (c *Connection) loadAgentSigners(ctx context.Context) ([]ssh.Signer, func()) {
-	if string(c.sshConfig.IdentityAgent) == "none" {
+	if string(c.sshConfig.IdentityAgent) == sshConfigNone {
 		log.Trace(ctx, "IdentityAgent is 'none', skipping ssh agent")
 		return nil, func() {}
 	}
@@ -587,10 +633,10 @@ func (c *Connection) certSignerFromFile(ctx context.Context, certPath string, si
 // homedir.Expand so that CertificateFile entries set programmatically also work.
 // Returns nil when no matching certificate is found.
 func (c *Connection) certSignerForSigner(ctx context.Context, signer ssh.Signer, keyPath string) ssh.Signer {
-	hasNone := slices.Contains(c.sshConfig.CertificateFile, "none")
+	hasNone := slices.Contains(c.sshConfig.CertificateFile, sshConfigNone)
 	candidates := make([]string, 0, len(c.sshConfig.CertificateFile)+1)
 	for _, p := range c.sshConfig.CertificateFile {
-		if p != "none" {
+		if p != sshConfigNone {
 			candidates = append(candidates, p)
 		}
 	}
@@ -675,7 +721,11 @@ func (c *Connection) clientConfig(ctx context.Context) (*ssh.ClientConfig, func(
 		User: c.User,
 	}
 
-	hkc, err := c.hostkeyCallback(ctx)
+	// CheckHostIP is skipped when HostKeyAlias is set: the alias may not resolve
+	// to the actual TCP address, so IP verification against known_hosts would
+	// give wrong results. This matches OpenSSH behaviour.
+	checkIP := c.sshConfig.CheckHostIP.IsTrue() && c.sshConfig.HostKeyAlias == ""
+	hkc, err := c.hostkeyCallback(ctx, checkIP)
 	if err != nil {
 		return nil, func() {}, err
 	}
@@ -789,7 +839,7 @@ func (c *Connection) connectViaBastion(ctx context.Context, dst string, config *
 	if !ok {
 		return fmt.Errorf("%w: bastion connection is not an SSH connection", protocol.ErrNonRetryable)
 	}
-	c.Log().Debug("connecting to bastion", log.HostAttr(c), "bastion", bastionSSH)
+	c.Log().Debug("connecting to bastion", log.HostAttr(c), "bastion", net.JoinHostPort(c.Bastion.Address, strconv.Itoa(c.Bastion.Port)))
 	if err := bastionSSH.Connect(ctx); err != nil {
 		if errors.Is(err, hostkey.ErrHostKeyMismatch) {
 			return fmt.Errorf("%w: bastion connect: %w", protocol.ErrNonRetryable, err)
@@ -998,6 +1048,17 @@ func (c *Connection) Connect(ctx context.Context) error {
 
 	dst := net.JoinHostPort(c.Address, strconv.Itoa(c.Port))
 
+	// Intentional behavior: ProxyCommand wins over a ProxyJump-derived bastion.
+	// OpenSSH uses first-match semantics (whichever of ProxyCommand/ProxyJump
+	// appears first in ssh_config wins), but directive order is not preserved by
+	// the sshconfig parser, so that cannot be replicated here. In practice both
+	// directives being set simultaneously is rare (they come from different Host
+	// blocks) and ProxyCommand-wins is a safe default.
+	// An explicitly-configured Bastion (not from ProxyJump) always takes priority.
+	if c.sshConfig.ProxyCommand != "" && c.sshConfig.ProxyCommand != sshConfigNone && (c.Bastion == nil || c.bastionFromProxyJump) {
+		return c.connectViaProxyCommand(ctx, dst, config, agentClose)
+	}
+
 	if c.Bastion != nil {
 		return c.connectViaBastion(ctx, dst, config, agentClose)
 	}
@@ -1085,7 +1146,7 @@ func (c *Connection) pkeySigner(ctx context.Context, agentSigners []ssh.Signer, 
 		}
 
 		if c.PasswordCallback != nil {
-			log.Trace(ctx, "asking for a password to decrypt key", log.HostAttr(c), log.KeyFile, path)
+			log.Trace(ctx, "asking for a password to decrypt key", log.KeyFile, path)
 			pass, err := c.PasswordCallback()
 			if err != nil {
 				return nil, false, skipCache(fmt.Errorf("%w: failed to get password: %w", protocol.ErrNonRetryable, err))

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -720,7 +720,7 @@ func TestHostkeyCallbackUserNoneFallsBackToGlobalKnownHostsFile(t *testing.T) {
 		},
 	}
 
-	cb, err := c.hostkeyCallback(context.Background())
+	cb, err := c.hostkeyCallback(context.Background(), false)
 	require.NoError(t, err)
 	require.NotNil(t, cb)
 }
@@ -741,7 +741,7 @@ func TestHostkeyCallbackUserNoneAfterValidPathFallsBackToGlobal(t *testing.T) {
 		},
 	}
 
-	cb, err := c.hostkeyCallback(context.Background())
+	cb, err := c.hostkeyCallback(context.Background(), false)
 	require.NoError(t, err)
 	require.NotNil(t, cb)
 }
@@ -760,7 +760,7 @@ func TestHostkeyCallbackFallsBackToGlobalKnownHostsFile(t *testing.T) {
 		},
 	}
 
-	cb, err := c.hostkeyCallback(context.Background())
+	cb, err := c.hostkeyCallback(context.Background(), false)
 	require.NoError(t, err)
 	require.NotNil(t, cb)
 }
@@ -775,7 +775,7 @@ func TestHostkeyCallbackNoKnownHostsFile(t *testing.T) {
 		},
 	}
 
-	_, err := c.hostkeyCallback(context.Background())
+	_, err := c.hostkeyCallback(context.Background(), false)
 	require.Error(t, err)
 }
 
@@ -791,7 +791,7 @@ func TestHostkeyCallbackSkipsMissingGlobalKnownHostsFile(t *testing.T) {
 		},
 	}
 
-	_, err := c.hostkeyCallback(context.Background())
+	_, err := c.hostkeyCallback(context.Background(), false)
 	require.Error(t, err, "missing global known_hosts must not be created — should fall through to error")
 
 	_, statErr := os.Stat(missing)
@@ -823,7 +823,7 @@ func TestHostkeyCallbackCheckHostIPEnabled(t *testing.T) {
 		},
 	}
 
-	cb, err := c.hostkeyCallback(context.Background())
+	cb, err := c.hostkeyCallback(context.Background(), true)
 	require.NoError(t, err)
 	require.NotNil(t, cb)
 
@@ -865,7 +865,7 @@ func TestHostkeyCallbackHostKeyAliasDisablesCheckHostIP(t *testing.T) {
 		},
 	}
 
-	cb, err := c.hostkeyCallback(context.Background())
+	cb, err := c.hostkeyCallback(context.Background(), false)
 	require.NoError(t, err)
 
 	// Wrap with alias as clientConfig does.

--- a/protocol/ssh/proxy.go
+++ b/protocol/ssh/proxy.go
@@ -216,17 +216,24 @@ func (c *Connection) connectViaProxyCommand(ctx context.Context, dst string, con
 	case <-dialCtx.Done():
 		_ = pconn.Close()
 		killProc()
-		// resultCh is buffered (cap 1), so a non-blocking receive covers the race
-		// where the handshake completed concurrently with the context firing.
-		// If the goroutine hasn't written yet, the pipe close and process kill above
-		// will cause ssh.NewClientConn to fail; it will then write to the buffered
-		// channel and exit without blocking.
+		// Try a non-blocking drain first: if the handshake goroutine already wrote
+		// its result, close any ssh.Conn it produced and we're done.
+		// If it hasn't finished yet, the pipe close and process kill above will
+		// cause ssh.NewClientConn to return (pipe EOF / broken pipe), so the
+		// goroutine will write to the buffered channel and exit without blocking.
+		// The spawned goroutine closes any ssh.Conn that happened to complete just
+		// as the context fired.
 		select {
 		case r := <-resultCh:
 			if r.ncc != nil {
 				_ = r.ncc.Close()
 			}
 		default:
+			go func() {
+				if r := <-resultCh; r.ncc != nil {
+					_ = r.ncc.Close()
+				}
+			}()
 		}
 		agentClose()
 		return fmt.Errorf("proxy command connect: %w", dialCtx.Err())

--- a/protocol/ssh/proxy.go
+++ b/protocol/ssh/proxy.go
@@ -230,15 +230,6 @@ func (c *Connection) connectViaProxyCommand(ctx context.Context, dst string, con
 		agentClose()
 		return fmt.Errorf("proxy command connect: %w", dialCtx.Err())
 	case result = <-resultCh:
-		if ctxErr := dialCtx.Err(); ctxErr != nil {
-			if result.ncc != nil {
-				_ = result.ncc.Close()
-			}
-			_ = pconn.Close()
-			killProc()
-			agentClose()
-			return fmt.Errorf("proxy command connect: %w", ctxErr)
-		}
 	}
 
 	agentClose()

--- a/protocol/ssh/proxy.go
+++ b/protocol/ssh/proxy.go
@@ -1,0 +1,264 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/k0sproject/rig/v2/protocol"
+	"github.com/k0sproject/rig/v2/protocol/ssh/hostkey"
+	ssh "golang.org/x/crypto/ssh"
+)
+
+var (
+	errEmptyProxyJumpHost     = errors.New("empty host in ProxyJump entry")
+	errProxyJumpPortRange     = errors.New("port out of range in ProxyJump entry")
+	errProxyJumpTrailingColon = errors.New("trailing colon in ProxyJump address")
+)
+
+// proxyAddr is a net.Addr that carries a host:port string for the ProxyCommand
+// transport. The knownhosts library calls SplitHostPort on RemoteAddr().String(),
+// so it must look like a valid host:port, not an opaque label.
+type proxyAddr struct{ hostport string }
+
+func (a proxyAddr) Network() string { return "tcp" }
+func (a proxyAddr) String() string  { return a.hostport }
+
+// cmdConn wraps a subprocess's stdin/stdout as a net.Conn for use as an SSH transport.
+// remote is the actual server address (host:port) used by the host-key callback.
+// Deadline methods are no-ops; deadline enforcement is handled at the caller level via
+// context cancellation + process kill.
+type cmdConn struct {
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	remote proxyAddr
+	once   sync.Once
+}
+
+func (c *cmdConn) Read(b []byte) (int, error)  { return c.stdout.Read(b) } //nolint:wrapcheck // io.Reader contract: callers compare against io.EOF, wrapping breaks it
+func (c *cmdConn) Write(b []byte) (int, error) { return c.stdin.Write(b) } //nolint:wrapcheck // io.Writer contract: callers compare against io.EOF, wrapping breaks it
+func (c *cmdConn) Close() error {
+	c.once.Do(func() {
+		_ = c.stdin.Close()
+		_ = c.stdout.Close()
+	})
+	return nil
+}
+
+func (c *cmdConn) LocalAddr() net.Addr                { return proxyAddr{} }
+func (c *cmdConn) RemoteAddr() net.Addr               { return c.remote }
+func (c *cmdConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *cmdConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *cmdConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+// parseJumpPort parses and validates a port string from a ProxyJump address.
+func parseJumpPort(portStr string) (int, error) {
+	portNum, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid port in ProxyJump %q: %w", portStr, err)
+	}
+	if portNum < 1 || portNum > 65535 {
+		return 0, fmt.Errorf("%w: %d", errProxyJumpPortRange, portNum)
+	}
+	return portNum, nil
+}
+
+// stripBrackets removes surrounding [] from a bracketed IPv6 address string.
+// Returns the string unchanged if it is not bracketed.
+func stripBrackets(s string) string {
+	if len(s) >= 2 && s[0] == '[' && s[len(s)-1] == ']' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// parseProxyJump parses a single ProxyJump entry of the form
+// [user@]host[:port] or ssh://[user@]host[:port] and returns a Config for it.
+func parseProxyJump(jump, defaultUser string) (*Config, error) {
+	jump = strings.TrimPrefix(jump, "ssh://")
+
+	user := defaultUser
+	if at := strings.LastIndex(jump, "@"); at >= 0 {
+		user = jump[:at]
+		jump = jump[at+1:]
+	}
+	if user == "" {
+		user = "root"
+	}
+
+	port := 22
+	host, portStr, splitErr := net.SplitHostPort(jump)
+	if splitErr != nil {
+		// A trailing colon (e.g. "example.com:") is always invalid.
+		if strings.HasSuffix(jump, ":") {
+			return nil, fmt.Errorf("%w: %q", errProxyJumpTrailingColon, jump)
+		}
+		// Detect the no-port case by structure rather than matching the error string
+		// (which is not part of the net package's API contract).
+		// A valid no-port address is a plain hostname (no colon) or a properly
+		// bracketed IPv6 like [::1] (starts with "[" AND ends with "]").
+		// Reject unbracketed IPv6 (e.g. "::1") and malformed brackets (e.g. "[::1").
+		if (strings.HasPrefix(jump, "[") && !strings.HasSuffix(jump, "]")) ||
+			(!strings.HasPrefix(jump, "[") && strings.ContainsRune(jump, ':')) {
+			return nil, fmt.Errorf("invalid ProxyJump address %q: %w", jump, splitErr)
+		}
+		// Bare bracketed IPv6 like [::1] must have brackets stripped so
+		// Config.Address is a bare host suitable for net.JoinHostPort.
+		host = stripBrackets(jump)
+	} else {
+		var err error
+		if port, err = parseJumpPort(portStr); err != nil {
+			return nil, err
+		}
+	}
+
+	if host == "" {
+		return nil, fmt.Errorf("%w: %q", errEmptyProxyJumpHost, jump)
+	}
+
+	return &Config{Address: host, User: user, Port: port}, nil
+}
+
+// proxyCommandClientConfig returns a copy of config with CheckHostIP disabled.
+// Per ssh_config(5), CheckHostIP is unsupported for ProxyCommand: the transport
+// (subprocess stdin/stdout) does not expose the real TCP peer address, so
+// DNS-based IP verification would give incorrect results.
+func (c *Connection) proxyCommandClientConfig(ctx context.Context, config *ssh.ClientConfig) (*ssh.ClientConfig, error) {
+	if !c.sshConfig.CheckHostIP.IsTrue() || c.sshConfig.HostKeyAlias != "" {
+		return config, nil
+	}
+	hkc, err := c.hostkeyCallback(ctx, false)
+	if err != nil {
+		return nil, fmt.Errorf("%w: proxy host key callback: %w", protocol.ErrNonRetryable, err)
+	}
+	proxyCfg := *config
+	proxyCfg.HostKeyCallback = hkc
+	return &proxyCfg, nil
+}
+
+// startProxyProcess starts the ProxyCommand subprocess, wires its stdin/stdout
+// as a net.Conn, and returns a kill function for cleanup. The returned killProc
+// must be called if the caller does not store proc for later reaping.
+func startProxyProcess(pcmd, dst string) (pconn *cmdConn, proc *exec.Cmd, killProc func(), err error) {
+	args := proxyCommandArgs(pcmd)
+	proc = exec.Command(args[0], args[1:]...) //nolint:noctx,gosec // proxy process lifetime is bound to the connection, not the connect ctx; ProxyCommand is from user ssh config
+	proc.Stderr = os.Stderr                   // surface proxy process errors to the caller, matching OpenSSH behavior
+
+	stdinPipe, err := proc.StdinPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("%w: proxy command stdin pipe: %w", protocol.ErrNonRetryable, err)
+	}
+	stdoutPipe, err := proc.StdoutPipe()
+	if err != nil {
+		_ = stdinPipe.Close()
+		return nil, nil, nil, fmt.Errorf("%w: proxy command stdout pipe: %w", protocol.ErrNonRetryable, err)
+	}
+	if err := proc.Start(); err != nil {
+		_ = stdinPipe.Close()
+		_ = stdoutPipe.Close()
+		return nil, nil, nil, fmt.Errorf("%w: proxy command start: %w", protocol.ErrNonRetryable, err)
+	}
+	pconn = &cmdConn{stdin: stdinPipe, stdout: stdoutPipe, remote: proxyAddr{hostport: dst}}
+	killProc = func() {
+		_ = proc.Process.Kill()
+		go proc.Wait() //nolint:errcheck
+	}
+	return pconn, proc, killProc, nil
+}
+
+// connectViaProxyCommand runs the configured ProxyCommand, wraps its stdin/stdout as
+// an SSH transport, and completes the SSH handshake. The process is stored on c so
+// that disconnect() can reap it.
+func (c *Connection) connectViaProxyCommand(ctx context.Context, dst string, config *ssh.ClientConfig, agentClose func()) error {
+	pcmd := c.sshConfig.ProxyCommand
+	c.Log().Debug("connecting via ProxyCommand")
+
+	var err error
+	config, err = c.proxyCommandClientConfig(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	pconn, proc, killProc, err := startProxyProcess(pcmd, dst)
+	if err != nil {
+		return err
+	}
+
+	// Run the SSH handshake in a goroutine so we can honour the connect deadline /
+	// context cancellation (cmdConn.SetDeadline is a no-op).
+	type connResult struct {
+		ncc   ssh.Conn
+		chans <-chan ssh.NewChannel
+		reqs  <-chan *ssh.Request
+		err   error
+	}
+	resultCh := make(chan connResult, 1)
+	go func() {
+		ncc, chans, reqs, hsErr := ssh.NewClientConn(pconn, dst, config)
+		resultCh <- connResult{ncc, chans, reqs, hsErr}
+	}()
+
+	deadline := c.connectDeadline(ctx)
+	dialCtx := ctx
+	if !deadline.IsZero() {
+		var cancel context.CancelFunc
+		dialCtx, cancel = context.WithDeadline(ctx, deadline)
+		defer cancel()
+	}
+
+	var result connResult
+	select {
+	case <-dialCtx.Done():
+		_ = pconn.Close()
+		killProc()
+		// Drain the handshake goroutine asynchronously — it may not unblock
+		// immediately even after pipe close/process kill, so blocking here
+		// would defeat context cancellation.
+		go func() {
+			if r := <-resultCh; r.ncc != nil {
+				_ = r.ncc.Close()
+			}
+		}()
+		agentClose()
+		return fmt.Errorf("proxy command connect: %w", dialCtx.Err())
+	case result = <-resultCh:
+		if ctxErr := dialCtx.Err(); ctxErr != nil {
+			if result.ncc != nil {
+				_ = result.ncc.Close()
+			}
+			_ = pconn.Close()
+			killProc()
+			agentClose()
+			return fmt.Errorf("proxy command connect: %w", ctxErr)
+		}
+	}
+
+	agentClose()
+
+	if result.err != nil {
+		_ = pconn.Close()
+		killProc()
+		if errors.Is(result.err, hostkey.ErrHostKeyMismatch) {
+			return fmt.Errorf("%w: %w", protocol.ErrNonRetryable, result.err)
+		}
+		return fmt.Errorf("proxy command ssh connect: %w", result.err)
+	}
+
+	c.mu.Lock()
+	c.client = ssh.NewClient(result.ncc, result.chans, result.reqs)
+	c.proxyCmd = proc
+	c.startKeepalive()
+	c.mu.Unlock()
+
+	c.prewarmWindows(ctx)
+
+	return nil
+}

--- a/protocol/ssh/proxy.go
+++ b/protocol/ssh/proxy.go
@@ -167,10 +167,7 @@ func startProxyProcess(pcmd, dst string) (pconn *cmdConn, proc *exec.Cmd, killPr
 		return nil, nil, nil, fmt.Errorf("%w: proxy command start: %w", protocol.ErrNonRetryable, err)
 	}
 	pconn = &cmdConn{stdin: stdinPipe, stdout: stdoutPipe, remote: proxyAddr{hostport: dst}}
-	killProc = func() {
-		_ = proc.Process.Kill()
-		go proc.Wait() //nolint:errcheck
-	}
+	killProc = buildKillFunc(proc)
 	return pconn, proc, killProc, nil
 }
 
@@ -219,14 +216,18 @@ func (c *Connection) connectViaProxyCommand(ctx context.Context, dst string, con
 	case <-dialCtx.Done():
 		_ = pconn.Close()
 		killProc()
-		// Drain the handshake goroutine asynchronously — it may not unblock
-		// immediately even after pipe close/process kill, so blocking here
-		// would defeat context cancellation.
-		go func() {
-			if r := <-resultCh; r.ncc != nil {
+		// resultCh is buffered (cap 1), so a non-blocking receive covers the race
+		// where the handshake completed concurrently with the context firing.
+		// If the goroutine hasn't written yet, the pipe close and process kill above
+		// will cause ssh.NewClientConn to fail; it will then write to the buffered
+		// channel and exit without blocking.
+		select {
+		case r := <-resultCh:
+			if r.ncc != nil {
 				_ = r.ncc.Close()
 			}
-		}()
+		default:
+		}
 		agentClose()
 		return fmt.Errorf("proxy command connect: %w", dialCtx.Err())
 	case result = <-resultCh:

--- a/protocol/ssh/proxy_notwindows.go
+++ b/protocol/ssh/proxy_notwindows.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package ssh
+
+import (
+	"os"
+	"strings"
+)
+
+// proxyCommandArgs returns the argv to run a ProxyCommand string through the
+// user's shell ($SHELL, falling back to sh). "exec" is prepended so the shell
+// replaces itself with the child process, ensuring process kill reaches the
+// actual proxy and not a lingering shell wrapper. The prefix is skipped when
+// the first token is already "exec" to avoid producing "exec exec ...".
+//
+// Limitation: prepending "exec" changes shell semantics for leading environment
+// variable assignments (e.g. "FOO=bar nc %h %p" becomes "exec FOO=bar ..." which
+// treats the assignment as a command name rather than an env var). Use
+// "env FOO=bar nc %h %p" as a portable alternative in ProxyCommand values.
+func proxyCommandArgs(pcmd string) []string {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "sh"
+	}
+	cmd := "exec " + pcmd
+	if first := strings.Fields(pcmd); len(first) > 0 && first[0] == "exec" {
+		cmd = pcmd
+	}
+	return []string{shell, "-c", cmd}
+}

--- a/protocol/ssh/proxy_notwindows.go
+++ b/protocol/ssh/proxy_notwindows.go
@@ -4,8 +4,19 @@ package ssh
 
 import (
 	"os"
+	"os/exec"
 	"strings"
 )
+
+// buildKillFunc returns a function that kills the proxy process and reaps it.
+// On Unix, exec prepends "exec" to replace the shell with the child, so
+// killing proc.Process directly reaches the actual proxy.
+func buildKillFunc(proc *exec.Cmd) func() {
+	return func() {
+		_ = proc.Process.Kill()
+		go proc.Wait() //nolint:errcheck
+	}
+}
 
 // proxyCommandArgs returns the argv to run a ProxyCommand string through the
 // user's shell ($SHELL, falling back to sh). "exec" is prepended so the shell

--- a/protocol/ssh/proxy_test.go
+++ b/protocol/ssh/proxy_test.go
@@ -1,0 +1,408 @@
+package ssh
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ssh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// TestMain handles the helper-proxy subprocess invoked by TestConnectViaProxyCommand.
+// When RIG_TEST_SSH_PROXY=1 the binary dials RIG_TEST_SSH_PROXY_DEST and bridges stdin/stdout.
+func TestMain(m *testing.M) {
+	if os.Getenv("RIG_TEST_SSH_PROXY") == "1" {
+		dest := os.Getenv("RIG_TEST_SSH_PROXY_DEST")
+		conn, err := (&net.Dialer{Timeout: 10 * time.Second}).Dial("tcp", dest)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "helper proxy: dial %s: %v\n", dest, err)
+			os.Exit(1)
+		}
+		defer conn.Close()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			io.Copy(conn, os.Stdin) //nolint:errcheck
+		}()
+		io.Copy(os.Stdout, conn) //nolint:errcheck
+		<-done
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// startMinimalSSHServer starts a minimal SSH server with NoClientAuth (accepts
+// connections without credentials), serves no channels, and returns its listener
+// address plus the host signer so tests can pin the host key.
+func startMinimalSSHServer(t *testing.T) (addr string, hostSigner ssh.Signer) {
+	t.Helper()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	hostSigner, err = ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	cfg := &ssh.ServerConfig{
+		NoClientAuth:  true,
+		// "linux" in the version string causes isKnownPosix() to return true,
+		// short-circuiting the ver.exe probe in detectWindows and avoiding a
+		// reconnect loop that would block the test for the full context duration.
+		ServerVersion: "SSH-2.0-test-linux",
+	}
+	cfg.AddHostKey(hostSigner)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, lErr := ln.Accept()
+			if lErr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				sconn, chans, reqs, hsErr := ssh.NewServerConn(c, cfg)
+				if hsErr != nil {
+					return
+				}
+				defer sconn.Close()
+				go ssh.DiscardRequests(reqs)
+				for newChan := range chans {
+					newChan.Reject(ssh.UnknownChannelType, "not supported") //nolint:errcheck
+				}
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String(), hostSigner
+}
+
+// TestParseProxyJump exercises the ProxyJump parser for various formats.
+func TestParseProxyJump(t *testing.T) {
+	cases := []struct {
+		name        string
+		jump        string
+		defaultUser string
+		wantAddr    string
+		wantUser    string
+		wantPort    int
+		wantErr     bool
+	}{
+		{
+			name:        "host only",
+			jump:        "example.com",
+			defaultUser: "alice",
+			wantAddr:    "example.com",
+			wantUser:    "alice",
+			wantPort:    22,
+		},
+		{
+			name:        "host:port",
+			jump:        "example.com:2222",
+			defaultUser: "alice",
+			wantAddr:    "example.com",
+			wantUser:    "alice",
+			wantPort:    2222,
+		},
+		{
+			name:        "user@host",
+			jump:        "bob@example.com",
+			defaultUser: "alice",
+			wantAddr:    "example.com",
+			wantUser:    "bob",
+			wantPort:    22,
+		},
+		{
+			name:        "user@host:port",
+			jump:        "bob@example.com:2222",
+			defaultUser: "alice",
+			wantAddr:    "example.com",
+			wantUser:    "bob",
+			wantPort:    2222,
+		},
+		{
+			name:        "ssh:// URI",
+			jump:        "ssh://bob@example.com:2222",
+			defaultUser: "alice",
+			wantAddr:    "example.com",
+			wantUser:    "bob",
+			wantPort:    2222,
+		},
+		{
+			name:        "ssh:// URI host only",
+			jump:        "ssh://example.com",
+			defaultUser: "alice",
+			wantAddr:    "example.com",
+			wantUser:    "alice",
+			wantPort:    22,
+		},
+		{
+			name:        "default user falls back to root when empty",
+			jump:        "example.com",
+			defaultUser: "",
+			wantAddr:    "example.com",
+			wantUser:    "root",
+			wantPort:    22,
+		},
+		{
+			name:        "IPv4",
+			jump:        "192.0.2.1",
+			defaultUser: "u",
+			wantAddr:    "192.0.2.1",
+			wantUser:    "u",
+			wantPort:    22,
+		},
+		{
+			name:        "IPv4 with port",
+			jump:        "192.0.2.1:2222",
+			defaultUser: "u",
+			wantAddr:    "192.0.2.1",
+			wantUser:    "u",
+			wantPort:    2222,
+		},
+		{
+			name:        "bracketed IPv6 with port",
+			jump:        "[::1]:2222",
+			defaultUser: "u",
+			wantAddr:    "::1",
+			wantUser:    "u",
+			wantPort:    2222,
+		},
+		{
+			name:    "empty string",
+			jump:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid port",
+			jump:    "example.com:notaport",
+			wantErr: true,
+		},
+		{
+			name:        "bracketed IPv6 without port strips brackets",
+			jump:        "[::1]",
+			defaultUser: "u",
+			wantAddr:    "::1",
+			wantUser:    "u",
+			wantPort:    22,
+		},
+		{
+			name:    "trailing colon rejected",
+			jump:    "example.com:",
+			wantErr: true,
+		},
+		{
+			name:    "unbracketed IPv6 rejected",
+			jump:    "::1",
+			wantErr: true,
+		},
+		{
+			name:    "unbracketed IPv6 with port rejected",
+			jump:    "::1:22",
+			wantErr: true,
+		},
+		{
+			name:    "malformed bracketed IPv6 missing closing bracket rejected",
+			jump:    "[::1",
+			wantErr: true,
+		},
+		{
+			name:    "port zero rejected",
+			jump:    "example.com:0",
+			wantErr: true,
+		},
+		{
+			name:    "port too large rejected",
+			jump:    "example.com:65536",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := parseProxyJump(tc.jump, tc.defaultUser)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantAddr, cfg.Address)
+			assert.Equal(t, tc.wantUser, cfg.User)
+			assert.Equal(t, tc.wantPort, cfg.Port)
+		})
+	}
+}
+
+// TestNewConnectionProxyJumpSetsBastion verifies that ProxyJump in sshconfig
+// populates Config.Bastion when no explicit Bastion is configured.
+func TestNewConnectionProxyJumpSetsBastion(t *testing.T) {
+	withConfigParser(t, "Host target\n  ProxyJump jump.example.com\n")
+	t.Setenv("SSH_KNOWN_HOSTS", "")
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	c, err := NewConnection(Config{Address: "target", User: "alice", AuthMethods: []ssh.AuthMethod{ssh.Password("x")}})
+	require.NoError(t, err)
+	require.NotNil(t, c.Config.Bastion, "ProxyJump must populate Config.Bastion")
+	assert.Equal(t, "jump.example.com", c.Config.Bastion.Address)
+	assert.Equal(t, "alice", c.Config.Bastion.User)
+	assert.Equal(t, 22, c.Config.Bastion.Port)
+}
+
+// TestNewConnectionProxyJumpNoneIgnored verifies that ProxyJump "none" is a no-op.
+func TestNewConnectionProxyJumpNoneIgnored(t *testing.T) {
+	withConfigParser(t, "Host target\n  ProxyJump none\n")
+	t.Setenv("SSH_KNOWN_HOSTS", "")
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	c, err := NewConnection(Config{Address: "target", User: "alice", AuthMethods: []ssh.AuthMethod{ssh.Password("x")}})
+	require.NoError(t, err)
+	assert.Nil(t, c.Config.Bastion, "ProxyJump none must not set a Bastion")
+}
+
+// TestNewConnectionExplicitBastionWinsOverProxyJump verifies that an explicit
+// Bastion in Config takes precedence over the sshconfig ProxyJump value.
+func TestNewConnectionExplicitBastionWinsOverProxyJump(t *testing.T) {
+	withConfigParser(t, "Host target\n  ProxyJump ssh-config-bastion.example.com\n")
+	t.Setenv("SSH_KNOWN_HOSTS", "")
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	explicit := &Config{Address: "explicit.example.com", User: "alice", Port: 22}
+	c, err := NewConnection(Config{
+		Address:     "target",
+		User:        "alice",
+		Bastion:     explicit,
+		AuthMethods: []ssh.AuthMethod{ssh.Password("x")},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c.Config.Bastion)
+	assert.Equal(t, "explicit.example.com", c.Config.Bastion.Address, "explicit Bastion must not be overwritten by ProxyJump")
+}
+
+// TestConnectProxyCommandPrecedence verifies that ProxyCommand wins over a
+// ProxyJump-populated bastion.  The ProxyCommand here points to a fast-failing
+// binary so we can confirm the ProxyCommand path is entered without a real
+// SSH server.
+func TestConnectProxyCommandPrecedence(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix-specific ProxyCommand values (false); not portable to Windows")
+	}
+
+	withConfigParser(t, "Host target\n  ProxyJump jump.example.com\n  ProxyCommand false\n")
+	t.Setenv("SSH_KNOWN_HOSTS", "")
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	c, err := NewConnection(Config{Address: "target", User: "alice", AuthMethods: []ssh.AuthMethod{ssh.Password("x")}})
+	require.NoError(t, err)
+	// ProxyJump was wired as a bastion...
+	require.NotNil(t, c.Config.Bastion, "ProxyJump should still populate Bastion")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	connectErr := c.Connect(ctx)
+	// The error must come from the ProxyCommand path ("proxy command"), not the
+	// bastion path ("bastion dial" / "bastion connect").
+	require.Error(t, connectErr)
+	assert.Contains(t, connectErr.Error(), "proxy command", "error should originate from the ProxyCommand path")
+	assert.NotContains(t, connectErr.Error(), "bastion", "bastion path must not be entered when ProxyCommand is set")
+}
+
+// TestConnectExplicitBastionBeatsProxyCommand verifies that an explicit Config.Bastion
+// takes precedence over a ProxyCommand from sshconfig.
+func TestConnectExplicitBastionBeatsProxyCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix-specific ProxyCommand values (false); not portable to Windows")
+	}
+
+	withConfigParser(t, "Host target\n  ProxyCommand false\n")
+	t.Setenv("SSH_KNOWN_HOSTS", "")
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	explicit := &Config{Address: "explicit.example.com", User: "alice", Port: 22}
+	c, err := NewConnection(Config{
+		Address:     "target",
+		User:        "alice",
+		Bastion:     explicit,
+		AuthMethods: []ssh.AuthMethod{ssh.Password("x")},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	connectErr := c.Connect(ctx)
+	// The explicit bastion path is entered, not the ProxyCommand path.
+	require.Error(t, connectErr)
+	assert.NotContains(t, connectErr.Error(), "proxy command", "ProxyCommand must not be used when an explicit Bastion is configured")
+}
+
+// TestConnectViaProxyCommand performs an end-to-end Connect via a ProxyCommand
+// subprocess. The ProxyCommand re-invokes the test binary in helper-proxy mode,
+// which dials the in-process SSH server and bridges stdin/stdout.
+func TestConnectViaProxyCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix-specific shell commands and quoting; not portable to Windows")
+	}
+
+	// Isolate from the developer's ~/.ssh/config so ProxyCommand is the only
+	// connection path and no extra options can interfere.
+	withConfigParser(t, "")
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	serverAddr, hostSigner := startMinimalSSHServer(t)
+
+	// Parse the actual server port so the connection's dst matches the
+	// known_hosts entry and host-key verification is exercised, not bypassed.
+	serverHost, serverPortStr, err := net.SplitHostPort(serverAddr)
+	require.NoError(t, err)
+	serverPort, err := strconv.Atoi(serverPortStr)
+	require.NoError(t, err)
+
+	// Pin the host key: MarshalAuthorizedKey already includes the key type.
+	// knownhosts.Normalize converts "host:port" to "[host]:port" for non-22 ports.
+	hostPub := hostSigner.PublicKey()
+	normalizedAddr := knownhosts.Normalize(serverAddr)
+	knownHostsLine := fmt.Sprintf("%s %s\n",
+		normalizedAddr,
+		strings.TrimRight(string(ssh.MarshalAuthorizedKey(hostPub)), "\n"),
+	)
+	khFile := t.TempDir() + "/known_hosts"
+	require.NoError(t, os.WriteFile(khFile, []byte(knownHostsLine), 0o600))
+	t.Setenv("SSH_KNOWN_HOSTS", khFile)
+
+	// Build ProxyCommand: re-invoke this test binary in helper-proxy mode.
+	// All env vars are passed via t.Setenv so the child inherits them — inline
+	// shell assignments (VAR=val cmd) are incompatible with the exec prefix that
+	// connectViaProxyCommand adds to eliminate the shell wrapper process.
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	t.Setenv("PROXY_CMD_EXE", exe)
+	t.Setenv("RIG_TEST_SSH_PROXY", "1")
+	t.Setenv("RIG_TEST_SSH_PROXY_DEST", serverAddr)
+	proxyCmd := `"$PROXY_CMD_EXE" -test.run='^$'`
+
+	conn, err := NewConnection(Config{
+		Address:     serverHost,
+		Port:        serverPort,
+		User:        "test",
+		AuthMethods: []ssh.AuthMethod{ssh.Password("any")},
+	})
+	require.NoError(t, err)
+	conn.sshConfig.ProxyCommand = proxyCmd
+	t.Cleanup(conn.Disconnect)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, conn.Connect(ctx))
+}

--- a/protocol/ssh/proxy_windows.go
+++ b/protocol/ssh/proxy_windows.go
@@ -2,7 +2,24 @@
 
 package ssh
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// buildKillFunc returns a function that terminates the proxy process tree on
+// Windows. Killing proc.Process only terminates cmd.exe, leaving its children
+// (the actual proxy program) as orphans. taskkill /F /T terminates the full
+// process tree; proc.Process.Kill() is called as a fallback.
+func buildKillFunc(proc *exec.Cmd) func() {
+	return func() {
+		pid := proc.Process.Pid
+		_ = exec.Command("taskkill", "/F", "/T", "/PID", fmt.Sprintf("%d", pid)).Run() //nolint:noctx,gosec // pid is an integer, no injection risk; no ctx needed for a best-effort cleanup call
+		_ = proc.Process.Kill()
+		go proc.Wait() //nolint:errcheck
+	}
+}
 
 // proxyCommandArgs returns the argv to run a ProxyCommand string through the
 // Windows command processor (COMSPEC, falling back to cmd.exe).

--- a/protocol/ssh/proxy_windows.go
+++ b/protocol/ssh/proxy_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package ssh
+
+import "os"
+
+// proxyCommandArgs returns the argv to run a ProxyCommand string through the
+// Windows command processor (COMSPEC, falling back to cmd.exe).
+func proxyCommandArgs(pcmd string) []string {
+	shell := os.Getenv("COMSPEC")
+	if shell == "" {
+		shell = "cmd.exe"
+	}
+	return []string{shell, "/c", pcmd}
+}


### PR DESCRIPTION
Auto-populate Config.Bastion from the first ProxyJump entry in sshconfig when no explicit Bastion is configured (t-088). Support ProxyCommand as an alternative SSH transport by running the command and bridging its stdin/stdout as a net.Conn (t-099).

When both ProxyCommand and ProxyJump are set, ProxyCommand takes precedence. This intentionally diverges from OpenSSH's first-match semantics (whichever directive appears first in ssh_config wins): the sshconfig parser does not preserve directive order, so first-match cannot be replicated. In practice, both directives being set simultaneously is rare (they come from different Host blocks), and ProxyCommand-wins is a safe default. An explicitly-configured Config.Bastion (not from ProxyJump) always takes priority over ProxyCommand.

Key design decisions:
- ProxyCommand process is bound to Connection lifetime (stored in c.proxyCmd, reaped in disconnect()), not the connect context, so the transport survives after Connect() returns.
- SSH handshake runs in a goroutine with a select on the connect deadline so stalled handshakes are abortable even though SetDeadline is a no-op on a pipe transport.
- cmdConn.RemoteAddr() returns the real dst address so the knownhosts callback can call SplitHostPort on it without error.
- Token expansion (%h, %p, %r, etc.) is already handled by sshconfig.Setter.Finalize() called inside ConfigParser.Apply().
- CheckHostIP is disabled for ProxyCommand transports: the subprocess stdin/stdout pipe does not expose the real TCP peer address, so DNS-based IP verification would give incorrect results (per ssh_config(5)).