### PR TITLE
Change curl and wget commands to resume downloads

### DIFF
--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -402,13 +402,13 @@ func (s *PosixFS) ChownTreeInt(name string, uid, gid int) error {
 // and falls back to wget. Returns a descriptive error if neither is available.
 func (s *PosixFS) DownloadURL(url, dst string) error {
 	if _, err := s.LookPath("curl"); err == nil {
-		if err := s.Exec(sh.Command("curl", "-sSLf", "-o", dst, "--", url)); err != nil {
+		if err := s.Exec(sh.Command("curl", "-C -", "-sSLf", "-o", dst, "--", url)); err != nil {
 			return fmt.Errorf("download %s: %w", url, err)
 		}
 		return nil
 	}
 	if _, err := s.LookPath("wget"); err == nil {
-		if err := s.Exec(sh.Command("wget", "-qO", dst, "--", url)); err != nil {
+		if err := s.Exec(sh.Command("wget", "-c", "-qO", dst, "--", url)); err != nil {
 			return fmt.Errorf("download %s: %w", url, err)
 		}
 		return nil

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -402,7 +402,7 @@ func (s *PosixFS) ChownTreeInt(name string, uid, gid int) error {
 // and falls back to wget. Returns a descriptive error if neither is available.
 func (s *PosixFS) DownloadURL(url, dst string) error {
 	if _, err := s.LookPath("curl"); err == nil {
-		if err := s.Exec(sh.Command("curl", "-C -", "-sSLf", "-o", dst, "--", url)); err != nil {
+		if err := s.Exec(sh.Command("curl", "-C", "-", "-sSLf", "-o", dst, "--", url)); err != nil {
 			return fmt.Errorf("download %s: %w", url, err)
 		}
 		return nil


### PR DESCRIPTION
Partially fixes: https://github.com/k0sproject/k0sctl/issues/1131
This is the first part handling the commands `curl` and `wget`. There will be another PR regarding Windows Powershell.

Currently, repeated executions will download a complete file each time even if the file is already existing.

This change implements resuming downloads by default for `curl` and `wget`. In case, the source server does not support resuming, then this option is simply ignored and the download happens anyway.

`curl`
Use option `-C` or `--continue-at <offset>` to resume downloads. It is required to specify the offset which can be generalized by adding the option with `-C -`.

`wget`
Use option `-c` or `--continue` to resume downloads.
