### PR TITLE
feat(packagemanager): allow vendor change on zypper install

### DIFF
--- a/packagemanager/zypper.go
+++ b/packagemanager/zypper.go
@@ -7,8 +7,12 @@ import (
 )
 
 // NewZypper creates a new zypper package manager.
+//
+// The install action passes --allow-vendor-change so that a package which
+// replaces one provided by a different vendor resolves non-interactively
+// instead of cancelling with exit code 4.
 func NewZypper(c cmd.ContextRunner) PackageManager {
-	return newUniversalPackageManager(c, "zypper", "zypper", "install -y", "remove -y", "refresh")
+	return newUniversalPackageManager(c, "zypper", "zypper", "install -y --allow-vendor-change", "remove -y", "refresh")
 }
 
 // RegisterZypper registers the zypper package manager to a repository.


### PR DESCRIPTION
Fixes #417.

## What

Pass `--allow-vendor-change` on the zypper **install** action in `NewZypper`, so `PackageManager.Install` succeeds non-interactively when the only dependency-resolution solution replaces a package from a different vendor.

## Why

rig always runs zypper's non-interactive install (`zypper install -y`). By default zypper will not switch a package's vendor during an install, and non-interactively it does not accept the vendor-changing solution — it cancels and exits 4, with no actionable error. This affects any rig consumer installing a package whose resolution crosses a vendor boundary on SLES/openSUSE; it is not specific to any tool, repo, or package. Full mechanism, repro, and logs are in #417.

## ⚠️ This may be undesirable — RFC

**This change is deliberately aggressive about package adoption.** Passing `--allow-vendor-change` unconditionally lets zypper switch a package's vendor/origin on any install, which some operators may consider undesirable as a global default (it weakens the same-vendor guarantee zypper gives out of the box).

Raising as an RFC. If a global default isn't acceptable, the alternative is to gate it behind an opt-in install option — but that requires extending `PackageManager.Install` (today `Install(ctx, packageNames ...string)`, no room for per-call options), a larger, breaking-ish API change affecting every manager and caller. Happy to implement whichever shape you prefer; this one-line version is the minimal demonstration.

## Testing

- `go build ./packagemanager/...` and `go test ./packagemanager/...` pass.
- Manually verified on a SLES 15 instance: the un-flagged install exits 4 on a vendor-change resolution, and the same install with `--allow-vendor-change` succeeds (exit 0).

Written by AI: claude-sonnet-5
