### PR TITLE
Fix sudo wrapping to run commands through a shell

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -18,7 +18,6 @@ import (
 	rigos "github.com/k0sproject/rig/os"
 	ps "github.com/k0sproject/rig/pkg/powershell"
 	"github.com/k0sproject/rig/pkg/rigfs"
-	"github.com/mattn/go-shellwords"
 )
 
 const osWindows = "windows"
@@ -266,30 +265,13 @@ func sudoNoop(cmd string) string {
 	return cmd
 }
 
+// sudoSudo wraps the command in a shell invocation under sudo. Passing the command to
+// "${SHELL-sh}" -c as a single quoted argument ensures compound expressions (pipes,
+// boolean lists, subshells, redirections) and inline KEY=VALUE assignments are interpreted
+// by a shell rather than handed to sudo verbatim. This mirrors the doas decorator and the
+// rig v2 sudo behavior.
 func sudoSudo(cmd string) string {
-	parts, err := shellwords.Parse(cmd)
-	if err != nil {
-		return "sudo -- " + cmd
-	}
-
-	var idx int
-	for i, p := range parts {
-		if strings.Contains(p, "=") {
-			idx = i + 1
-			continue
-		}
-		break
-	}
-
-	if idx == 0 {
-		return "sudo -- " + cmd
-	}
-
-	for i, p := range parts {
-		parts[i] = shellescape.Quote(p)
-	}
-
-	return fmt.Sprintf("sudo %s -- %s", strings.Join(parts[0:idx], " "), strings.Join(parts[idx:], " "))
+	return `sudo -n -- "${SHELL-sh}" -c ` + shellescape.Quote(cmd)
 }
 
 func sudoDoas(cmd string) string {

--- a/connection.go
+++ b/connection.go
@@ -266,16 +266,16 @@ func sudoNoop(cmd string) string {
 }
 
 // sudoSudo wraps the command in a shell invocation under sudo. Passing the command to
-// "${SHELL-sh}" -c as a single quoted argument ensures compound expressions (pipes,
+// "${SHELL:-sh}" -c as a single quoted argument ensures compound expressions (pipes,
 // boolean lists, subshells, redirections) and inline KEY=VALUE assignments are interpreted
 // by a shell rather than handed to sudo verbatim. This mirrors the doas decorator and the
 // rig v2 sudo behavior.
 func sudoSudo(cmd string) string {
-	return `sudo -n -- "${SHELL-sh}" -c ` + shellescape.Quote(cmd)
+	return `sudo -n -- "${SHELL:-sh}" -c ` + shellescape.Quote(cmd)
 }
 
 func sudoDoas(cmd string) string {
-	return `doas -n -- "${SHELL-sh}" -c ` + shellescape.Quote(cmd)
+	return `doas -n -- "${SHELL:-sh}" -c ` + shellescape.Quote(cmd)
 }
 
 // sudoWindows is a no-op: the session already has effective administrator privileges.
@@ -295,7 +295,7 @@ func (c *Connection) discoverSudo() {
 			c.SetSudofn(sudoSudo)
 			return
 		}
-		if c.Exec(`doas -n -- "${SHELL-sh}" -c true`) == nil {
+		if c.Exec(`doas -n -- "${SHELL:-sh}" -c true`) == nil {
 			// user has passwordless doas
 			c.SetSudofn(sudoDoas)
 		}

--- a/connection_test.go
+++ b/connection_test.go
@@ -161,3 +161,36 @@ func TestSudo(t *testing.T) {
 	require.NoError(t, h.Execf("ls %s", "/tmp", exec.Sudo(&h)))
 	require.Contains(t, mc.commands, "sudo-goes-here ls /tmp")
 }
+
+func TestSudoSudo(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{
+			name: "simple command",
+			cmd:  "ls /tmp",
+			want: `sudo -n -- "${SHELL-sh}" -c 'ls /tmp'`,
+		},
+		{
+			name: "compound command with subshell groups",
+			cmd:  "(systemctl start k0sworker) || (rc-service k0sworker start)",
+			want: `sudo -n -- "${SHELL-sh}" -c '(systemctl start k0sworker) || (rc-service k0sworker start)'`,
+		},
+		{
+			name: "pipeline",
+			cmd:  "cat /etc/passwd | grep root",
+			want: `sudo -n -- "${SHELL-sh}" -c 'cat /etc/passwd | grep root'`,
+		},
+		{
+			name: "leading environment assignment",
+			cmd:  "FOO=bar printenv FOO",
+			want: `sudo -n -- "${SHELL-sh}" -c 'FOO=bar printenv FOO'`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, sudoSudo(tt.cmd))
+		})
+	}
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -171,22 +171,22 @@ func TestSudoSudo(t *testing.T) {
 		{
 			name: "simple command",
 			cmd:  "ls /tmp",
-			want: `sudo -n -- "${SHELL-sh}" -c 'ls /tmp'`,
+			want: `sudo -n -- "${SHELL:-sh}" -c 'ls /tmp'`,
 		},
 		{
 			name: "compound command with subshell groups",
 			cmd:  "(systemctl start k0sworker) || (rc-service k0sworker start)",
-			want: `sudo -n -- "${SHELL-sh}" -c '(systemctl start k0sworker) || (rc-service k0sworker start)'`,
+			want: `sudo -n -- "${SHELL:-sh}" -c '(systemctl start k0sworker) || (rc-service k0sworker start)'`,
 		},
 		{
 			name: "pipeline",
 			cmd:  "cat /etc/passwd | grep root",
-			want: `sudo -n -- "${SHELL-sh}" -c 'cat /etc/passwd | grep root'`,
+			want: `sudo -n -- "${SHELL:-sh}" -c 'cat /etc/passwd | grep root'`,
 		},
 		{
 			name: "leading environment assignment",
 			cmd:  "FOO=bar printenv FOO",
-			want: `sudo -n -- "${SHELL-sh}" -c 'FOO=bar printenv FOO'`,
+			want: `sudo -n -- "${SHELL:-sh}" -c 'FOO=bar printenv FOO'`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
sudoSudo concatenated the command directly after "sudo --", so compound expressions (subshell groups, pipes, boolean lists, redirections) were handed to sudo verbatim and the remote shell hit a syntax error, e.g. "sudo -- (systemctl start k0sworker) || (...)" exits 2 with "syntax error near unexpected token '('".

Wrap the command in `sudo -n -- "${SHELL-sh}" -c <quoted>` so a shell interprets it, matching the existing doas decorator and rig v2. This also removes the special-case handling of leading KEY=VALUE assignments, which the shell now interprets correctly on its own.

Reported against k0smotron RemoteMachine SSH provisioning (k0sproject/k0smotron#1500).