### PR TITLE
Fix maxUint32 overflow on 32-bit architectures

### DIFF
--- a/signals.go
+++ b/signals.go
@@ -54,10 +54,10 @@ func termSizeWNCH() []byte {
 		binary.BigEndian.PutUint32(size[4:], 80)
 	} else {
 		const maxUint32 = 1<<32 - 1
-		if cols < 0 || cols > maxUint32 {
+		if cols < 0 || uint64(cols) > maxUint32 {
 			cols = 80
 		}
-		if rows < 0 || rows > maxUint32 {
+		if rows < 0 || uint64(rows) > maxUint32 {
 			rows = 24
 		}
 		binary.BigEndian.PutUint32(size, uint32(cols))


### PR DESCRIPTION
The untyped constant maxUint32 (4294967295) overflows int when compared against int values on 32-bit platforms (arm, 386), breaking the build. Perform the upper-bound comparison via uint64, which can always hold the constant, after guarding the negative case.