### PR TITLE
Promote ErrAuthFailed to protocol and tag SSH auth failures

### DIFF
--- a/aliases.go
+++ b/aliases.go
@@ -23,6 +23,11 @@ var (
 	// ErrValidationFailed is returned when a validation check fails.
 	// An alias of protocol.ErrValidationFailed for easier access without importing subpackages.
 	ErrValidationFailed = protocol.ErrValidationFailed
+
+	// ErrAuthFailed is returned when the remote host rejects the supplied credentials.
+	// It is not an ErrNonRetryable, see the protocol.ErrAuthFailed documentation for why.
+	// An alias of protocol.ErrAuthFailed for easier access without importing subpackages.
+	ErrAuthFailed = protocol.ErrAuthFailed
 )
 
 // PackageManagerProvider is a type alias for packagemanager.Provider.

--- a/protocol/connection.go
+++ b/protocol/connection.go
@@ -15,6 +15,25 @@ var (
 	// ErrNonRetryable is returned when retrying an operation will not result in a
 	// different outcome.
 	ErrNonRetryable = errors.New("operation cannot be completed")
+
+	// ErrAuthFailed is returned when the remote host rejects the credentials it
+	// was given. Protocol implementations tag their authentication failures with
+	// it: an HTTP 401/403 on WinRM, an exhausted authentication handshake on SSH.
+	//
+	// It covers credentials the remote received and refused. It does not cover
+	// local configuration faults such as having no usable authentication method
+	// to offer in the first place -- those are ErrNonRetryable, because nothing
+	// about the local configuration changes between attempts.
+	//
+	// ErrAuthFailed is deliberately not wrapped in ErrNonRetryable. A rejection is
+	// the remote host's answer, and it is routinely transient while a host is
+	// still being provisioned: WinRM starts answering before authentication has
+	// been configured, and sshd accepts connections before authorized_keys has
+	// been written. A caller that provisions hosts and then connects to them
+	// needs to wait through that window, so retrying is left enabled by default.
+	// Callers that would rather fail fast on bad credentials can test for this
+	// error explicitly and stop their own retry loop.
+	ErrAuthFailed = errors.New("authentication failed")
 )
 
 // Waiter is a process that can be waited to finish.

--- a/protocol/openssh/connection.go
+++ b/protocol/openssh/connection.go
@@ -32,6 +32,43 @@ func isHostKeyError(stderr string) bool {
 		strings.Contains(stderr, "REMOTE HOST IDENTIFICATION HAS CHANGED")
 }
 
+// isAuthError reports whether ssh stderr output indicates the remote rejected
+// every authentication method that was offered. The openssh client reports this
+// as "Permission denied" followed by the parenthesised list of methods it tried,
+// for example:
+//
+//	user@host: Permission denied (publickey,password).
+//
+// The method list is what makes the match specific: a bare "Permission denied"
+// is also produced by the remote command and by unreadable local key files,
+// neither of which is a credential rejection.
+func isAuthError(stderr string) bool {
+	_, rest, found := strings.Cut(stderr, "Permission denied (")
+	if !found {
+		return false
+	}
+	methods, _, closed := strings.Cut(rest, ")")
+	return closed && methods != ""
+}
+
+// classifyConnectError describes a failed ssh client invocation with the
+// sentinel its stderr points to, prefixed with the stage that produced it.
+//
+// A host key failure is a security decision that will not come out differently
+// on the next attempt, so it is non-retryable. A credential rejection is the
+// remote's answer and may clear once it finishes provisioning, so it is tagged
+// but left retryable. Everything else is returned with only the stage prefix.
+func classifyConnectError(err error, stderr, stage string) error {
+	switch {
+	case isHostKeyError(stderr):
+		return fmt.Errorf("%w: host key verification failed: %w (%s)", protocol.ErrNonRetryable, err, stderr)
+	case isAuthError(stderr):
+		return fmt.Errorf("%w: %s: %w (%s)", protocol.ErrAuthFailed, stage, err, stderr)
+	default:
+		return fmt.Errorf("%s: %w (%s)", stage, err, stderr)
+	}
+}
+
 // Connection is a rig.Connection implementation that uses the system openssh client "ssh" to connect to remote hosts.
 // The connection is by default multiplexec over a control master, so that subsequent connections don't need to re-authenticate.
 type Connection struct {
@@ -192,11 +229,7 @@ func (c *Connection) Connect(ctx context.Context) error {
 			err = proc.Wait()
 		}
 		if err != nil {
-			errOut := errBuf.String()
-			if isHostKeyError(errOut) {
-				return fmt.Errorf("%w: host key verification failed: %w (%s)", protocol.ErrNonRetryable, err, errOut)
-			}
-			return fmt.Errorf("failed to connect: %w", err)
+			return classifyConnectError(err, errBuf.String(), "failed to connect")
 		}
 		c.controlMutex.Lock()
 		c.isConnected = true
@@ -225,11 +258,7 @@ func (c *Connection) Connect(ctx context.Context) error {
 	if err := cmd.Run(); err != nil {
 		c.isConnected = false
 		c.controlMutex.Unlock()
-		errOut := errBuf.String()
-		if isHostKeyError(errOut) {
-			return fmt.Errorf("%w: host key verification failed: %w (%s)", protocol.ErrNonRetryable, err, errOut)
-		}
-		return fmt.Errorf("failed to start ssh multiplexing control master: %w (%s)", err, errOut)
+		return classifyConnectError(err, errBuf.String(), "failed to start ssh multiplexing control master")
 	}
 
 	c.isConnected = true

--- a/protocol/openssh/connection.go
+++ b/protocol/openssh/connection.go
@@ -58,14 +58,21 @@ func isAuthError(stderr string) bool {
 // on the next attempt, so it is non-retryable. A credential rejection is the
 // remote's answer and may clear once it finishes provisioning, so it is tagged
 // but left retryable. Everything else is returned with only the stage prefix.
+//
+// The captured stderr is appended in parentheses when it carries anything; ssh
+// can fail before writing a word of it, and an empty "()" only adds noise.
 func classifyConnectError(err error, stderr, stage string) error {
+	var detail string
+	if out := strings.TrimSpace(stderr); out != "" {
+		detail = " (" + out + ")"
+	}
 	switch {
 	case isHostKeyError(stderr):
-		return fmt.Errorf("%w: host key verification failed: %w (%s)", protocol.ErrNonRetryable, err, stderr)
+		return fmt.Errorf("%w: %s: host key verification failed: %w%s", protocol.ErrNonRetryable, stage, err, detail)
 	case isAuthError(stderr):
-		return fmt.Errorf("%w: %s: %w (%s)", protocol.ErrAuthFailed, stage, err, stderr)
+		return fmt.Errorf("%w: %s: %w%s", protocol.ErrAuthFailed, stage, err, detail)
 	default:
-		return fmt.Errorf("%s: %w (%s)", stage, err, stderr)
+		return fmt.Errorf("%s: %w%s", stage, err, detail)
 	}
 }
 

--- a/protocol/openssh/connection_test.go
+++ b/protocol/openssh/connection_test.go
@@ -1,8 +1,10 @@
 package openssh
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/k0sproject/rig/v2/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -102,6 +104,60 @@ func Test_isHostKeyError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, isHostKeyError(tt.stderr), "isHostKeyError(%q)", tt.stderr)
+		})
+	}
+}
+
+func Test_classifyConnectError(t *testing.T) {
+	errExit := errors.New("exit status 255")
+
+	tests := []struct {
+		name         string
+		stderr       string
+		wantMessage  string
+		wantSentinel error
+	}{
+		{
+			name:         "host key failure",
+			stderr:       "Host key verification failed.\r\n",
+			wantMessage:  protocol.ErrNonRetryable.Error() + ": failed to connect: host key verification failed: exit status 255 (Host key verification failed.)",
+			wantSentinel: protocol.ErrNonRetryable,
+		},
+		{
+			name:         "credential rejection",
+			stderr:       "test@127.0.0.1: Permission denied (publickey).\r\n",
+			wantMessage:  protocol.ErrAuthFailed.Error() + ": failed to connect: exit status 255 (test@127.0.0.1: Permission denied (publickey).)",
+			wantSentinel: protocol.ErrAuthFailed,
+		},
+		{
+			name:        "unclassified failure",
+			stderr:      "ssh: connect to host 10.0.0.1 port 22: Connection refused\r\n",
+			wantMessage: "failed to connect: exit status 255 (ssh: connect to host 10.0.0.1 port 22: Connection refused)",
+		},
+		{
+			name:        "empty stderr is not appended",
+			stderr:      "",
+			wantMessage: "failed to connect: exit status 255",
+		},
+		{
+			name:        "blank stderr is not appended",
+			stderr:      "\r\n \n",
+			wantMessage: "failed to connect: exit status 255",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := classifyConnectError(errExit, tt.stderr, "failed to connect")
+			require.EqualError(t, err, tt.wantMessage)
+			require.ErrorIs(t, err, errExit, "the underlying error must stay unwrappable")
+			if tt.wantSentinel != nil {
+				require.ErrorIs(t, err, tt.wantSentinel)
+			}
+			// only a host key failure is fatal; everything else stays retryable.
+			if !errors.Is(tt.wantSentinel, protocol.ErrNonRetryable) {
+				require.NotErrorIs(t, err, protocol.ErrNonRetryable)
+			}
 		})
 	}
 }

--- a/protocol/openssh/connection_test.go
+++ b/protocol/openssh/connection_test.go
@@ -1,0 +1,107 @@
+package openssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_isAuthError(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		want   bool
+	}{
+		{
+			name:   "empty stderr",
+			stderr: "",
+			want:   false,
+		},
+		{
+			name:   "publickey rejected",
+			stderr: "test@127.0.0.1: Permission denied (publickey).\r\n",
+			want:   true,
+		},
+		{
+			name:   "several methods rejected",
+			stderr: "test@127.0.0.1: Permission denied (publickey,gssapi-keyex,password).\r\n",
+			want:   true,
+		},
+		{
+			name:   "verbose output before the rejection",
+			stderr: "debug1: Next authentication method: password\ntest@host: Permission denied (password,keyboard-interactive).\n",
+			want:   true,
+		},
+		{
+			name:   "remote command permission denied is not an auth failure",
+			stderr: "cat: /etc/shadow: Permission denied\n",
+			want:   false,
+		},
+		{
+			name:   "unreadable local key file is not an auth failure",
+			stderr: "Load key \"/home/test/.ssh/id_ed25519\": Permission denied\n",
+			want:   false,
+		},
+		{
+			name:   "empty method list is not a rejection",
+			stderr: "Permission denied ()\n",
+			want:   false,
+		},
+		{
+			name:   "unterminated method list is not a rejection",
+			stderr: "Permission denied (publickey",
+			want:   false,
+		},
+		{
+			name:   "host key failure is not an auth failure",
+			stderr: "Host key verification failed.\r\n",
+			want:   false,
+		},
+		{
+			name:   "connection refused is not an auth failure",
+			stderr: "ssh: connect to host 10.0.0.1 port 22: Connection refused\r\n",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isAuthError(tt.stderr), "isAuthError(%q)", tt.stderr)
+		})
+	}
+}
+
+func Test_isHostKeyError(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		want   bool
+	}{
+		{
+			name:   "empty stderr",
+			stderr: "",
+			want:   false,
+		},
+		{
+			name:   "verification failed",
+			stderr: "Host key verification failed.\r\n",
+			want:   true,
+		},
+		{
+			name:   "identification changed",
+			stderr: "@@@@@@@\nWARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!\n",
+			want:   true,
+		},
+		{
+			name:   "auth failure is not a host key error",
+			stderr: "test@127.0.0.1: Permission denied (publickey).\r\n",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isHostKeyError(tt.stderr), "isHostKeyError(%q)", tt.stderr)
+		})
+	}
+}

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -38,6 +38,41 @@ var (
 	errNotRegularFile = errors.New("not a regular file")
 )
 
+// isAuthError reports whether err is the handshake failure golang.org/x/crypto/ssh
+// returns once every configured authentication method has been refused by the
+// remote. The library returns an untyped formatted error, so this matches by
+// substring on the message it builds in client_auth.go:
+//
+//	"ssh: unable to authenticate, attempted methods [...], no supported methods remain"
+//
+// Only a rejection by the remote counts. Failing to assemble any usable
+// authentication method locally is a configuration fault and stays
+// protocol.ErrNonRetryable.
+func isAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "ssh: unable to authenticate")
+}
+
+// classifyHandshakeError describes a failed SSH handshake with the sentinel that
+// fits it, prefixed with the stage that produced it.
+//
+// A host key mismatch is a security decision that will not come out differently
+// on the next attempt, so it is non-retryable. A credential rejection is the
+// remote's answer and may clear once it finishes provisioning, so it is tagged
+// but left retryable. Everything else is returned with only the stage prefix.
+func classifyHandshakeError(err error, stage string) error {
+	switch {
+	case errors.Is(err, hostkey.ErrHostKeyMismatch):
+		return fmt.Errorf("%w: %s: %w", protocol.ErrNonRetryable, stage, err)
+	case isAuthError(err):
+		return fmt.Errorf("%w: %s: %w", protocol.ErrAuthFailed, stage, err)
+	default:
+		return fmt.Errorf("%s: %w", stage, err)
+	}
+}
+
 // Connection describes an SSH connection.
 type Connection struct {
 	log.LoggerInjectable `yaml:"-"`
@@ -863,10 +898,7 @@ func (c *Connection) connectViaBastion(ctx context.Context, dst string, config *
 	agentClose()
 	if err != nil {
 		_ = bconn.Close()
-		if errors.Is(err, hostkey.ErrHostKeyMismatch) {
-			return fmt.Errorf("%w: bastion client connect: %w", protocol.ErrNonRetryable, err)
-		}
-		return fmt.Errorf("bastion client connect: %w", err)
+		return classifyHandshakeError(err, "bastion client connect")
 	}
 	if !deadline.IsZero() {
 		_ = bconn.SetDeadline(time.Time{})
@@ -1074,10 +1106,7 @@ func (c *Connection) Connect(ctx context.Context) error {
 	agentClose()
 	if err != nil {
 		_ = conn.Close()
-		if errors.Is(err, hostkey.ErrHostKeyMismatch) {
-			return fmt.Errorf("%w: %w", protocol.ErrNonRetryable, err)
-		}
-		return fmt.Errorf("ssh dial: %w", err)
+		return classifyHandshakeError(err, "ssh dial")
 	}
 	_ = conn.SetDeadline(time.Time{})
 	c.mu.Lock()

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -5,10 +5,13 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +26,68 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
 )
+
+// errAuthRejected is what test SSH servers return when refusing a credential.
+var errAuthRejected = errors.New("auth rejected")
+
+// startSSHServer starts an in-process SSH server on a random loopback port using
+// the given config and returns its listen address. It serves no channels: every
+// channel-open request is rejected. The listener is closed by t.Cleanup.
+func startSSHServer(t *testing.T, cfg *ssh.ServerConfig) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, lErr := ln.Accept()
+			if lErr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				sconn, chans, reqs, hsErr := ssh.NewServerConn(c, cfg)
+				if hsErr != nil {
+					return
+				}
+				defer sconn.Close()
+				go ssh.DiscardRequests(reqs)
+				for newChan := range chans {
+					newChan.Reject(ssh.UnknownChannelType, "not supported") //nolint:errcheck
+				}
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String()
+}
+
+// newHostSigner generates an ephemeral ed25519 host key for a test SSH server.
+func newHostSigner(t *testing.T) ssh.Signer {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+	return signer
+}
+
+// pinHostKey writes a known_hosts file pinning hostSigner's public key for addr
+// and points SSH_KNOWN_HOSTS at it, so host key verification is exercised rather
+// than bypassed. knownhosts.Normalize converts "host:port" to "[host]:port" for
+// non-22 ports, which is the form the validator looks up.
+func pinHostKey(t *testing.T, addr string, hostSigner ssh.Signer) {
+	t.Helper()
+	line := fmt.Sprintf("%s %s\n",
+		knownhosts.Normalize(addr),
+		strings.TrimRight(string(ssh.MarshalAuthorizedKey(hostSigner.PublicKey())), "\n"),
+	)
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(path, []byte(line), 0o600))
+	t.Setenv("SSH_KNOWN_HOSTS", path)
+}
 
 // withConfigParser temporarily installs a hermetic ssh config parser built from
 // the given ssh_config content and restores the previous parser afterwards.
@@ -486,6 +551,99 @@ func newBlockingSSHClient(t *testing.T) *ssh.Client {
 	client := ssh.NewClient(clientConn, clientChans, clientReqs)
 	t.Cleanup(func() { client.Close() })
 	return client
+}
+
+func Test_isAuthError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "handshake exhausted all methods",
+			err:  errors.New("ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"),
+			want: true,
+		},
+		{
+			name: "wrapped handshake failure",
+			err:  fmt.Errorf("ssh dial: %w", errors.New("ssh: unable to authenticate, attempted methods [none], no supported methods remain")),
+			want: true,
+		},
+		{
+			name: "connection refused",
+			err:  errors.New("dial tcp 10.0.0.1:22: connect: connection refused"),
+			want: false,
+		},
+		{
+			name: "host key mismatch",
+			err:  errors.New("ssh: handshake failed: host key mismatch"),
+			want: false,
+		},
+		{
+			name: "remote command permission denied",
+			err:  errors.New("Process exited with status 1: cat: /etc/shadow: Permission denied"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isAuthError(tt.err), "isAuthError(%v)", tt.err)
+		})
+	}
+}
+
+// TestConnectAuthFailure drives Connect against an in-process SSH server that
+// refuses every credential it is offered. The resulting error must be tagged
+// protocol.ErrAuthFailed so callers can fail fast on bad credentials, but must
+// not be non-retryable: the same credentials can start working once the remote
+// finishes provisioning.
+func TestConnectAuthFailure(t *testing.T) {
+	withConfigParser(t, "")
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	hostSigner := newHostSigner(t)
+	cfg := &ssh.ServerConfig{
+		ServerVersion: "SSH-2.0-test-linux",
+		PasswordCallback: func(_ ssh.ConnMetadata, _ []byte) (*ssh.Permissions, error) {
+			return nil, errAuthRejected
+		},
+	}
+	cfg.AddHostKey(hostSigner)
+
+	serverAddr := startSSHServer(t, cfg)
+	pinHostKey(t, serverAddr, hostSigner)
+
+	serverHost, serverPortStr, err := net.SplitHostPort(serverAddr)
+	require.NoError(t, err)
+	serverPort, err := strconv.Atoi(serverPortStr)
+	require.NoError(t, err)
+
+	conn, err := NewConnection(Config{
+		Address:     serverHost,
+		Port:        serverPort,
+		User:        "test",
+		AuthMethods: []ssh.AuthMethod{ssh.Password("wrong")},
+	})
+	require.NoError(t, err)
+	t.Cleanup(conn.Disconnect)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = conn.Connect(ctx)
+	require.Error(t, err, "Connect must fail against a server that rejects every credential")
+	require.ErrorIs(t, err, protocol.ErrAuthFailed)
+	require.NotErrorIs(t, err, protocol.ErrNonRetryable,
+		"a credential rejection can clear once the remote finishes provisioning")
+	require.ErrorContains(t, err, "ssh dial",
+		"the tag must come from the direct-connect handshake, not some other path")
+	require.False(t, conn.IsConnected())
 }
 
 // TestDialWithDeadlineContextCancelled verifies that dialWithDeadline aborts

--- a/protocol/ssh/proxy.go
+++ b/protocol/ssh/proxy.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/k0sproject/rig/v2/protocol"
-	"github.com/k0sproject/rig/v2/protocol/ssh/hostkey"
 	ssh "golang.org/x/crypto/ssh"
 )
 
@@ -245,10 +244,7 @@ func (c *Connection) connectViaProxyCommand(ctx context.Context, dst string, con
 	if result.err != nil {
 		_ = pconn.Close()
 		killProc()
-		if errors.Is(result.err, hostkey.ErrHostKeyMismatch) {
-			return fmt.Errorf("%w: %w", protocol.ErrNonRetryable, result.err)
-		}
-		return fmt.Errorf("proxy command ssh connect: %w", result.err)
+		return classifyHandshakeError(result.err, "proxy command ssh connect")
 	}
 
 	c.mu.Lock()

--- a/protocol/ssh/proxy_test.go
+++ b/protocol/ssh/proxy_test.go
@@ -2,22 +2,18 @@ package ssh
 
 import (
 	"context"
-	"crypto/ed25519"
-	"crypto/rand"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"runtime"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ssh "golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // TestMain handles the helper-proxy subprocess invoked by TestConnectViaProxyCommand.
@@ -49,13 +45,9 @@ func TestMain(m *testing.M) {
 func startMinimalSSHServer(t *testing.T) (addr string, hostSigner ssh.Signer) {
 	t.Helper()
 
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
-	hostSigner, err = ssh.NewSignerFromKey(priv)
-	require.NoError(t, err)
-
+	hostSigner = newHostSigner(t)
 	cfg := &ssh.ServerConfig{
-		NoClientAuth:  true,
+		NoClientAuth: true,
 		// "linux" in the version string causes isKnownPosix() to return true,
 		// short-circuiting the ver.exe probe in detectWindows and avoiding a
 		// reconnect loop that would block the test for the full context duration.
@@ -63,32 +55,7 @@ func startMinimalSSHServer(t *testing.T) (addr string, hostSigner ssh.Signer) {
 	}
 	cfg.AddHostKey(hostSigner)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { ln.Close() })
-
-	go func() {
-		for {
-			conn, lErr := ln.Accept()
-			if lErr != nil {
-				return
-			}
-			go func(c net.Conn) {
-				defer c.Close()
-				sconn, chans, reqs, hsErr := ssh.NewServerConn(c, cfg)
-				if hsErr != nil {
-					return
-				}
-				defer sconn.Close()
-				go ssh.DiscardRequests(reqs)
-				for newChan := range chans {
-					newChan.Reject(ssh.UnknownChannelType, "not supported") //nolint:errcheck
-				}
-			}(conn)
-		}
-	}()
-
-	return ln.Addr().String(), hostSigner
+	return startSSHServer(t, cfg), hostSigner
 }
 
 // TestParseProxyJump exercises the ProxyJump parser for various formats.
@@ -369,17 +336,7 @@ func TestConnectViaProxyCommand(t *testing.T) {
 	serverPort, err := strconv.Atoi(serverPortStr)
 	require.NoError(t, err)
 
-	// Pin the host key: MarshalAuthorizedKey already includes the key type.
-	// knownhosts.Normalize converts "host:port" to "[host]:port" for non-22 ports.
-	hostPub := hostSigner.PublicKey()
-	normalizedAddr := knownhosts.Normalize(serverAddr)
-	knownHostsLine := fmt.Sprintf("%s %s\n",
-		normalizedAddr,
-		strings.TrimRight(string(ssh.MarshalAuthorizedKey(hostPub)), "\n"),
-	)
-	khFile := t.TempDir() + "/known_hosts"
-	require.NoError(t, os.WriteFile(khFile, []byte(knownHostsLine), 0o600))
-	t.Setenv("SSH_KNOWN_HOSTS", khFile)
+	pinHostKey(t, serverAddr, hostSigner)
 
 	// Build ProxyCommand: re-invoke this test binary in helper-proxy mode.
 	// All env vars are passed via t.Setenv so the child inherits them — inline

--- a/protocol/winrm/connection.go
+++ b/protocol/winrm/connection.go
@@ -86,12 +86,12 @@ func (c *Connection) IsWindows() bool {
 }
 
 // probe runs a no-op command to verify the connection is alive and authenticated.
-// HTTP 401/403 responses are wrapped as ErrAuthFailed.
+// HTTP 401/403 responses are tagged with protocol.ErrAuthFailed.
 func (c *Connection) probe(ctx context.Context) error {
 	proc, err := c.StartProcess(ctx, "cmd.exe /c exit 0", nil, nil, nil)
 	if err != nil {
 		if isAuthError(err) {
-			return fmt.Errorf("%w: %w", ErrAuthFailed, err)
+			return fmt.Errorf("%w: %w", protocol.ErrAuthFailed, err)
 		}
 		return err
 	}
@@ -100,18 +100,6 @@ func (c *Connection) probe(ctx context.Context) error {
 	}
 	return nil
 }
-
-// ErrAuthFailed is returned when the remote host rejects the supplied
-// credentials with an HTTP 401 or 403.
-//
-// This is deliberately not wrapped in protocol.ErrNonRetryable. A rejection is
-// the remote host's answer, and on Windows it is routinely transient: the WinRM
-// listener starts answering before provisioning has finished configuring
-// authentication, so a host that has just booted returns 401 for a while with
-// entirely correct credentials. Callers that provision hosts need to wait
-// through that, and callers that want to fail fast on bad credentials can test
-// for this error explicitly.
-var ErrAuthFailed = errors.New("authentication failed")
 
 // isAuthError reports whether err looks like an HTTP 401/403 response from the
 // WinRM library. The library returns untyped formatted errors so we match by

--- a/protocol/winrm/connection_test.go
+++ b/protocol/winrm/connection_test.go
@@ -115,7 +115,7 @@ func Test_authErrorWrapping(t *testing.T) {
 			// against a real WinRM server is deferred to the todo item for WinRM tests.
 			var err error
 			if isAuthError(tt.startErr) {
-				err = fmt.Errorf("%w: %w", ErrAuthFailed, tt.startErr)
+				err = fmt.Errorf("%w: %w", protocol.ErrAuthFailed, tt.startErr)
 			} else {
 				err = tt.startErr
 			}
@@ -123,8 +123,8 @@ func Test_authErrorWrapping(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected an error, got nil")
 			}
-			if got := errors.Is(err, ErrAuthFailed); got != tt.wantAuthFailed {
-				t.Errorf("errors.Is(err, ErrAuthFailed) = %v, want %v (err: %v)", got, tt.wantAuthFailed, err)
+			if got := errors.Is(err, protocol.ErrAuthFailed); got != tt.wantAuthFailed {
+				t.Errorf("errors.Is(err, protocol.ErrAuthFailed) = %v, want %v (err: %v)", got, tt.wantAuthFailed, err)
 			}
 			// Neither case may abort a caller's retry loop.
 			if errors.Is(err, protocol.ErrNonRetryable) {
@@ -200,8 +200,8 @@ func TestConnect_probeClassification(t *testing.T) {
 				t.Fatal("Connect() succeeded against stub server, want error")
 			}
 
-			if got := errors.Is(err, ErrAuthFailed); got != tt.wantAuthFailed {
-				t.Errorf("Connect() errors.Is(err, ErrAuthFailed) = %v, want %v (err: %v)", got, tt.wantAuthFailed, err)
+			if got := errors.Is(err, protocol.ErrAuthFailed); got != tt.wantAuthFailed {
+				t.Errorf("Connect() errors.Is(err, protocol.ErrAuthFailed) = %v, want %v (err: %v)", got, tt.wantAuthFailed, err)
 			}
 
 			// No HTTP status from the remote may abort a caller's retry loop: the


### PR DESCRIPTION
PR #421 gave WinRM a way to say "the remote rejected these credentials" without saying "stop retrying". The sentinel it added lives in protocol/winrm, so a consumer that wants to fail fast on bad credentials has to import the WinRM subpackage, test a WinRM-specific error, and then still substring-match SSH's rejection separately. That is the duplicated substring match #421 set out to remove, relocated rather than removed.

The condition is not protocol-specific. A remote refuses the credentials it was handed, and on a host that is still being provisioned it does so with credentials that are entirely correct: WinRM answers before authentication is configured, sshd accepts connections before authorized_keys is written.

Move the sentinel to protocol.ErrAuthFailed, re-export it as rig.ErrAuthFailed alongside ErrNonRetryable, and tag the SSH side with it: the direct, bastion, and ProxyCommand handshakes in protocol/ssh, and both the multiplexed and non-multiplexed connect paths in protocol/openssh. One errors.Is check now covers every protocol.

Removing winrm.ErrAuthFailed breaks nothing published: git tag --contains on the #421 merge is empty and v2.0.1 predates it, so the symbol has never shipped in a release.

The SSH change is purely additive. None of those handshake errors were ErrNonRetryable before -- protocol/ssh has only ever marked local faults non-retryable (no known_hosts, no usable auth method, unparsable key, bastion misconfig) plus a host key mismatch, which is a security decision rather than a race. Retry behaviour on the SSH path is unchanged; callers gain a tag they can test. The host key check stays first at every site.

Matching stays deliberately narrow. x/crypto returns an untyped error, so protocol/ssh matches "ssh: unable to authenticate" from client_auth.go and nothing else -- notably not disconnect reason 14, which is sshd's MaxAuthTries limit and clears with a narrower key set rather than with different credentials. protocol/openssh requires the parenthesised method list ("Permission denied (publickey,password)") because a bare "Permission denied" is also what the remote command and an unreadable local key file produce.

Classification at the three SSH handshake sites and the two OpenSSH connect sites collapses into classifyHandshakeError/classifyConnectError, which keeps cyclop and nestif satisfied and makes the ordering between the two sentinels explicit in one place instead of five.

Two error strings change as a result, both deliberately:

  - OpenSSH's non-multiplexed connect failure now appends the ssh client's stderr, which is what the multiplexed path -- the default configuration -- has always done. This normalises the two, it does not add a new class of output.
  - An SSH host key mismatch gains the stage prefix, so the direct path reads "operation cannot be completed: ssh dial: ...". errors.Is is unaffected, and k0sctl's strings.Contains(err.Error(), "host key mismatch") still matches, since the substring sits in the wrapped error.

TestConnectAuthFailure drives Connect against an in-process SSH server that rejects every credential, so it fails if the tagging is dropped. The listener boilerplate proxy_test.go already had is now shared as startSSHServer/newHostSigner/pinHostKey. OpenSSH gets a classifier table test rather than a live ssh binary; note that isHostKeyError has a pre-existing quirk the new isAuthError inherits -- stderr is only populated when the failure comes from Wait, not from StartProcess itself.

Written by AI: claude-opus-5