### PR TITLE
fix(openssh): stop Connect blocking on the daemonized control master

### DIFF
--- a/protocol/openssh/connection.go
+++ b/protocol/openssh/connection.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -257,15 +258,10 @@ func (c *Connection) Connect(ctx context.Context) error {
 	args = append(args, opts.ToArgs()...)
 	args = append(args, c.args()...)
 
-	cmd := exec.CommandContext(ctx, "ssh", args...)
-	errBuf := bytes.NewBuffer(nil)
-	cmd.Stderr = errBuf
-
-	log.Trace(ctx, "starting ssh control master", log.KeyHost, c, log.KeyCommand, strings.Join(args, " "))
-	if err := cmd.Run(); err != nil {
+	if err := c.runControlMaster(ctx, args); err != nil {
 		c.isConnected = false
 		c.controlMutex.Unlock()
-		return classifyConnectError(err, errBuf.String(), "failed to start ssh multiplexing control master")
+		return err
 	}
 
 	c.isConnected = true
@@ -278,6 +274,67 @@ func (c *Connection) Connect(ctx context.Context) error {
 	c.prewarmWindows(ctx)
 
 	return nil
+}
+
+// runControlMaster starts the multiplexing control master described by args and
+// waits for the foreground ssh process to exit.
+//
+// The master's stderr is captured in a temporary file rather than an in-memory
+// writer. "ssh -N -f" daemonizes: once authentication succeeds it forks a
+// background control master that stays alive for ControlPersist and inherits
+// the stderr it was handed. os/exec wires any writer that is not an *os.File
+// through an os.Pipe and a copier goroutine, and cmd.Wait does not return until
+// that goroutine sees EOF -- which cannot happen while the daemon holds the
+// write end open. Connect would therefore block for the full ControlPersist
+// (ten minutes by default) even though the foreground ssh had already exited
+// successfully. An *os.File is dup'd straight into the child instead, so no
+// copier is started and Wait returns with the foreground process no matter what
+// the daemon keeps open.
+//
+// This only ever bit the success path: an authentication or host key failure
+// exits before the fork, so the pipe closed and Wait returned promptly.
+func (c *Connection) runControlMaster(ctx context.Context, args []string) error {
+	stderrFile, err := os.CreateTemp("", "rig-ssh-master-*.stderr")
+	if err != nil {
+		return fmt.Errorf("create ssh control master stderr file: %w", err)
+	}
+	defer func() {
+		_ = stderrFile.Close()
+		// The daemonized master keeps its inherited handle to this file. On unix
+		// the unlink succeeds anyway and the space is reclaimed once the master
+		// exits; on Windows it may fail while the handle is held, which is left
+		// best-effort rather than reported as a connection failure.
+		_ = os.Remove(stderrFile.Name())
+	}()
+
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd.Stderr = stderrFile
+
+	log.Trace(ctx, "starting ssh control master", log.KeyHost, c, log.KeyCommand, strings.Join(args, " "))
+	if err := cmd.Run(); err != nil {
+		return classifyConnectError(err, readStderrFile(stderrFile), "failed to start ssh multiplexing control master")
+	}
+	return nil
+}
+
+// readStderrFile reads back what a subprocess wrote to f. A read failure yields
+// an empty string rather than an error, because the contents are folded into an
+// error that already carries the real cause and an I/O error from the readback
+// would displace it. The contents are more than extra context, though: they are
+// what classifyConnectError matches on, so an unreadable file costs accuracy --
+// a host key failure loses protocol.ErrNonRetryable and a credential rejection
+// loses protocol.ErrAuthFailed, leaving a plain retryable error carrying the
+// stage prefix and the exit status.
+//
+// It opens the path rather than seeking f itself: os/exec dups f's descriptor
+// into the child, and dup'd descriptors share a file offset, so rewinding f
+// would move the write position of any process still holding that descriptor.
+func readStderrFile(f *os.File) string {
+	out, err := os.ReadFile(f.Name())
+	if err != nil {
+		return ""
+	}
+	return string(out)
 }
 
 // prewarmWindows calls detectWindows with a short bounded context derived from

--- a/protocol/openssh/connection_test.go
+++ b/protocol/openssh/connection_test.go
@@ -1,8 +1,15 @@
 package openssh
 
 import (
+	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/k0sproject/rig/v2/protocol"
 	"github.com/stretchr/testify/require"
@@ -160,4 +167,108 @@ func Test_classifyConnectError(t *testing.T) {
 			}
 		})
 	}
+}
+
+// controlMasterLifetime is how long the fake client's stand-in control master
+// lingers, and connectBudget is how long Connect may take. The two are set an
+// order of magnitude apart: a leaked stderr pipe blocks Connect for the master's
+// full lifetime, while a Connect that correctly returns with the foreground ssh
+// takes well under a second even though it forks twice (control master, then the
+// Windows probe). The budget is loose because "go test ./..." runs packages in
+// parallel, and fork latency on a saturated machine stretches Connect to a few
+// seconds.
+const (
+	controlMasterLifetime = 30 * time.Second
+	connectBudget         = 10 * time.Second
+)
+
+// fakeSSHScript stands in for the openssh client and reproduces what
+// "ssh -N -f" does on a successful connect: fork a background process that
+// inherits stderr and outlives the foreground process, then exit 0. The
+// backgrounded sleep stands in for a control master lingering for
+// ControlPersist. It is a plain bounded sleep rather than something the test
+// signals, so that a regression fails the test instead of deadlocking it --
+// cleanup cannot run while the test goroutine is blocked inside Connect. Its pid
+// is recorded so that the test can reap it once Connect has returned instead of
+// leaving it to time out.
+const fakeSSHScript = `#!/bin/sh
+echo "$@" >> "$RIG_TEST_ARGV_LOG"
+case " $* " in
+*" -f "*) ( sleep "$RIG_TEST_MASTER_LIFETIME" & echo "$!" >> "$RIG_TEST_MASTER_PID_LOG" ) ;;
+esac
+echo 'fake ssh: control master forked' >&2
+exit 0
+`
+
+// killRecordedMasters reaps the stand-in control masters whose pids the fake ssh
+// client recorded in path. It is best-effort throughout: the file is absent when
+// nothing daemonized, and the kill only means anything while the sleep is still
+// alive. A regression keeps Connect blocked until the sleep exits on its own, so
+// there the pid is stale by cleanup time -- but that run has already failed the
+// elapsed-time assertion and left nothing behind to reap.
+func killRecordedMasters(path string) {
+	recorded, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	for token := range strings.FieldsSeq(string(recorded)) {
+		pid, err := strconv.Atoi(token)
+		// A pid of 0 or below addresses a process group rather than the sleep, so
+		// an unexpected token is skipped instead of signalled.
+		if err != nil || pid <= 0 {
+			continue
+		}
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			continue
+		}
+		_ = proc.Kill()
+	}
+}
+
+// TestConnectDoesNotWaitForControlMaster covers the hang described in #405: the
+// daemonized control master inherits the stderr it was handed, so passing
+// os/exec an in-memory writer made cmd.Wait block until ControlPersist expired
+// even though the connection was already up.
+func TestConnectDoesNotWaitForControlMaster(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the fake ssh client is a POSIX shell script")
+	}
+
+	binDir := t.TempDir()
+	argvLog := filepath.Join(binDir, "argv.log")
+	pidLog := filepath.Join(binDir, "master.pid")
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "ssh"), []byte(fakeSSHScript), 0o755)) //nolint:gosec // the fake client has to be executable
+	// Prepend rather than replace: the fake shadows the real ssh while leaving
+	// the sleep it backgrounds resolvable.
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("RIG_TEST_ARGV_LOG", argvLog)
+	t.Setenv("RIG_TEST_MASTER_PID_LOG", pidLog)
+	t.Setenv("RIG_TEST_MASTER_LIFETIME", strconv.Itoa(int(controlMasterLifetime.Seconds())))
+	// Reap the stand-in master once Connect has returned; otherwise it lingers for
+	// its full lifetime after the test has finished.
+	t.Cleanup(func() { killRecordedMasters(pidLog) })
+
+	conn, err := NewConnection(Config{Address: "127.0.0.1"})
+	require.NoError(t, err)
+
+	// Long enough not to cut the pre-fix hang short: the point of the test is
+	// that Connect returns on its own, not that the context rescues it.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*controlMasterLifetime)
+	defer cancel()
+
+	start := time.Now()
+	require.NoError(t, conn.Connect(ctx))
+	elapsed := time.Since(start)
+
+	argv, readErr := os.ReadFile(argvLog)
+	require.NoError(t, readErr)
+	// Guard against the test passing vacuously: without -f nothing daemonizes,
+	// so the hang could no longer be observed here at all.
+	require.Contains(t, string(argv), "-N -f", "control master should still be started with -N -f")
+	// A missing pid log would make the cleanup a silent no-op and leave the
+	// stand-in master running for its full lifetime.
+	require.FileExists(t, pidLog, "the fake client should have recorded the stand-in master's pid")
+	require.Less(t, elapsed, connectBudget, "Connect waited for the backgrounded control master to exit")
+	require.True(t, conn.IsConnected(), "connection should report as established after Connect")
 }


### PR DESCRIPTION
Fixes #405 

Connect started the multiplexing control master with cmd.Stderr set to a bytes.Buffer. os/exec wires any writer that is not an *os.File through an os.Pipe and a copier goroutine, and cmd.Wait does not return until that goroutine sees EOF.

"ssh -N -f" daemonizes: once authentication succeeds it forks a background control master that lives for ControlPersist and inherits the stderr it was handed. The daemon therefore held the pipe's write end open, the copier never saw EOF, and Connect blocked for the full ControlPersist -- ten minutes by default -- even though the connection was already up. SIGINT unblocked it by killing the master and closing the pipe, which is why the hang looked like it resolved on Ctrl-C.

Capture the master's stderr in a temporary file instead. An *os.File is dup'd straight into the child, so os/exec starts no copier and Wait returns with the foreground ssh regardless of what the daemon keeps open. Confirmed empirically: a foreground process that backgrounds a 5s child returns in 5.03s with a bytes.Buffer and 15ms with an *os.File.

This only ever bit the success path -- an authentication or host key failure exits before the fork, so the pipe closed and Wait returned promptly. Error classification is untouched; stderr is still read back and fed to classifyConnectError, and the success path discarded it before as it does now.

TestConnectDoesNotWaitForControlMaster shadows "ssh" on PATH with a script that reproduces the daemonize-and-exit-0 shape. It fails in 30s against the old code and passes in under a second against the new, with the budget set an order of magnitude apart from the stand-in master's lifetime so package-parallel fork latency cannot flake it.

The DisableMultiplexing path is unaffected: it runs "ssh -- exit 0" with no -f, so nothing daemonizes and its buffer is safe.