### PR TITLE
feat(winrm): export ErrAuthFailed and stop marking 401/403 non-retryable

### DIFF
--- a/protocol/winrm/connection.go
+++ b/protocol/winrm/connection.go
@@ -86,12 +86,12 @@ func (c *Connection) IsWindows() bool {
 }
 
 // probe runs a no-op command to verify the connection is alive and authenticated.
-// HTTP 401/403 responses are wrapped as ErrNonRetryable.
+// HTTP 401/403 responses are wrapped as ErrAuthFailed.
 func (c *Connection) probe(ctx context.Context) error {
 	proc, err := c.StartProcess(ctx, "cmd.exe /c exit 0", nil, nil, nil)
 	if err != nil {
 		if isAuthError(err) {
-			return fmt.Errorf("%w: %w", protocol.ErrNonRetryable, err)
+			return fmt.Errorf("%w: %w", ErrAuthFailed, err)
 		}
 		return err
 	}
@@ -100,6 +100,18 @@ func (c *Connection) probe(ctx context.Context) error {
 	}
 	return nil
 }
+
+// ErrAuthFailed is returned when the remote host rejects the supplied
+// credentials with an HTTP 401 or 403.
+//
+// This is deliberately not wrapped in protocol.ErrNonRetryable. A rejection is
+// the remote host's answer, and on Windows it is routinely transient: the WinRM
+// listener starts answering before provisioning has finished configuring
+// authentication, so a host that has just booted returns 401 for a while with
+// entirely correct credentials. Callers that provision hosts need to wait
+// through that, and callers that want to fail fast on bad credentials can test
+// for this error explicitly.
+var ErrAuthFailed = errors.New("authentication failed")
 
 // isAuthError reports whether err looks like an HTTP 401/403 response from the
 // WinRM library. The library returns untyped formatted errors so we match by

--- a/protocol/winrm/connection_test.go
+++ b/protocol/winrm/connection_test.go
@@ -79,9 +79,11 @@ func Test_isAuthError(t *testing.T) {
 }
 
 // Test_authErrorWrapping verifies that the classification/wrapping logic used in
-// probe produces ErrNonRetryable for auth errors and leaves other errors retryable.
-// probe itself is not called here because it requires a live WinRM client; see the
-// todo item for WinRM integration tests.
+// probe tags auth errors with ErrAuthFailed and leaves other errors untagged,
+// and that neither is marked non-retryable -- a credential rejection is the
+// remote host's answer and is routinely transient while a host is still being
+// provisioned. probe itself is not called here because it requires a live WinRM
+// client; see the todo item for WinRM integration tests.
 func Test_authErrorWrapping(t *testing.T) {
 	authErr := fmt.Errorf("create shell: http error 401: Unauthorized")
 	nonAuthErr := fmt.Errorf("dial tcp 10.0.0.1:5985: connect: connection refused")
@@ -89,19 +91,19 @@ func Test_authErrorWrapping(t *testing.T) {
 	tests := []struct {
 		name           string
 		startErr       error
-		wantNonRetry   bool
+		wantAuthFailed bool
 		wantErrContain string
 	}{
 		{
-			name:           "auth failure becomes ErrNonRetryable",
+			name:           "auth failure is tagged ErrAuthFailed",
 			startErr:       authErr,
-			wantNonRetry:   true,
+			wantAuthFailed: true,
 			wantErrContain: authErr.Error(),
 		},
 		{
-			name:           "network failure stays retryable",
+			name:           "network failure is not tagged",
 			startErr:       nonAuthErr,
-			wantNonRetry:   false,
+			wantAuthFailed: false,
 			wantErrContain: nonAuthErr.Error(),
 		},
 	}
@@ -113,7 +115,7 @@ func Test_authErrorWrapping(t *testing.T) {
 			// against a real WinRM server is deferred to the todo item for WinRM tests.
 			var err error
 			if isAuthError(tt.startErr) {
-				err = fmt.Errorf("%w: %w", protocol.ErrNonRetryable, tt.startErr)
+				err = fmt.Errorf("%w: %w", ErrAuthFailed, tt.startErr)
 			} else {
 				err = tt.startErr
 			}
@@ -121,9 +123,12 @@ func Test_authErrorWrapping(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected an error, got nil")
 			}
-			gotNonRetry := errors.Is(err, protocol.ErrNonRetryable)
-			if gotNonRetry != tt.wantNonRetry {
-				t.Errorf("errors.Is(err, ErrNonRetryable) = %v, want %v (err: %v)", gotNonRetry, tt.wantNonRetry, err)
+			if got := errors.Is(err, ErrAuthFailed); got != tt.wantAuthFailed {
+				t.Errorf("errors.Is(err, ErrAuthFailed) = %v, want %v (err: %v)", got, tt.wantAuthFailed, err)
+			}
+			// Neither case may abort a caller's retry loop.
+			if errors.Is(err, protocol.ErrNonRetryable) {
+				t.Errorf("err must not be ErrNonRetryable, a rejection can clear once the host finishes provisioning (err: %v)", err)
 			}
 			if tt.wantErrContain != "" {
 				if msg := err.Error(); !strings.Contains(msg, tt.wantErrContain) {
@@ -136,24 +141,24 @@ func Test_authErrorWrapping(t *testing.T) {
 
 func TestConnect_probeClassification(t *testing.T) {
 	tests := []struct {
-		name         string
-		statusCode   int
-		wantNonRetry bool
+		name           string
+		statusCode     int
+		wantAuthFailed bool
 	}{
 		{
-			name:         "401 becomes ErrNonRetryable",
-			statusCode:   http.StatusUnauthorized,
-			wantNonRetry: true,
+			name:           "401 becomes ErrAuthFailed",
+			statusCode:     http.StatusUnauthorized,
+			wantAuthFailed: true,
 		},
 		{
-			name:         "403 becomes ErrNonRetryable",
-			statusCode:   http.StatusForbidden,
-			wantNonRetry: true,
+			name:           "403 becomes ErrAuthFailed",
+			statusCode:     http.StatusForbidden,
+			wantAuthFailed: true,
 		},
 		{
-			name:         "500 stays retryable",
-			statusCode:   http.StatusInternalServerError,
-			wantNonRetry: false,
+			name:           "500 is not an auth failure",
+			statusCode:     http.StatusInternalServerError,
+			wantAuthFailed: false,
 		},
 	}
 
@@ -195,9 +200,14 @@ func TestConnect_probeClassification(t *testing.T) {
 				t.Fatal("Connect() succeeded against stub server, want error")
 			}
 
-			gotNonRetry := errors.Is(err, protocol.ErrNonRetryable)
-			if gotNonRetry != tt.wantNonRetry {
-				t.Errorf("Connect() errors.Is(err, ErrNonRetryable) = %v, want %v (err: %v)", gotNonRetry, tt.wantNonRetry, err)
+			if got := errors.Is(err, ErrAuthFailed); got != tt.wantAuthFailed {
+				t.Errorf("Connect() errors.Is(err, ErrAuthFailed) = %v, want %v (err: %v)", got, tt.wantAuthFailed, err)
+			}
+
+			// No HTTP status from the remote may abort a caller's retry loop: the
+			// response can differ once the host finishes provisioning.
+			if errors.Is(err, protocol.ErrNonRetryable) {
+				t.Errorf("Connect() must not return ErrNonRetryable for an HTTP %d (err: %v)", tt.statusCode, err)
 			}
 
 			if conn.IsConnected() {


### PR DESCRIPTION
## What
Exports `winrm.ErrAuthFailed` and tags HTTP 401/403 responses with it, instead of wrapping them in `protocol.ErrNonRetryable`.

## Why
`probe` currently does this:

```go
if isAuthError(err) {
    return fmt.Errorf("%w: %w", protocol.ErrNonRetryable, err)
}
```

`ErrNonRetryable` ends a caller's retry loop on its first attempt, and that is the wrong conclusion to draw from a 401.

A credential rejection is the **remote host's answer**, not a statement about local configuration — and on Windows it is routinely transient. The WinRM listener starts answering before provisioning has finished configuring authentication, so a freshly booted host returns 401 for a period with entirely correct credentials. A tool that provisions hosts and then connects to them needs to wait through that window.

### It also sits oddly beside the SSH protocol

Every `ErrNonRetryable` in `protocol/ssh` is a **local** fault that cannot change between attempts:

| SSH site | Nature |
|---|---|
| `no known_hosts file found`, `global known_hosts` | local config |
| `create host key validator`, `create config` | local config |
| `no usable authentication method found` | local — *we* have nothing to offer |
| `signer not found for public key` | local |
| `bastion connection is not an SSH connection` | local config |
| `host key verification failed` (openssh) | local trust decision |

Notably, SSH does **not** classify a server-side credential rejection this way. WinRM's 401/403 is the only case where a remote response terminates the retry loop.

### Consumers currently have to duplicate the substring match

`isAuthError` matches the WinRM library's untyped errors by substring, and none of that is reachable from outside the package. A consumer that wants to keep waiting through a 401 has no option but to copy those four substrings — which is exactly what we ended up doing downstream, and it silently couples us to this file's internals.

## How this showed up
Found while migrating [Mirantis/launchpad](https://github.com/Mirantis/launchpad) from rig v0 to v2. Our connect phase waits up to 60 attempts for hosts to come up. After the migration, Windows hosts failed on the first attempt:

```
Open Remote Connection => connect <host>:5986: All attempts fail:
#1: retry: abort condition reached after 1 attempts: operation cannot be
    completed: create shell: http response error: 401 - invalid content type
```

The contrast within a single CI run made it clear: a host returning `i/o timeout` was retried to attempt 36 of 60 and given every chance to come up, while a host returning 401 was abandoned immediately. Both were the same underlying condition — provisioning not yet finished — and the same host connected fine on an earlier run.

Under rig v0 these errors were unclassified, so the wait absorbed them and the condition healed itself.

## Approach
This changes default behaviour, so I want to flag the trade explicitly: callers with genuinely wrong credentials will now spend their retry budget before reporting, rather than failing at once. I think that is the right default for a library used to bring up hosts — and the information is no longer lost, since `ErrAuthFailed` makes fail-fast a one-line opt-in:

```go
if errors.Is(err, winrm.ErrAuthFailed) { /* stop now */ }
```

**If you would rather not change the default**, I am equally happy to keep the `ErrNonRetryable` wrap and only add the exported sentinel. That alone removes the substring duplication for consumers, which is the part we cannot work around cleanly. Say which you prefer and I will reshape it.

## Testing
The two existing tests are **updated rather than added to**, since they pinned the previous classification:

- `Test_authErrorWrapping` — now asserts `ErrAuthFailed` is applied, and that neither case is `ErrNonRetryable`.
- `TestConnect_probeClassification` — drives a real `httptest` server through `Connect`. Verified it fails against the old behaviour, reproducing the production error verbatim: `Connect() must not return ErrNonRetryable for an HTTP 401 (err: operation cannot be completed: create shell: http response error: 401 - invalid content type)`.

`Test_isAuthError` is unchanged and still passes — the substring matching itself is not altered. Full suite green (24 packages).

Written by AI: claude-sonnet-5
