### PR TITLE
fix(misc): k0sctl migration findings

### DIFF
--- a/initsystem/defaultprovider.go
+++ b/initsystem/defaultprovider.go
@@ -49,6 +49,12 @@ type ServiceEnvironmentManager interface {
 	ServiceEnvironmentContent(env map[string]string) string
 }
 
+// ServiceEnvironmentSetter is a servicemanager that can directly set environment variables for a
+// service without an intermediate file (e.g. Windows SCM via the registry).
+type ServiceEnvironmentSetter interface {
+	SetServiceEnvironment(ctx context.Context, h cmd.ContextRunner, s string, env map[string]string) error
+}
+
 var (
 	// DefaultRegistry is the default repository for init systems.
 	DefaultRegistry = sync.OnceValue(func() *Registry {

--- a/initsystem/systemd.go
+++ b/initsystem/systemd.go
@@ -78,7 +78,7 @@ func (i Systemd) ServiceIsRunning(ctx context.Context, h cmd.ContextRunner, s st
 
 // ServiceScriptPath returns the path to a service configuration file.
 func (i Systemd) ServiceScriptPath(ctx context.Context, h cmd.ContextRunner, s string) (string, error) {
-	out, err := h.ExecOutputContext(ctx, systemctlCmd("show", "-p", "FragmentPath", s+".service").Pipe("cut", `-d"="`, "-f2").String())
+	out, err := h.ExecOutputContext(ctx, systemctlCmd("show", "-p", "FragmentPath", s+".service").Pipe("cut", "-d=", "-f2").String())
 	if err != nil {
 		return "", fmt.Errorf("failed to get service %s script path: %w", s, err)
 	}

--- a/initsystem/winscm.go
+++ b/initsystem/winscm.go
@@ -99,7 +99,7 @@ func (c WinSCM) SetServiceEnvironment(ctx context.Context, runner cmd.ContextRun
 		regPath,
 		strings.Join(entries, ","),
 	)
-	if err := runner.ExecContext(ctx, script, cmd.PS()); err != nil {
+	if err := runner.ExecContext(ctx, script, cmd.PS(), cmd.Sensitive()); err != nil {
 		return fmt.Errorf("failed to set environment for service %s: %w", s, err)
 	}
 	return nil

--- a/initsystem/winscm.go
+++ b/initsystem/winscm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/k0sproject/rig/v2/cmd"
@@ -79,6 +80,29 @@ func (c WinSCM) DisableService(ctx context.Context, h cmd.ContextRunner, s strin
 // ServiceIsRunning returns true if a service is running.
 func (c WinSCM) ServiceIsRunning(ctx context.Context, h cmd.ContextRunner, s string) bool {
 	return h.ExecContext(ctx, fmt.Sprintf("$ErrorActionPreference='Stop'\nif ((Get-Service %s -ErrorAction SilentlyContinue).Status -ne 'Running') { exit 1 }", ps.SingleQuote(s)), cmd.PS()) == nil
+}
+
+// SetServiceEnvironment sets environment variables for a Windows service via the registry.
+func (c WinSCM) SetServiceEnvironment(ctx context.Context, runner cmd.ContextRunner, s string, env map[string]string) error {
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	entries := make([]string, len(keys))
+	for i, k := range keys {
+		entries[i] = ps.SingleQuote(k + "=" + env[k])
+	}
+	regPath := ps.SingleQuote(`HKLM:\SYSTEM\CurrentControlSet\Services\` + s)
+	script := fmt.Sprintf(
+		"$ErrorActionPreference='Stop'\nNew-ItemProperty -LiteralPath %s -Name 'Environment' -PropertyType MultiString -Value @(%s) -Force -ErrorAction Stop | Out-Null",
+		regPath,
+		strings.Join(entries, ","),
+	)
+	if err := runner.ExecContext(ctx, script, cmd.PS()); err != nil {
+		return fmt.Errorf("failed to set environment for service %s: %w", s, err)
+	}
+	return nil
 }
 
 // RegisterWinSCM registers the WinSCM in a repository.

--- a/initsystem/winscm_test.go
+++ b/initsystem/winscm_test.go
@@ -126,6 +126,27 @@ func TestWinSCMDisableService(t *testing.T) {
 	})
 }
 
+func TestWinSCMSetServiceEnvironment(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+		err := initsystem.WinSCM{}.SetServiceEnvironment(context.Background(), mr, "myservice", map[string]string{"FOO": "bar", "BAZ": "qux"})
+		require.NoError(t, err)
+		script := decodePSCmd(t, mr.LastCommand())
+		require.Contains(t, script, "New-ItemProperty")
+		require.Contains(t, script, `HKLM:\SYSTEM\CurrentControlSet\Services\myservice`)
+		require.Contains(t, script, "MultiString")
+		require.Contains(t, script, "FOO=bar")
+		require.Contains(t, script, "BAZ=qux")
+	})
+	t.Run("failure", func(t *testing.T) {
+		mr := newWinRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
+		err := initsystem.WinSCM{}.SetServiceEnvironment(context.Background(), mr, "myservice", map[string]string{"FOO": "bar"})
+		require.Error(t, err)
+	})
+}
+
 func TestWinSCMServiceIsRunning(t *testing.T) {
 	t.Run("running", func(t *testing.T) {
 		mr := newWinRunner()

--- a/remotefs/http.go
+++ b/remotefs/http.go
@@ -1,99 +1,63 @@
 package remotefs
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 )
 
-const maxEncodedResponseSize = 32 * 1024 * 1024 // base64-encoded limit (~24 MiB decoded)
+// ErrHTTPStatusNotSupported is returned by HTTPStatusInsecure when the FS
+// implementation does not support HTTP status checks. Callers can detect this
+// with errors.Is.
+var ErrHTTPStatusNotSupported = errors.New("http status check not supported by this filesystem type")
 
 var (
-	errNilRequest        = errors.New("net/http: nil Request")
-	errNilRequestURL     = errors.New("net/http: nil Request.URL")
-	errUnsupportedScheme = errors.New("unsupported URL scheme")
-	errMissingURLHost    = errors.New("missing URL host")
-	errUserinfoInURL     = errors.New("URL must not contain userinfo (credentials in URLs leak to remote command line)")
-	errInvalidURLChars   = errors.New("URL contains control characters (CR, LF, or NUL)")
-	errInvalidHeader     = errors.New("invalid header: contains CR, LF, or NUL")
-	errResponseTooLarge  = errors.New("http response exceeds maximum size")
+	errURLInvalidCharacter    = errors.New("url contains invalid character")
+	errURLContainsCredentials = errors.New("url must not contain credentials")
+	errURLInvalidScheme       = errors.New("url scheme must be http or https")
+	errURLMissingHost         = errors.New("url must contain a host")
 )
 
-// validateRoundTripURL returns an error if u has an unsupported scheme, no host, userinfo, or control characters.
-// Must be called after a nil-URL guard.
-func validateRoundTripURL(target *url.URL) error {
-	if strings.ContainsAny(target.String(), "\r\n\x00") {
-		return errInvalidURLChars
+// httpStatusProvider is implemented by FS types that support insecure HTTP status checks.
+type httpStatusProvider interface {
+	httpStatusInsecure(ctx context.Context, url string) (int, error)
+}
+
+func validateHTTPURL(rawURL string) error {
+	for _, c := range rawURL {
+		if c < 0x20 || c == 0x7f {
+			return fmt.Errorf("%w: %q", errURLInvalidCharacter, c)
+		}
 	}
-	switch strings.ToLower(target.Scheme) {
-	case "http", "https":
-	default:
-		return fmt.Errorf("%w: %q", errUnsupportedScheme, target.Scheme)
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
 	}
-	if target.Host == "" {
-		return errMissingURLHost
+	if scheme := strings.ToLower(u.Scheme); scheme != "http" && scheme != "https" {
+		return fmt.Errorf("%w: %q", errURLInvalidScheme, u.Scheme)
 	}
-	if target.User != nil {
-		return errUserinfoInURL
+	if u.Host == "" {
+		return errURLMissingHost
+	}
+	if u.User != nil {
+		return errURLContainsCredentials
 	}
 	return nil
 }
 
-// HTTPTransport is implemented by remote filesystems that can proxy HTTP requests
-// through the remote host. Since RoundTrip matches the http.RoundTripper signature,
-// any FS value satisfies http.RoundTripper and can be used directly as http.Client.Transport.
-//
-// Note: RoundTrip materializes the entire HTTP response on the remote side before
-// transferring it to the caller as a base64-encoded string. Depending on the
-// implementation, the remote side may buffer the response in memory or write it to a
-// temporary file, and the caller also buffers the full response while decoding and
-// parsing it. It is not suitable for large response bodies; use DownloadURL for
-// downloading large files instead.
-type HTTPTransport interface {
-	DownloadURL(url, dst string) error
-	RoundTrip(req *http.Request) (*http.Response, error)
-}
-
-// HTTPStatus issues a HEAD request via t and returns the HTTP status code.
-func HTTPStatus(ctx context.Context, t http.RoundTripper, url string) (int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
-	if err != nil {
-		return 0, fmt.Errorf("http-status: %w", err)
+// HTTPStatusInsecure checks whether url is reachable and returns the HTTP status
+// code, skipping TLS certificate verification. On Windows with PowerShell 5.x,
+// TLS certificate verification is not skipped and requests will fail for
+// self-signed certificates.
+func HTTPStatusInsecure(ctx context.Context, fs FS, url string) (int, error) {
+	if err := validateHTTPURL(url); err != nil {
+		return 0, fmt.Errorf("HTTPStatusInsecure: %w", err)
 	}
-	resp, err := t.RoundTrip(req)
-	if err != nil {
-		return 0, fmt.Errorf("http-status %s: %w", req.URL.Redacted(), err)
+	p, ok := fs.(httpStatusProvider)
+	if !ok {
+		return 0, ErrHTTPStatusNotSupported
 	}
-	_ = resp.Body.Close()
-	return resp.StatusCode, nil
-}
-
-// parseRawHTTPResponse decodes a base64-encoded raw HTTP/1.1 response and parses it.
-// 100 Continue responses are consumed and discarded; all other responses are returned as-is.
-func parseRawHTTPResponse(encoded string, req *http.Request) (*http.Response, error) {
-	cleaned := strings.NewReplacer("\r", "", "\n", "").Replace(strings.TrimSpace(encoded))
-	if len(cleaned) > maxEncodedResponseSize {
-		return nil, fmt.Errorf("%w (%d bytes)", errResponseTooLarge, len(cleaned))
-	}
-	raw, err := base64.StdEncoding.DecodeString(cleaned)
-	if err != nil {
-		return nil, fmt.Errorf("decode http response: %w", err)
-	}
-	reader := bufio.NewReader(bytes.NewReader(raw))
-	for {
-		resp, err := http.ReadResponse(reader, req)
-		if err != nil {
-			return nil, fmt.Errorf("parse http response: %w", err)
-		}
-		if resp.StatusCode != http.StatusContinue {
-			return resp, nil
-		}
-		_ = resp.Body.Close()
-	}
+	return p.httpStatusInsecure(ctx, url)
 }

--- a/remotefs/http_test.go
+++ b/remotefs/http_test.go
@@ -2,11 +2,8 @@ package remotefs_test
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
-	"io"
-	"net/http"
-	"strings"
+	"fmt"
 	"testing"
 
 	"github.com/k0sproject/rig/v2/remotefs"
@@ -14,332 +11,107 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPosixRoundTripGET(t *testing.T) {
-	rawResp := "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nhello"
-	encoded := base64.StdEncoding.EncodeToString([]byte(rawResp))
-
+func TestHTTPStatusInsecureURLValidation(t *testing.T) {
 	mr := rigtest.NewMockRunner()
-	mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
-	mr.AddCommandOutput(rigtest.Equal("command -v base64"), "/usr/bin/base64")
-	mr.AddCommandOutput(rigtest.Contains("--http1.1"), encoded)
 	f := remotefs.NewPosixFS(mr)
 
-	req, err := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-	require.NoError(t, err)
-
-	resp, err := f.RoundTrip(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	require.Equal(t, 200, resp.StatusCode)
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, "hello", string(body))
-}
-
-func TestPosixRoundTrip404(t *testing.T) {
-	rawResp := "HTTP/1.1 404 Not Found\r\n\r\n"
-	encoded := base64.StdEncoding.EncodeToString([]byte(rawResp))
-
-	mr := rigtest.NewMockRunner()
-	mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
-	mr.AddCommandOutput(rigtest.Equal("command -v base64"), "/usr/bin/base64")
-	mr.AddCommandOutput(rigtest.Contains("--http1.1"), encoded)
-	f := remotefs.NewPosixFS(mr)
-
-	req, err := http.NewRequest(http.MethodGet, "http://example.com/missing", nil)
-	require.NoError(t, err)
-
-	resp, err := f.RoundTrip(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	require.Equal(t, 404, resp.StatusCode)
-}
-
-func TestPosixRoundTripWithRequestBody(t *testing.T) {
-	rawResp := "HTTP/1.1 201 Created\r\n\r\n"
-	encoded := base64.StdEncoding.EncodeToString([]byte(rawResp))
-
-	mr := rigtest.NewMockRunner()
-	mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
-	mr.AddCommandOutput(rigtest.Equal("command -v base64"), "/usr/bin/base64")
-	mr.AddCommandOutput(rigtest.Contains("--http1.1"), encoded)
-	f := remotefs.NewPosixFS(mr)
-
-	req, err := http.NewRequest(http.MethodPost, "http://example.com/api", strings.NewReader(`{"key":"val"}`))
-	require.NoError(t, err)
-
-	resp, err := f.RoundTrip(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	require.Equal(t, 201, resp.StatusCode)
-	require.Contains(t, mr.LastCommand(), "--data-binary")
-	// curl adds Content-Type: application/x-www-form-urlencoded for --data-binary when none is set;
-	// we suppress it so callers get the same default-free behavior as net/http.
-	require.Contains(t, mr.LastCommand(), "Content-Type:")
-}
-
-func TestPosixRoundTripBodyWithContentType(t *testing.T) {
-	rawResp := "HTTP/1.1 200 OK\r\n\r\n"
-	encoded := base64.StdEncoding.EncodeToString([]byte(rawResp))
-
-	mr := rigtest.NewMockRunner()
-	mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
-	mr.AddCommandOutput(rigtest.Equal("command -v base64"), "/usr/bin/base64")
-	mr.AddCommandOutput(rigtest.Contains("--http1.1"), encoded)
-	f := remotefs.NewPosixFS(mr)
-
-	req, err := http.NewRequest(http.MethodPost, "http://example.com/api", strings.NewReader(`{"key":"val"}`))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := f.RoundTrip(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	require.Equal(t, 200, resp.StatusCode)
-	require.Contains(t, mr.LastCommand(), "Content-Type: application/json")
-}
-
-func TestPosixRoundTripCurlUnavailable(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.AddCommandFailure(rigtest.Equal("command -v curl"), errors.New("not found"))
-	f := remotefs.NewPosixFS(mr)
-
-	req, err := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-	require.NoError(t, err)
-
-	_, err = f.RoundTrip(req)
-	require.Error(t, err)
-}
-
-func TestPosixRoundTripBase64Unavailable(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
-	mr.AddCommandFailure(rigtest.Equal("command -v base64"), errors.New("not found"))
-	f := remotefs.NewPosixFS(mr)
-
-	req, err := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-	require.NoError(t, err)
-
-	_, err = f.RoundTrip(req)
-	require.Error(t, err)
-}
-
-func TestHTTPStatusFreeFuncPosix(t *testing.T) {
-	rawResp := "HTTP/1.1 200 OK\r\n\r\n"
-	encoded := base64.StdEncoding.EncodeToString([]byte(rawResp))
-
-	mr := rigtest.NewMockRunner()
-	mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
-	mr.AddCommandOutput(rigtest.Equal("command -v base64"), "/usr/bin/base64")
-	mr.AddCommandOutput(rigtest.Contains("--http1.1"), encoded)
-	f := remotefs.NewPosixFS(mr)
-
-	code, err := remotefs.HTTPStatus(context.Background(), f, "http://example.com/health")
-	require.NoError(t, err)
-	require.Equal(t, 200, code)
-
-	require.Contains(t, mr.LastCommand(), "-I")
-}
-
-func TestWinRoundTripGET(t *testing.T) {
-	rawResp := "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nhello"
-	encoded := base64.StdEncoding.EncodeToString([]byte(rawResp))
-
-	mr := rigtest.NewMockRunner()
-	mr.Windows = true
-	mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), encoded)
-	f := remotefs.NewWindowsFS(mr)
-
-	req, err := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-	require.NoError(t, err)
-
-	resp, err := f.RoundTrip(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	require.Equal(t, 200, resp.StatusCode)
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, "hello", string(body))
-}
-
-func TestWinRoundTripCommandError(t *testing.T) {
-	mr := rigtest.NewMockRunner()
-	mr.Windows = true
-	mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
-	f := remotefs.NewWindowsFS(mr)
-
-	req, err := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-	require.NoError(t, err)
-
-	_, err = f.RoundTrip(req)
-	require.Error(t, err)
-}
-
-func TestWinRoundTrip404(t *testing.T) {
-	rawResp := "HTTP/1.1 404 Not Found\r\n\r\n"
-	encoded := base64.StdEncoding.EncodeToString([]byte(rawResp))
-
-	mr := rigtest.NewMockRunner()
-	mr.Windows = true
-	mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), encoded)
-	f := remotefs.NewWindowsFS(mr)
-
-	req, err := http.NewRequest(http.MethodGet, "http://example.com/missing", nil)
-	require.NoError(t, err)
-
-	resp, err := f.RoundTrip(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	require.Equal(t, 404, resp.StatusCode)
-}
-
-func TestWinRoundTripWithRequestBody(t *testing.T) {
-	rawResp := "HTTP/1.1 201 Created\r\n\r\n"
-	encoded := base64.StdEncoding.EncodeToString([]byte(rawResp))
-
-	mr := rigtest.NewMockRunner()
-	mr.Windows = true
-	mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), encoded)
-	f := remotefs.NewWindowsFS(mr)
-
-	req, err := http.NewRequest(http.MethodPost, "http://example.com/api", strings.NewReader(`{"key":"val"}`))
-	require.NoError(t, err)
-
-	resp, err := f.RoundTrip(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	require.Equal(t, 201, resp.StatusCode)
-	script, ok := decodePSScript(mr.LastCommand())
-	require.True(t, ok, "expected encoded PS command")
-	require.Contains(t, script, "OpenStandardInput")
-}
-
-func TestRoundTripURLValidation(t *testing.T) {
-	tests := []struct {
-		name string
-		req  func() *http.Request
-	}{
-		{"unsupported scheme", func() *http.Request {
-			req, _ := http.NewRequest(http.MethodGet, "ftp://example.com/", nil)
-			return req
-		}},
-		{"missing host", func() *http.Request {
-			req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-			req.URL.Host = ""
-			return req
-		}},
-		{"userinfo in URL", func() *http.Request {
-			req, _ := http.NewRequest(http.MethodGet, "http://user:pass@example.com/", nil)
-			return req
-		}},
-		{"CR in URL host", func() *http.Request {
-			req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-			req.URL.Host = "example.com\r"
-			return req
-		}},
-		{"LF in URL host", func() *http.Request {
-			req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-			req.URL.Host = "example.com\n"
-			return req
-		}},
-		{"NUL in URL host", func() *http.Request {
-			req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-			req.URL.Host = "example.com\x00"
-			return req
-		}},
+	for _, rawURL := range []string{
+		"file:///etc/passwd",
+		"ftp://example.com",
+		"http:///path",
+		"/relative/path",
+		"http://user:pass@example.com",
+		"http://example.com\x00",
+	} {
+		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, rawURL)
+		require.Error(t, err, "expected error for %q", rawURL)
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Posix: validateRoundTripURL runs before requireHTTPTools, so no tool stubs needed.
-			mr := rigtest.NewMockRunner()
-			f := remotefs.NewPosixFS(mr)
-			_, err := f.RoundTrip(tc.req())
-			require.Error(t, err)
+}
+
+func TestPosixHTTPStatusInsecure(t *testing.T) {
+	t.Run("200", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "200")
+		f := remotefs.NewPosixFS(mr)
+		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		require.NoError(t, err)
+		require.Equal(t, 200, code)
+		require.Contains(t, mr.LastCommand(), "-k")
+	})
+	t.Run("503", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "503")
+		f := remotefs.NewPosixFS(mr)
+		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		require.NoError(t, err)
+		require.Equal(t, 503, code)
+	})
+	t.Run("curl error", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("curl"), errors.New("exit status 60"))
+		f := remotefs.NewPosixFS(mr)
+		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		require.Error(t, err)
+	})
+}
+
+func TestPosixHTTPStatusInsecureWget(t *testing.T) {
+	noCurl := errors.New("not found")
+
+	t.Run("200 via wget", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Equal("command -v curl"), noCurl)
+		mr.AddCommandOutput(rigtest.Equal("command -v wget"), "/usr/bin/wget")
+		mr.AddCommand(rigtest.HasPrefix("wget"), func(a *rigtest.A) error {
+			_, err := fmt.Fprint(a.Stderr, "  HTTP/1.1 200 OK\n")
+			return err
 		})
-	}
+		f := remotefs.NewPosixFS(mr)
+		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		require.NoError(t, err)
+		require.Equal(t, 200, code)
+	})
+
+	t.Run("301 via wget", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Equal("command -v curl"), noCurl)
+		mr.AddCommandOutput(rigtest.Equal("command -v wget"), "/usr/bin/wget")
+		mr.AddCommand(rigtest.HasPrefix("wget"), func(a *rigtest.A) error {
+			_, err := fmt.Fprint(a.Stderr, "  HTTP/1.1 301 Moved Permanently\n")
+			return err
+		})
+		f := remotefs.NewPosixFS(mr)
+		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		require.NoError(t, err)
+		require.Equal(t, 301, code)
+	})
+
+	t.Run("no tools", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Equal("command -v curl"), noCurl)
+		mr.AddCommandFailure(rigtest.Equal("command -v wget"), noCurl)
+		f := remotefs.NewPosixFS(mr)
+		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		require.ErrorIs(t, err, remotefs.ErrHTTPStatusNotSupported)
+	})
 }
 
-func TestCurlHeaderSanitization(t *testing.T) {
-	okResp := base64.StdEncoding.EncodeToString([]byte("HTTP/1.1 200 OK\r\n\r\n"))
-
-	stubTools := func(mr *rigtest.MockRunner) {
-		mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
-		mr.AddCommandOutput(rigtest.Equal("command -v base64"), "/usr/bin/base64")
-	}
-
-	t.Run("CR in header name rejected", func(t *testing.T) {
+func TestWindowsHTTPStatusInsecure(t *testing.T) {
+	t.Run("200", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
-		stubTools(mr)
-		f := remotefs.NewPosixFS(mr)
-		req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-		req.Header["X-Bad\rName"] = []string{"value"}
-		_, err := f.RoundTrip(req)
-		require.Error(t, err)
-	})
-
-	t.Run("LF in header value rejected", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		stubTools(mr)
-		f := remotefs.NewPosixFS(mr)
-		req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-		req.Header["X-Custom"] = []string{"val\nue"}
-		_, err := f.RoundTrip(req)
-		require.Error(t, err)
-	})
-
-	t.Run("NUL in header value rejected", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		stubTools(mr)
-		f := remotefs.NewPosixFS(mr)
-		req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-		req.Header["X-Custom"] = []string{"val\x00ue"}
-		_, err := f.RoundTrip(req)
-		require.Error(t, err)
-	})
-
-	t.Run("req.Host injected as Host header", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		stubTools(mr)
-		mr.AddCommandOutput(rigtest.Contains("--http1.1"), okResp)
-		f := remotefs.NewPosixFS(mr)
-		req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-		req.Host = "override.example.com"
-		resp, err := f.RoundTrip(req)
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "200")
+		f := remotefs.NewWindowsFS(mr)
+		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
 		require.NoError(t, err)
-		_ = resp.Body.Close()
-		require.Contains(t, mr.LastCommand(), "Host: override.example.com")
+		require.Equal(t, 200, code)
 	})
-
-	t.Run("Host in req.Header is skipped", func(t *testing.T) {
+	t.Run("failure", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
-		stubTools(mr)
-		mr.AddCommandOutput(rigtest.Contains("--http1.1"), okResp)
-		f := remotefs.NewPosixFS(mr)
-		req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-		req.Header.Set("Host", "should-not-appear.example.com")
-		resp, err := f.RoundTrip(req)
-		require.NoError(t, err)
-		_ = resp.Body.Close()
-		require.NotContains(t, mr.LastCommand(), "should-not-appear.example.com")
-	})
-
-	t.Run("Cookie values joined with semicolon", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		stubTools(mr)
-		mr.AddCommandOutput(rigtest.Contains("--http1.1"), okResp)
-		f := remotefs.NewPosixFS(mr)
-		req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
-		req.Header["Cookie"] = []string{"a=1", "b=2"}
-		resp, err := f.RoundTrip(req)
-		require.NoError(t, err)
-		_ = resp.Body.Close()
-		require.Contains(t, mr.LastCommand(), "Cookie: a=1; b=2")
+		mr.Windows = true
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
+		f := remotefs.NewWindowsFS(mr)
+		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		require.Error(t, err)
 	})
 }

--- a/remotefs/patchfile_test.go
+++ b/remotefs/patchfile_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"io/fs"
-	"net/http"
 	"path"
 	"testing"
 	"time"
@@ -57,10 +56,9 @@ func (f *patchFS) ReadDir(_ string) ([]fs.DirEntry, error) { panic("not implemen
 func (f *patchFS) OpenFile(_ string, _ int, _ fs.FileMode) (remotefs.File, error) {
 	panic("not implemented")
 }
-func (f *patchFS) Sha256(_ string) (string, error)                       { panic("not implemented") }
-func (f *patchFS) DownloadURL(_, _ string) error                         { panic("not implemented") }
-func (f *patchFS) RoundTrip(_ *http.Request) (*http.Response, error)     { panic("not implemented") }
-func (f *patchFS) RemoveAll(_ string) error                              { panic("not implemented") }
+func (f *patchFS) Sha256(_ string) (string, error)  { panic("not implemented") }
+func (f *patchFS) DownloadURL(_, _ string) error    { panic("not implemented") }
+func (f *patchFS) RemoveAll(_ string) error         { panic("not implemented") }
 func (f *patchFS) Mkdir(_ string, _ fs.FileMode) error                   { panic("not implemented") }
 func (f *patchFS) MkdirTemp(_, _ string) (string, error)                 { panic("not implemented") }
 func (f *patchFS) FileExist(_ string) bool                               { panic("not implemented") }

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -8,12 +8,10 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"net/http"
 	"os"
 	"path"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/k0sproject/rig/v2/cmd"
@@ -23,17 +21,16 @@ import (
 )
 
 var (
-	_                 fs.FS = (*PosixFS)(nil)
-	_                 FS    = (*PosixFS)(nil)
-	errInvalid              = errors.New("invalid")
-	errNoDownloadTool       = errors.New("neither curl nor wget is available on the remote host")
-	errCurlRequired         = errors.New("curl is not available on the remote host")
-	errBase64Required       = errors.New("base64 is not available on the remote host")
-	errGrepFailed           = errors.New("grep failed")
-	errTestFailed           = errors.New("test failed")
-	errStatInitFailed       = errors.New("stat command not found or unsupported stat implementation")
-	statCmdGNU              = `env -i PATH="$PATH" LC_ALL=C stat -c '%%#f %%s %%.9Y //%%n//' -- %s 2> /dev/null`
-	statCmdBSD              = `env -i PATH="$PATH" LC_ALL=C stat -f '%%#p %%z %%Fm //%%N//' -- %s 2> /dev/null`
+	_                    fs.FS = (*PosixFS)(nil)
+	_                    FS    = (*PosixFS)(nil)
+	errInvalid                 = errors.New("invalid")
+	errNoDownloadTool          = errors.New("neither curl nor wget is available on the remote host")
+	errWgetStatusUnknown       = errors.New("could not determine http status from wget output")
+	errGrepFailed              = errors.New("grep failed")
+	errTestFailed              = errors.New("test failed")
+	errStatInitFailed          = errors.New("stat command not found or unsupported stat implementation")
+	statCmdGNU                 = `env -i PATH="$PATH" LC_ALL=C stat -c '%%#f %%s %%.9Y //%%n//' -- %s 2> /dev/null`
+	statCmdBSD                 = `env -i PATH="$PATH" LC_ALL=C stat -f '%%#p %%z %%Fm //%%N//' -- %s 2> /dev/null`
 )
 
 const (
@@ -49,9 +46,6 @@ type PosixFS struct {
 	// TODO: these should probably be in some kind of "coreutils" package
 	statCmd   *string
 	chtimesFn func(name string, atime, mtime int64) error
-
-	httpToolsOnce sync.Once
-	httpToolsErr  error
 }
 
 // NewPosixFS returns a fs.FS implementation for a remote filesystem that uses POSIX commands for access.
@@ -422,133 +416,38 @@ func (s *PosixFS) DownloadURL(url, dst string) error {
 	return fmt.Errorf("download %s: %w", url, errNoDownloadTool)
 }
 
-// headerKeyExists reports whether h contains a key matching name, case-insensitively.
-// http.Header keys assigned directly to the map may not be canonical, so
-// http.Header.Get (which only looks up canonical keys) can miss them.
-func headerKeyExists(h http.Header, name string) bool {
-	for k := range h {
-		if strings.EqualFold(k, name) {
-			return true
+// httpStatusInsecure checks whether url is reachable and returns the HTTP status
+// code. TLS certificate verification is skipped (equivalent to curl -k).
+// It prefers curl and falls back to wget.
+func (s *PosixFS) httpStatusInsecure(ctx context.Context, rawURL string) (int, error) {
+	if _, err := s.LookPath("curl"); err == nil {
+		out, err := s.ExecOutputContext(ctx, sh.Command("curl", "-kIso", "/dev/null", "--connect-timeout", "20", "-w", "%{http_code}", "--", rawURL), cmd.Sensitive())
+		if err != nil {
+			return 0, fmt.Errorf("http-status %s: %w", rawURL, err)
 		}
+		code, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			return 0, fmt.Errorf("http-status %s: invalid response %q: %w", rawURL, out, err)
+		}
+		return code, nil
 	}
-	return false
-}
-
-// curlHeaderArgs builds the -H flag list for curl from an http.Header map.
-// Header["Host"] is always skipped (ignored in net/http client requests); host is injected
-// when non-empty. Returns errInvalidHeader if any key or value contains CR, LF, or NUL.
-func curlHeaderArgs(header http.Header, host string) ([]string, error) {
-	args := make([]string, 0, (len(header)+1)*2)
-	for name, vals := range header {
-		if strings.EqualFold(name, "Host") {
-			continue
-		}
-		if strings.ContainsAny(name, "\r\n\x00") {
-			return nil, fmt.Errorf("%w: %q", errInvalidHeader, name)
-		}
-		if len(vals) == 0 {
-			continue
-		}
-		if strings.EqualFold(name, "Cookie") {
-			joined := strings.Join(vals, "; ")
-			if strings.ContainsAny(joined, "\r\n\x00") {
-				return nil, fmt.Errorf("%w: %q", errInvalidHeader, name)
-			}
-			args = append(args, "-H", name+": "+joined)
-		} else {
-			for _, v := range vals {
-				if strings.ContainsAny(v, "\r\n\x00") {
-					return nil, fmt.Errorf("%w: %q", errInvalidHeader, name)
+	if _, err := s.LookPath("wget"); err == nil {
+		var errBuf strings.Builder
+		execErr := s.ExecContext(ctx, sh.Command("wget", "--server-response", "--spider", "--no-check-certificate", "--max-redirect=0", "-q", "--", rawURL),
+			cmd.Sensitive(), cmd.Stderr(&errBuf))
+		for line := range strings.SplitSeq(errBuf.String(), "\n") {
+			if fields := strings.Fields(line); len(fields) >= 2 && strings.HasPrefix(fields[0], "HTTP/") {
+				if code, err := strconv.Atoi(fields[1]); err == nil {
+					return code, nil
 				}
-				args = append(args, "-H", name+": "+v)
 			}
 		}
-	}
-	if host != "" {
-		if strings.ContainsAny(host, "\r\n\x00") {
-			return nil, fmt.Errorf("%w: %q", errInvalidHeader, "Host")
+		if execErr != nil {
+			return 0, fmt.Errorf("http-status %s: %w", rawURL, execErr)
 		}
-		args = append(args, "-H", "Host: "+host)
+		return 0, fmt.Errorf("http-status %s: %w", rawURL, errWgetStatusUnknown)
 	}
-	return args, nil
-}
-
-func (s *PosixFS) requireHTTPTools() error {
-	s.httpToolsOnce.Do(func() {
-		if _, err := s.LookPath("curl"); err != nil {
-			s.httpToolsErr = fmt.Errorf("%w: %w", errCurlRequired, err)
-			return
-		}
-		if _, err := s.LookPath("base64"); err != nil {
-			s.httpToolsErr = fmt.Errorf("%w: %w", errBase64Required, err)
-		}
-	})
-	return s.httpToolsErr
-}
-
-// buildCurlArgs constructs the curl arguments and execution options for the request.
-// It does not verify that curl or base64 are available; callers are expected to
-// perform any required tool checks before invoking it. It returns an error only
-// if the request headers contain invalid values.
-func buildCurlArgs(req *http.Request) ([]string, []cmd.ExecOption, error) {
-	args := []string{"curl", "-si", "--http1.1", "--raw"}
-	if !headerKeyExists(req.Header, "Expect") {
-		args = append(args, "-H", "Expect:")
-	}
-	method := req.Method
-	if method == "" {
-		method = http.MethodGet
-	}
-	hasBody := req.Body != nil && req.Body != http.NoBody
-	if method == http.MethodHead && !hasBody {
-		args = append(args, "-I")
-	} else {
-		args = append(args, "-X", method)
-	}
-	headerArgs, err := curlHeaderArgs(req.Header, req.Host)
-	if err != nil {
-		return nil, nil, err
-	}
-	args = append(args, headerArgs...)
-	var execOpts []cmd.ExecOption
-	if hasBody {
-		args = append(args, "--data-binary", "@-")
-		if !headerKeyExists(req.Header, "Content-Type") {
-			args = append(args, "-H", "Content-Type:")
-		}
-		execOpts = append(execOpts, cmd.Stdin(req.Body))
-	}
-	return args, execOpts, nil
-}
-
-// RoundTrip implements http.RoundTripper by executing the request via curl on the remote host.
-func (s *PosixFS) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req == nil {
-		return nil, errNilRequest
-	}
-	if req.URL == nil {
-		return nil, errNilRequestURL
-	}
-	if req.Body != nil && req.Body != http.NoBody {
-		defer req.Body.Close()
-	}
-	if err := validateRoundTripURL(req.URL); err != nil {
-		return nil, fmt.Errorf("http round-trip %s: %w", req.URL.Redacted(), err)
-	}
-	if err := s.requireHTTPTools(); err != nil {
-		return nil, fmt.Errorf("http round-trip %s: %w", req.URL.Redacted(), err)
-	}
-	args, execOpts, err := buildCurlArgs(req)
-	if err != nil {
-		return nil, fmt.Errorf("http round-trip %s: %w", req.URL.Redacted(), err)
-	}
-	curlCmd := sh.CommandBuilder(sh.Command(args[0], args[1:]...)).Raw("--").Arg(req.URL.String())
-	script := `_t=$(mktemp "${TMPDIR:-/tmp}/rigXXXXXX") && ` + curlCmd.String() + ` > "$_t" && base64 < "$_t"; _e=$?; rm -f "$_t" 2>/dev/null; exit "$_e"`
-	out, err := s.ExecOutputContext(req.Context(), script, append(execOpts, cmd.HideOutput(), cmd.HideCommand())...)
-	if err != nil {
-		return nil, fmt.Errorf("http round-trip %s: %w", req.URL.Redacted(), err)
-	}
-	return parseRawHTTPResponse(out, req)
+	return 0, fmt.Errorf("%w: neither curl nor wget found", ErrHTTPStatusNotSupported)
 }
 
 // FileContains reports whether the file at path contains the given substring.

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -3,7 +3,6 @@ package remotefs_test
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
 	"io"
 	"io/fs"
@@ -275,37 +274,6 @@ func TestPosixChownTreeInt(t *testing.T) {
 	})
 }
 
-func TestPosixHTTPStatus(t *testing.T) {
-	t.Run("200", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
-		mr.AddCommandOutput(rigtest.Equal("command -v base64"), "/usr/bin/base64")
-		resp200 := base64.StdEncoding.EncodeToString([]byte("HTTP/1.1 200 OK\r\n\r\n"))
-		mr.AddCommandOutput(rigtest.Contains("--http1.1"), resp200)
-		f := remotefs.NewPosixFS(mr)
-		code, err := remotefs.HTTPStatus(context.Background(), f, "http://example.com/health")
-		require.NoError(t, err)
-		require.Equal(t, 200, code)
-	})
-	t.Run("503", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
-		mr.AddCommandOutput(rigtest.Equal("command -v base64"), "/usr/bin/base64")
-		resp503 := base64.StdEncoding.EncodeToString([]byte("HTTP/1.1 503 Service Unavailable\r\n\r\n"))
-		mr.AddCommandOutput(rigtest.Contains("--http1.1"), resp503)
-		f := remotefs.NewPosixFS(mr)
-		code, err := remotefs.HTTPStatus(context.Background(), f, "http://example.com/health")
-		require.NoError(t, err)
-		require.Equal(t, 503, code)
-	})
-	t.Run("curl unavailable", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.AddCommandFailure(rigtest.Equal("command -v curl"), errors.New("not found"))
-		f := remotefs.NewPosixFS(mr)
-		_, err := remotefs.HTTPStatus(context.Background(), f, "http://example.com/health")
-		require.Error(t, err)
-	})
-}
 
 func TestPosixInitStat(t *testing.T) {
 	// initStat selects between GNU and BSD stat by inspecting stat's capabilities.

--- a/remotefs/types.go
+++ b/remotefs/types.go
@@ -18,7 +18,7 @@ type FS interface {
 	fs.ReadFileFS
 	fs.ReadDirFS
 	OS
-	HTTPTransport
+	Downloader
 	Opener
 	Sha256summer
 }
@@ -72,6 +72,11 @@ type OS interface { //nolint:interfacebloat // intentionally large interface
 	Reboot(ctx context.Context) error
 	NativePath(path string) string
 	ShellQuote(s string) string
+}
+
+// Downloader can download content from a URL to a file on the remote host.
+type Downloader interface {
+	DownloadURL(url, dst string) error
 }
 
 // Opener is a file opener interface, modeled after stdlib's OS package.

--- a/remotefs/upload_test.go
+++ b/remotefs/upload_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"io"
 	"io/fs"
-	"net/http"
 	"os"
 	"path"
 	"testing"
@@ -98,9 +97,8 @@ func (f *uploadFS) Chtimes(_ string, _, _ int64) error                    { pani
 func (f *uploadFS) Touch(_ string, _ ...time.Time) error                  { panic("not implemented") }
 func (f *uploadFS) Truncate(_ string, _ int64) error                      { panic("not implemented") }
 func (f *uploadFS) Getenv(_ string) string                                { panic("not implemented") }
-func (f *uploadFS) DownloadURL(_ string, _ string) error                  { panic("not implemented") }
-func (f *uploadFS) RoundTrip(_ *http.Request) (*http.Response, error)     { panic("not implemented") }
-func (f *uploadFS) FileContains(_ string, _ string) (bool, error)         { panic("not implemented") }
+func (f *uploadFS) DownloadURL(_ string, _ string) error          { panic("not implemented") }
+func (f *uploadFS) FileContains(_ string, _ string) (bool, error) { panic("not implemented") }
 func (f *uploadFS) Follow(_ context.Context, _ string, _ io.Writer) error { panic("not implemented") }
 func (f *uploadFS) IsContainer() (bool, error)                            { panic("not implemented") }
 func (f *uploadFS) Hostname() (string, error)                             { panic("not implemented") }

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -462,113 +461,30 @@ try {
 	return nil
 }
 
-// winHeaderScript builds the PowerShell $params['Headers'] assignment from an http.Header map.
-// Header["Host"] is always skipped (ignored in net/http client requests); host is injected when
-// non-empty. Returns errInvalidHeader if any key, value, or host contains CR, LF, or NUL.
-func winHeaderScript(header http.Header, host string) (string, error) {
-	lines := make([]string, 0, len(header)+1)
-	for name, vals := range header {
-		if strings.EqualFold(name, "Host") {
-			continue
-		}
-		if strings.ContainsAny(name, "\r\n\x00") {
-			return "", fmt.Errorf("%w: %q", errInvalidHeader, name)
-		}
-		if len(vals) == 0 {
-			continue
-		}
-		sep := ", "
-		if strings.EqualFold(name, "Cookie") {
-			sep = "; "
-		}
-		joined := strings.Join(vals, sep)
-		if strings.ContainsAny(joined, "\r\n\x00") {
-			return "", fmt.Errorf("%w: %q", errInvalidHeader, name)
-		}
-		lines = append(lines, "  "+ps.SingleQuote(name)+"="+ps.SingleQuote(joined))
-	}
-	if host != "" {
-		if strings.ContainsAny(host, "\r\n\x00") {
-			return "", fmt.Errorf("%w: host %q", errInvalidHeader, host)
-		}
-		lines = append(lines, "  "+ps.SingleQuote("Host")+"="+ps.SingleQuote(host))
-	}
-	if len(lines) == 0 {
-		return "", nil
-	}
-	return "$params['Headers']=@{\n" + strings.Join(lines, "\n") + "\n}", nil
-}
-
-// RoundTrip implements http.RoundTripper by executing the request via Invoke-WebRequest on the remote host.
-func (s *WinFS) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req == nil {
-		return nil, errNilRequest
-	}
-	if req.URL == nil {
-		return nil, errNilRequestURL
-	}
-	if req.Body != nil && req.Body != http.NoBody {
-		defer req.Body.Close()
-	}
-	if err := validateRoundTripURL(req.URL); err != nil {
-		return nil, fmt.Errorf("http round-trip %s: %w", req.URL.Redacted(), err)
-	}
-	method := req.Method
-	if method == "" {
-		method = http.MethodGet
-	}
-	headerScript, err := winHeaderScript(req.Header, req.Host)
-	if err != nil {
-		return nil, fmt.Errorf("http round-trip %s: %w", req.URL.Redacted(), err)
-	}
-
-	var execOpts []cmd.ExecOption
-	bodyScript := ""
-	if req.Body != nil && req.Body != http.NoBody {
-		execOpts = append(execOpts, cmd.Stdin(req.Body))
-		bodyScript = `$ms=[IO.MemoryStream]::new()
-[Console]::OpenStandardInput().CopyTo($ms)
-$params['Body']=$ms.ToArray()
-$ms.Dispose()`
-	}
-
+// httpStatusInsecure checks whether url is reachable and returns the HTTP status
+// code. On PowerShell 6+, TLS certificate verification is skipped. On PowerShell
+// 5.x, TLS certificate verification is not skipped and requests will fail for
+// self-signed certificates.
+func (s *WinFS) httpStatusInsecure(ctx context.Context, rawURL string) (int, error) {
 	script := fmt.Sprintf(`$ProgressPreference='SilentlyContinue'
 $ErrorActionPreference='Stop'
-function ConvertTo-RawResponse($code,$desc,$hdrs,$body){
-  $crlf=[char]13+[char]10
-  $head="HTTP/1.1 $code $desc"+$crlf
-  if($hdrs.PSObject.Properties['AllKeys']){$hdrs.AllKeys|ForEach-Object{$key=$_;if($key -ne 'Transfer-Encoding' -and $key -ne 'Content-Length'){$hdrs.GetValues($key)|ForEach-Object{$head+="${key}: $_"+$crlf}}}}else{$hdrs.GetEnumerator()|ForEach-Object{$key=$_.Key;if($key -ne 'Transfer-Encoding' -and $key -ne 'Content-Length'){@($_.Value)|ForEach-Object{$head+="${key}: $_"+$crlf}}}}
-  $head+="Content-Length: "+$body.Length+$crlf
-  $head+=$crlf
-  $hb=[Text.Encoding]::GetEncoding(28591).GetBytes($head)
-  $out=[byte[]]::new($hb.Length+$body.Length)
-  [Buffer]::BlockCopy($hb,0,$out,0,$hb.Length)
-  [Buffer]::BlockCopy($body,0,$out,$hb.Length,$body.Length)
-  [Convert]::ToBase64String($out)
-}
-$params=@{Uri=%s;Method=%s;UseBasicParsing=$true;ErrorAction='Stop';MaximumRedirection=0}
-%s
-%s
+$params=@{Uri=%s;Method='HEAD';MaximumRedirection=0}
+if($PSVersionTable.PSVersion.Major -ge 6){$params['SkipCertificateCheck']=$true}else{$params['UseBasicParsing']=$true}
 try{
   $r=Invoke-WebRequest @params
-  $b=if($r.PSObject.Properties['RawContentStream']){$r.RawContentStream.ToArray()}elseif($r.PSObject.Properties['BaseResponse']){$ms2=New-Object System.IO.MemoryStream;$r.BaseResponse.GetResponseStream().CopyTo($ms2);$ms2.ToArray()}else{[byte[]]$r.Content}
-  ConvertTo-RawResponse ([int]$r.StatusCode) $r.StatusDescription $r.Headers $b
+  [int]$r.StatusCode
 }catch [System.Net.WebException]{
-  if($_.Exception.Response -ne $null){
-    $er=$_.Exception.Response
-    $ms=New-Object System.IO.MemoryStream
-    $er.GetResponseStream().CopyTo($ms)
-    $eh=@{}
-    $er.Headers.AllKeys|ForEach-Object{$eh[$_]=$er.Headers[$_]}
-    ConvertTo-RawResponse ([int]$er.StatusCode) $er.StatusDescription $eh $ms.ToArray()
-  }else{Write-Error $_.Exception.Message;exit 1}
-}catch{Write-Error $_.Exception.Message;exit 1}`, ps.SingleQuote(req.URL.String()), ps.SingleQuote(method), headerScript, bodyScript)
-
-	out, err := s.ExecOutputContext(req.Context(), script, append(execOpts, cmd.PS(), cmd.HideOutput(), cmd.HideCommand())...)
+  if($_.Exception.Response -ne $null){[int]$_.Exception.Response.StatusCode}else{throw}
+}`, ps.SingleQuote(rawURL))
+	out, err := s.ExecOutputContext(ctx, script, cmd.PS(), cmd.Sensitive())
 	if err != nil {
-		return nil, fmt.Errorf("http round-trip %s: %w", req.URL.Redacted(), err)
+		return 0, fmt.Errorf("http-status %s: %w", rawURL, err)
 	}
-	return parseRawHTTPResponse(out, req)
+	code, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("http-status %s: invalid response %q: %w", rawURL, out, err)
+	}
+	return code, nil
 }
 
 // FileContains reports whether the file at path contains the given substring.

--- a/remotefs/winfs_test.go
+++ b/remotefs/winfs_test.go
@@ -3,7 +3,6 @@ package remotefs_test
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -216,26 +215,6 @@ func TestWindowsChownVariantsNotSupported(t *testing.T) {
 	require.ErrorIs(t, f.ChownTreeInt("/tmp", 0, 0), remotefs.ErrNotSupported)
 }
 
-func TestWindowsHTTPStatus(t *testing.T) {
-	t.Run("200", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		resp200 := base64.StdEncoding.EncodeToString([]byte("HTTP/1.1 200 OK\r\n\r\n"))
-		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), resp200)
-		f := remotefs.NewWindowsFS(mr)
-		code, err := remotefs.HTTPStatus(context.Background(), f, "http://example.com/health")
-		require.NoError(t, err)
-		require.Equal(t, 200, code)
-	})
-	t.Run("failure", func(t *testing.T) {
-		mr := rigtest.NewMockRunner()
-		mr.Windows = true
-		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
-		f := remotefs.NewWindowsFS(mr)
-		_, err := remotefs.HTTPStatus(context.Background(), f, "http://example.com/health")
-		require.Error(t, err)
-	})
-}
 
 func TestWindowsCreateTemp(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {

--- a/service.go
+++ b/service.go
@@ -182,9 +182,7 @@ func (m *Service) IsRunning(ctx context.Context) bool {
 var (
 	errLogReaderNotSupported    = errors.New("init system provider does not implement log reader")
 	errLogStreamerNotSupported  = errors.New("init system provider does not support log streaming")
-	errEnvManagerNotSupported   = errors.New("init system provider does not support service environment management")
-	errDaemonReloadNotSupported = errors.New("init system provider does not support daemon-reload")
-	errServiceFSNotAvailable    = errors.New("service has no filesystem access; use client.Service() instead of GetService()")
+errServiceFSNotAvailable    = errors.New("service has no filesystem access; use client.Service() instead of GetService()")
 )
 
 // Logs returns latest log lines for the service.
@@ -229,7 +227,7 @@ func (m *Service) SetEnvironment(ctx context.Context, env map[string]string) err
 	defer cancel()
 	envManager, ok := m.initsys.(initsystem.ServiceEnvironmentManager)
 	if !ok {
-		return errEnvManagerNotSupported
+		return nil
 	}
 	if m.fs == nil {
 		return errServiceFSNotAvailable
@@ -249,22 +247,6 @@ func (m *Service) SetEnvironment(ctx context.Context, env map[string]string) err
 		if err := reloader.DaemonReload(ctx, m.runner); err != nil {
 			return fmt.Errorf("daemon-reload after setting environment for service '%s': %w", m.name, err)
 		}
-	}
-	return nil
-}
-
-// DaemonReload triggers a daemon-reload on the init system, if supported. This is useful after
-// manually writing service unit files outside of rig. Enable and Disable call this automatically.
-// If ctx has no deadline, a 2-minute default timeout is applied.
-func (m *Service) DaemonReload(ctx context.Context) error {
-	ctx, cancel := withServiceTimeout(ctx)
-	defer cancel()
-	reloader, ok := m.initsys.(initsystem.ServiceManagerReloader)
-	if !ok {
-		return errDaemonReloadNotSupported
-	}
-	if err := reloader.DaemonReload(ctx, m.runner); err != nil {
-		return fmt.Errorf("daemon-reload: %w", err)
 	}
 	return nil
 }

--- a/service.go
+++ b/service.go
@@ -230,6 +230,11 @@ func (m *Service) SetEnvironment(ctx context.Context, env map[string]string) err
 		if err := setter.SetServiceEnvironment(ctx, m.runner, m.name, env); err != nil {
 			return fmt.Errorf("set environment for service '%s': %w", m.name, err)
 		}
+		if reloader, ok := m.initsys.(initsystem.ServiceManagerReloader); ok {
+			if err := reloader.DaemonReload(ctx, m.runner); err != nil {
+				return fmt.Errorf("daemon-reload after setting environment for service '%s': %w", m.name, err)
+			}
+		}
 		return nil
 	}
 	envManager, ok := m.initsys.(initsystem.ServiceEnvironmentManager)

--- a/service.go
+++ b/service.go
@@ -180,9 +180,10 @@ func (m *Service) IsRunning(ctx context.Context) bool {
 }
 
 var (
-	errLogReaderNotSupported    = errors.New("init system provider does not implement log reader")
-	errLogStreamerNotSupported  = errors.New("init system provider does not support log streaming")
-errServiceFSNotAvailable    = errors.New("service has no filesystem access; use client.Service() instead of GetService()")
+	errLogReaderNotSupported   = errors.New("init system provider does not implement log reader")
+	errLogStreamerNotSupported = errors.New("init system provider does not support log streaming")
+	errEnvManagerNotSupported  = errors.New("init system provider does not support service environment management")
+	errServiceFSNotAvailable   = errors.New("service has no filesystem access; use client.Service() instead of GetService()")
 )
 
 // Logs returns latest log lines for the service.
@@ -225,9 +226,15 @@ func (m *Service) StreamLogs(ctx context.Context, w io.Writer) error {
 func (m *Service) SetEnvironment(ctx context.Context, env map[string]string) error {
 	ctx, cancel := withServiceTimeout(ctx)
 	defer cancel()
+	if setter, ok := m.initsys.(initsystem.ServiceEnvironmentSetter); ok {
+		if err := setter.SetServiceEnvironment(ctx, m.runner, m.name, env); err != nil {
+			return fmt.Errorf("set environment for service '%s': %w", m.name, err)
+		}
+		return nil
+	}
 	envManager, ok := m.initsys.(initsystem.ServiceEnvironmentManager)
 	if !ok {
-		return nil
+		return errEnvManagerNotSupported
 	}
 	if m.fs == nil {
 		return errServiceFSNotAvailable

--- a/service_test.go
+++ b/service_test.go
@@ -69,6 +69,17 @@ type mockEnvSetter struct {
 	setEnv map[string]string
 }
 
+// mockEnvSetterReloader implements both ServiceEnvironmentSetter and ServiceManagerReloader.
+type mockEnvSetterReloader struct {
+	mockEnvSetter
+	reloaded bool
+}
+
+func (m *mockEnvSetterReloader) DaemonReload(_ context.Context, _ cmd.ContextRunner) error {
+	m.reloaded = true
+	return nil
+}
+
 func (m *mockEnvSetter) StartService(_ context.Context, _ cmd.ContextRunner, _ string) error {
 	return nil
 }
@@ -196,6 +207,18 @@ func TestServiceSetEnvironment(t *testing.T) {
 		}
 		require.NoError(t, svc.SetEnvironment(ctx, env))
 		require.Equal(t, env, mgr.setEnv)
+	})
+
+	t.Run("via setter with reloader", func(t *testing.T) {
+		mgr := &mockEnvSetterReloader{}
+		svc := &Service{
+			runner:  rigtest.NewMockRunner(),
+			name:    "mysvc",
+			initsys: mgr,
+		}
+		require.NoError(t, svc.SetEnvironment(ctx, env))
+		require.Equal(t, env, mgr.setEnv)
+		require.True(t, mgr.reloaded)
 	})
 
 	t.Run("env manager not supported", func(t *testing.T) {
@@ -415,9 +438,12 @@ func TestWithServiceTimeout(t *testing.T) {
 	})
 }
 
-// Ensure initsystem.ServiceEnvironmentManager is satisfied by types implementing it.
+// Ensure initsystem interfaces are satisfied by types implementing them.
 var _ initsystem.ServiceEnvironmentManager = (*mockEnvManager)(nil)
 var _ initsystem.ServiceManagerReloader = (*mockReloadEnvManager)(nil)
+var _ initsystem.ServiceEnvironmentSetter = (*mockEnvSetter)(nil)
+var _ initsystem.ServiceEnvironmentSetter = (*mockEnvSetterReloader)(nil)
+var _ initsystem.ServiceManagerReloader = (*mockEnvSetterReloader)(nil)
 var _ initsystem.ServiceManager = (*mockBasicManager)(nil)
 var _ initsystem.ServiceManager = (*mockLifecycleManager)(nil)
 var _ initsystem.ServiceManagerRestarter = (*mockNativeRestarter)(nil)

--- a/service_test.go
+++ b/service_test.go
@@ -64,6 +64,40 @@ func (m *mockReloadEnvManager) DaemonReload(_ context.Context, _ cmd.ContextRunn
 	return nil
 }
 
+// mockEnvSetter is a ServiceManager that implements ServiceEnvironmentSetter directly.
+type mockEnvSetter struct {
+	setEnv map[string]string
+}
+
+func (m *mockEnvSetter) StartService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockEnvSetter) StopService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockEnvSetter) ServiceScriptPath(_ context.Context, _ cmd.ContextRunner, _ string) (string, error) {
+	return "", nil
+}
+
+func (m *mockEnvSetter) EnableService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockEnvSetter) DisableService(_ context.Context, _ cmd.ContextRunner, _ string) error {
+	return nil
+}
+
+func (m *mockEnvSetter) ServiceIsRunning(_ context.Context, _ cmd.ContextRunner, _ string) bool {
+	return false
+}
+
+func (m *mockEnvSetter) SetServiceEnvironment(_ context.Context, _ cmd.ContextRunner, _ string, env map[string]string) error {
+	m.setEnv = env
+	return nil
+}
+
 // mockBasicManager is a ServiceManager without env or reload support.
 type mockBasicManager struct{}
 
@@ -153,6 +187,17 @@ func TestServiceSetEnvironment(t *testing.T) {
 		require.Equal(t, "/etc/conf.d/mysvc", mfs.writtenPath)
 	})
 
+	t.Run("via setter", func(t *testing.T) {
+		mgr := &mockEnvSetter{}
+		svc := &Service{
+			runner:  rigtest.NewMockRunner(),
+			name:    "mysvc",
+			initsys: mgr,
+		}
+		require.NoError(t, svc.SetEnvironment(ctx, env))
+		require.Equal(t, env, mgr.setEnv)
+	})
+
 	t.Run("env manager not supported", func(t *testing.T) {
 		svc := &Service{
 			runner:  rigtest.NewMockRunner(),
@@ -161,7 +206,7 @@ func TestServiceSetEnvironment(t *testing.T) {
 			fs:      &mockFS{},
 		}
 		err := svc.SetEnvironment(ctx, env)
-		require.NoError(t, err)
+		require.ErrorIs(t, err, errEnvManagerNotSupported)
 	})
 
 	t.Run("fs not available", func(t *testing.T) {

--- a/service_test.go
+++ b/service_test.go
@@ -161,7 +161,7 @@ func TestServiceSetEnvironment(t *testing.T) {
 			fs:      &mockFS{},
 		}
 		err := svc.SetEnvironment(ctx, env)
-		require.ErrorIs(t, err, errEnvManagerNotSupported)
+		require.NoError(t, err)
 	})
 
 	t.Run("fs not available", func(t *testing.T) {
@@ -175,30 +175,6 @@ func TestServiceSetEnvironment(t *testing.T) {
 	})
 }
 
-func TestServiceDaemonReload(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("supported", func(t *testing.T) {
-		mgr := &mockReloadEnvManager{}
-		svc := &Service{
-			runner:  rigtest.NewMockRunner(),
-			name:    "mysvc",
-			initsys: mgr,
-		}
-		require.NoError(t, svc.DaemonReload(ctx))
-		require.True(t, mgr.reloaded)
-	})
-
-	t.Run("not supported", func(t *testing.T) {
-		svc := &Service{
-			runner:  rigtest.NewMockRunner(),
-			name:    "mysvc",
-			initsys: &mockBasicManager{},
-		}
-		err := svc.DaemonReload(ctx)
-		require.ErrorIs(t, err, errDaemonReloadNotSupported)
-	})
-}
 
 // mockLifecycleManager tracks Start/Stop calls and maintains isRunning state.
 type mockLifecycleManager struct {


### PR DESCRIPTION
- The Pipe() helper shell-escapes all arguments via shellescape.Quote, so passing `-d"="` produced `'-d"="'` on the wire, causing cut to receive a three-character delimiter and fail with "the delimiter must be a single character". Use `-d=` directly, the equals sign needs no shell quoting.
- DaemonReload no longer exposed via the service wrapper, the caller must know to call the service manager's `DaemonReload` instead of all callers being forced to call it even-though it's a no-op on all but one of the init systems. 
- UpdateServiceEnvironment returned an error instead of setting service environment variables on windows, which is now done via registry.
- Remove the http.RoundTripper invention for now - replace with an universal client.Dial(..) later.



Breaking API is not a problem, the v2 API hasn't been released yet.