### PR TITLE
[release-0.x] fix winfsys to work with powershell default shell

### DIFF
--- a/pkg/rigfs/winfsys.go
+++ b/pkg/rigfs/winfsys.go
@@ -95,7 +95,7 @@ func (fsys *WinFsys) Remove(name string) error {
 		return fsys.removeDir(name)
 	}
 
-	if err := fsys.conn.Exec("cmd.exe /c del " + ps.DoubleQuotePath(name)); err != nil {
+	if err := fsys.conn.Exec("cmd.exe /c del "+ps.DoubleQuotePath(name), fsys.opts...); err != nil {
 		return fmt.Errorf("remove %s: %w", name, err)
 	}
 
@@ -104,11 +104,15 @@ func (fsys *WinFsys) Remove(name string) error {
 
 // RemoveAll deletes the named file or directory and all its child items
 func (fsys *WinFsys) RemoveAll(name string) error {
-	if existing, err := fsys.Stat(name); err == nil && existing.IsDir() {
+	existing, err := fsys.Stat(name)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err == nil && existing.IsDir() {
 		return fsys.removeDirAll(name)
 	}
 
-	if err := fsys.conn.Exec("cmd.exe /c del " + ps.DoubleQuotePath(name)); err != nil {
+	if err := fsys.conn.Exec("cmd.exe /c del "+ps.DoubleQuotePath(name), fsys.opts...); err != nil {
 		return fmt.Errorf("remove %s: %w", name, err)
 	}
 
@@ -116,14 +120,14 @@ func (fsys *WinFsys) RemoveAll(name string) error {
 }
 
 func (fsys *WinFsys) removeDir(name string) error {
-	if err := fsys.conn.Exec("cmd.exe /c rmdir /q " + ps.DoubleQuotePath(name)); err != nil {
+	if err := fsys.conn.Exec("cmd.exe /c rmdir /q "+ps.DoubleQuotePath(name), fsys.opts...); err != nil {
 		return fmt.Errorf("rmdir %s: %w", name, err)
 	}
 	return nil
 }
 
 func (fsys *WinFsys) removeDirAll(name string) error {
-	if err := fsys.conn.Exec("cmd.exe /c rmdir /s /q " + ps.DoubleQuotePath(name)); err != nil {
+	if err := fsys.conn.Exec("cmd.exe /c rmdir /s /q "+ps.DoubleQuotePath(name), fsys.opts...); err != nil {
 		return fmt.Errorf("rmdir %s: %w", name, err)
 	}
 

--- a/pkg/rigfs/winfsys.go
+++ b/pkg/rigfs/winfsys.go
@@ -42,7 +42,7 @@ var statCmdTemplate = `if (Test-Path -LiteralPath %[1]s) {
 func (fsys *WinFsys) Stat(name string) (fs.FileInfo, error) {
 	out, err := fsys.conn.ExecOutput(ps.Cmd(fmt.Sprintf(statCmdTemplate, ps.DoubleQuotePath(name))), fsys.opts...)
 	if err != nil {
-		return nil, &fs.PathError{Op: OpStat, Path: name, Err: fmt.Errorf("%w: %w", err, fs.ErrNotExist)}
+		return nil, &fs.PathError{Op: OpStat, Path: name, Err: err}
 	}
 
 	fi := &winFileInfo{fsys: fsys}

--- a/pkg/rigfs/winfsys.go
+++ b/pkg/rigfs/winfsys.go
@@ -95,7 +95,7 @@ func (fsys *WinFsys) Remove(name string) error {
 		return fsys.removeDir(name)
 	}
 
-	if err := fsys.conn.Exec("del " + ps.DoubleQuotePath(name)); err != nil {
+	if err := fsys.conn.Exec("cmd.exe /c del " + ps.DoubleQuotePath(name)); err != nil {
 		return fmt.Errorf("remove %s: %w", name, err)
 	}
 
@@ -108,7 +108,7 @@ func (fsys *WinFsys) RemoveAll(name string) error {
 		return fsys.removeDirAll(name)
 	}
 
-	if err := fsys.conn.Exec("del " + ps.DoubleQuotePath(name)); err != nil {
+	if err := fsys.conn.Exec("cmd.exe /c del " + ps.DoubleQuotePath(name)); err != nil {
 		return fmt.Errorf("remove %s: %w", name, err)
 	}
 
@@ -116,14 +116,14 @@ func (fsys *WinFsys) RemoveAll(name string) error {
 }
 
 func (fsys *WinFsys) removeDir(name string) error {
-	if err := fsys.conn.Exec("rmdir /q " + ps.DoubleQuotePath(name)); err != nil {
+	if err := fsys.conn.Exec("cmd.exe /c rmdir /q " + ps.DoubleQuotePath(name)); err != nil {
 		return fmt.Errorf("rmdir %s: %w", name, err)
 	}
 	return nil
 }
 
 func (fsys *WinFsys) removeDirAll(name string) error {
-	if err := fsys.conn.Exec("rmdir /s /q " + ps.DoubleQuotePath(name)); err != nil {
+	if err := fsys.conn.Exec("cmd.exe /c rmdir /s /q " + ps.DoubleQuotePath(name)); err != nil {
 		return fmt.Errorf("rmdir %s: %w", name, err)
 	}
 


### PR DESCRIPTION

### Description

WinFsys.Remove, RemoveAll, removeDir, and removeDirAll issue their delete commands as bare del / rmdir, which only behave as expected under a cmd.exe shell. They fail when the target Windows host's OpenSSH DefaultShell is PowerShell rather than cmd.exe.

### Why

When the OpenSSH default shell is PowerShell, rig's command string is parsed by PowerShell, where:
- del and rmdir are aliases for Remove-Item, not the cmd.exe builtins.
- rmdir /s /q "<path>" is parsed as Remove-Item /s /q "<path>", and Remove-Item rejects /s//q (treats them as positional paths → Cannot find path '/s'), so it exits non-zero.
- del "<path>" likewise runs as Remove-Item and errors (e.g. on a missing path).


### Fix

Wrap the four removal commands in cmd.exe /c so they run as cmd.exe builtins regardless of the host's default shell. Transparent under a cmd.exe shell; under PowerShell, cmd.exe is invoked as a native command and the (still ps.DoubleQuotePath-quoted) path is passed through. No change to path quoting.