### PR TITLE
Change Windows Powershell Invoke-WebRequest command to resume downloads

### DIFF
--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -450,7 +450,7 @@ func (s *WinFS) ChownTreeInt(name string, _, _ int) error {
 func (s *WinFS) DownloadURL(url, dst string) error {
 	script := fmt.Sprintf(`$ProgressPreference='SilentlyContinue'
 try {
-  Invoke-WebRequest -Uri %s -OutFile %s -UseBasicParsing -ErrorAction Stop | Out-Null
+  Invoke-WebRequest -Resume -Uri %s -OutFile %s -UseBasicParsing -ErrorAction Stop | Out-Null
 } catch {
   Write-Error $_.Exception.Message
   exit 1


### PR DESCRIPTION
Partially fixes: https://github.com/k0sproject/k0sctl/issues/1131

This is the second part handling the Windows Powershell `Invoke-WebRequest`. The reason to handle Windows Powershell separately is, because the below mentioned option was added in Powershell Version 6.1 which was released in **2018**. The question is whether the implementation needs to handle older Powershell versions as well. In that case, the PR needs revision.

Currently, repeated executions will download a complete file each time even if the file is already existing.

This change implements resuming downloads by default for Windows Powershell `Invoke-WebRequest`. In case, the source server does not support resuming, then this option is simply ignored and the download happens anyway.

Windows Powershell `Invoke-WebRequest`
Use option "-Resume" to resume downloads.
Source: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.6