### PR TITLE
fix(powershell): always use -EncodedCommand in Cmd()

### DIFF
--- a/powershell/golden_test.go
+++ b/powershell/golden_test.go
@@ -17,9 +17,9 @@ func TestCmdGolden(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "simple one-liner uses -Command",
+			name:  "simple one-liner is base64 encoded",
 			input: "Get-Service k0s",
-			want:  `powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -Command "$ProgressPreference='SilentlyContinue'; Get-Service k0s"`,
+			want:  `powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -E JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsAIABHAGUAdAAtAFMAZQByAHYAaQBjAGUAIABrADAAcwA=`,
 		},
 		{
 			name:  "pipe metachar forces -EncodedCommand",
@@ -39,7 +39,7 @@ func TestCmdGolden(t *testing.T) {
 		{
 			name:  "begin block skips ProgressPreference prefix",
 			input: "begin { $x = 1 } process { Write-Output $x }",
-			want:  `powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -Command "begin { $x = 1 } process { Write-Output $x }"`,
+			want:  `powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -E YgBlAGcAaQBuACAAewAgACQAeAAgAD0AIAAxACAAfQAgAHAAcgBvAGMAZQBzAHMAIAB7ACAAVwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIAAkAHgAIAB9AA==`,
 		},
 	}
 

--- a/powershell/powershell.go
+++ b/powershell/powershell.go
@@ -107,15 +107,16 @@ func EncodeCmd(psCmd string) string {
 }
 
 // Cmd builds a command-line for executing a PowerShell command or script.
-// Scripts that contain newlines, double-quotes, or cmd.exe metacharacters
-// are passed via -EncodedCommand to avoid shell expansion; simple one-liners
-// are passed via -Command so they remain readable in logs.
-// cmd.exe metacharacters guarded: " % ! ^ & | < >.
+// The command is always passed via -EncodedCommand (base64 UTF-16LE): the
+// payload is opaque to both cmd.exe and PowerShell, so it survives intact
+// regardless of the outer login shell. This matters when the remote host runs
+// OpenSSH with DefaultShell=PowerShell, where a plain -Command "..." argument
+// would be parsed and its $-tokens expanded by the outer shell before the
+// inner powershell.exe ever sees them. The trade-off is unreadable command
+// lines, but the runner's debug log decodes -EncodedCommand back to the
+// original script.
 func Cmd(psCmd string) string {
-	if strings.ContainsAny(psCmd, "\n\r\"%!^&|<>") {
-		return "powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -E " + EncodeCmd(psCmd)
-	}
-	return "powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -Command \"" + withProgressPreference(psCmd) + "\""
+	return "powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -NoP -E " + EncodeCmd(psCmd)
 }
 
 // SingleQuote quotes and escapes a string in a format that is accepted by powershell scriptlets

--- a/powershell/powershell_test.go
+++ b/powershell/powershell_test.go
@@ -11,11 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCmdSimpleUsesCommand(t *testing.T) {
+func TestCmdSimpleUsesEncoded(t *testing.T) {
+	// Even a trivial one-liner is base64-encoded: the payload must be opaque to
+	// an outer PowerShell login shell (OpenSSH DefaultShell=PowerShell) that
+	// would otherwise expand its $-tokens before the inner powershell.exe runs.
 	out := powershell.Cmd("$env:COMPUTERNAME")
-	require.Contains(t, out, "-Command")
-	require.NotContains(t, out, " -E ")
-	require.Contains(t, out, "$env:COMPUTERNAME")
+	require.Contains(t, out, " -E ")
+	require.NotContains(t, out, "-Command")
+	require.Contains(t, decodeCmd(t, out), "$env:COMPUTERNAME")
 }
 
 func TestCmdNewlineUsesEncoded(t *testing.T) {
@@ -32,13 +35,7 @@ func TestCmdDoubleQuoteUsesEncoded(t *testing.T) {
 
 func TestCmdSimpleInjectsProgressPreference(t *testing.T) {
 	out := powershell.Cmd("$env:COMPUTERNAME")
-	require.Contains(t, out, "$ProgressPreference='SilentlyContinue'")
-}
-
-func TestCmdSimpleReadableInLogs(t *testing.T) {
-	script := "[DateTimeOffset]::UtcNow.ToUnixTimeSeconds()"
-	out := powershell.Cmd(script)
-	require.True(t, strings.Contains(out, script), "simple script should be visible in the command string")
+	require.Contains(t, decodeCmd(t, out), "$ProgressPreference='SilentlyContinue'")
 }
 
 func TestCmdPercentUsesEncoded(t *testing.T) {
@@ -57,9 +54,7 @@ func TestCmdExclamationUsesEncoded(t *testing.T) {
 
 func TestCmdCmdExeMetacharsUseEncoded(t *testing.T) {
 	// These cmd.exe metacharacters can alter semantics when the command is
-	// executed via cmd.exe /c and must go through -EncodedCommand.
-	// Note: () are NOT included — they are protected inside the double-quoted
-	// -Command "..." argument and are ubiquitous in PowerShell method calls.
+	// executed via cmd.exe /c; -EncodedCommand keeps them opaque to the shell.
 	metacharScripts := []string{
 		`Write-Output ^escaped`,     // ^ escape character
 		`Get-Process & Get-Service`, // & command chaining
@@ -77,7 +72,19 @@ func TestCmdCmdExeMetacharsUseEncoded(t *testing.T) {
 func TestCmdBeginBlockSkipsProgressPrefix(t *testing.T) {
 	script := "begin { } process { Get-Date }"
 	out := powershell.Cmd(script)
-	require.NotContains(t, out, "$ProgressPreference")
+	// Decode first: the output is base64, so a raw substring check would pass
+	// trivially and prove nothing about the injected prefix.
+	require.NotContains(t, decodeCmd(t, out), "$ProgressPreference")
+}
+
+// decodeCmd extracts the -EncodedCommand payload from a full Cmd() command
+// line and decodes it back to the original PowerShell script.
+func decodeCmd(t *testing.T, cmd string) string {
+	t.Helper()
+	const marker = " -E "
+	idx := strings.Index(cmd, marker)
+	require.NotEqual(t, -1, idx, "command must use -EncodedCommand: %q", cmd)
+	return decodeEncodeCmd(t, cmd[idx+len(marker):])
 }
 
 // decodeEncodeCmd decodes a base64+UTF-16LE payload produced by EncodeCmd.
@@ -108,7 +115,7 @@ func TestCmdBeginBlockNoSpaceSkipsProgressPrefix(t *testing.T) {
 	// "begin{" without a space before the brace is also a valid begin block.
 	script := "begin{ } process { Get-Date }"
 	out := powershell.Cmd(script)
-	require.NotContains(t, out, "$ProgressPreference")
+	require.NotContains(t, decodeCmd(t, out), "$ProgressPreference")
 }
 
 func TestCmdBeginBlockCaseInsensitiveSkipsProgressPrefix(t *testing.T) {
@@ -118,7 +125,7 @@ func TestCmdBeginBlockCaseInsensitiveSkipsProgressPrefix(t *testing.T) {
 		"BEGIN { } PROCESS { Get-Date }",
 	} {
 		out := powershell.Cmd(script)
-		require.NotContains(t, out, "$ProgressPreference", "script: %s", script)
+		require.NotContains(t, decodeCmd(t, out), "$ProgressPreference", "script: %s", script)
 	}
 }
 


### PR DESCRIPTION
Fixes #398 

Cmd() previously routed simple one-liners through the readable -Command "..." form and only base64-encoded when cmd.exe metacharacters were present. That guard set (" % ! ^ & | < >) omits every PowerShell metacharacter ($, backtick, ;, quotes, spaces), so the readable path is unsafe whenever the outer login shell is PowerShell -- e.g. OpenSSH with DefaultShell=PowerShell. There the outer shell parses and expands the argument (including the injected $ProgressPreference='SilentlyContinue'; prefix) before the inner powershell.exe runs, corrupting the command.

Cmd() is a pure string helper with no knowledge of the remote shell, so it cannot reliably decide when -Command is safe. Always emitting -EncodedCommand makes the payload opaque to both cmd.exe and PowerShell and correct regardless of the outer shell. The runner's debug log already decodes -EncodedCommand, so readability is preserved for logging.