### PR TITLE
fix(remotefs): stop feeding /dev/stdin to install and dd (#410)

### DIFF
--- a/remotefs/patchfile_test.go
+++ b/remotefs/patchfile_test.go
@@ -56,9 +56,9 @@ func (f *patchFS) ReadDir(_ string) ([]fs.DirEntry, error) { panic("not implemen
 func (f *patchFS) OpenFile(_ string, _ int, _ fs.FileMode) (remotefs.File, error) {
 	panic("not implemented")
 }
-func (f *patchFS) Sha256(_ string) (string, error)  { panic("not implemented") }
-func (f *patchFS) DownloadURL(_, _ string) error    { panic("not implemented") }
-func (f *patchFS) RemoveAll(_ string) error         { panic("not implemented") }
+func (f *patchFS) Sha256(_ string) (string, error)                       { panic("not implemented") }
+func (f *patchFS) DownloadURL(_, _ string) error                         { panic("not implemented") }
+func (f *patchFS) RemoveAll(_ string) error                              { panic("not implemented") }
 func (f *patchFS) Mkdir(_ string, _ fs.FileMode) error                   { panic("not implemented") }
 func (f *patchFS) MkdirTemp(_, _ string) (string, error)                 { panic("not implemented") }
 func (f *patchFS) FileExist(_ string) bool                               { panic("not implemented") }
@@ -464,15 +464,16 @@ func TestPatchFilePosix(t *testing.T) {
 	// handler below (for MkdirAll's Stat("/etc")) does not fire first.
 	// 0x81a4 = 0o100644 (regular file, rw-r--r--).
 	mr.AddCommandOutput(rigtest.Match(`stat -c .+ -- /etc/env`), "0x81a4 12 1234567890.000000000 ///etc/env//")
-	// ReadFile via cat.
-	mr.AddCommandOutput(rigtest.Contains("cat"), "FOO=old\nBAR=keep\n")
+	// ReadFile via cat. Matched by prefix so it does not also catch the "cat >"
+	// redirect that WriteFile uses.
+	mr.AddCommandOutput(rigtest.HasPrefix("cat "), "FOO=old\nBAR=keep\n")
 	// WriteFileAtomic: MkdirAll probes Stat("/etc") — return directory so no install -d is needed.
 	// 0x41ed = 0o040755 (directory, rwxr-xr-x). This fires for any remaining stat -c call.
 	mr.AddCommandOutput(rigtest.Contains("stat -c"), "0x41ed 0 1234567890.000000000 ///etc//")
 	// CreateTemp.
 	mr.AddCommandOutput(rigtest.Contains("mktemp"), "/etc/.tmp-abc123")
-	// WriteFile via install -D + stdin.
-	mr.AddCommandSuccess(rigtest.Contains("install"))
+	// WriteFile via mkdir + umask + a cat redirect fed from stdin.
+	mr.AddCommandSuccess(rigtest.Contains("cat >"))
 	// Chmod.
 	mr.AddCommandSuccess(rigtest.Contains("chmod"))
 	// Rename.

--- a/remotefs/posixfile.go
+++ b/remotefs/posixfile.go
@@ -125,7 +125,10 @@ func (f *PosixFile) Write(p []byte) (int, error) {
 		limitedReader := bytes.NewReader(remaining[:toWrite])
 
 		err := f.fs.Exec(
-			sh.Command("dd", "if=/dev/stdin", "of="+f.path, fmt.Sprintf("bs=%d", bs), fmt.Sprintf("count=%d", count), fmt.Sprintf("seek=%d", skip), "conv=notrunc"),
+			// "if=" is omitted because dd reads stdin by default. Naming
+			// /dev/stdin adds nothing and only invites the kind of breakage
+			// documented in PosixFS.WriteFile.
+			sh.Command("dd", "of="+f.path, fmt.Sprintf("bs=%d", bs), fmt.Sprintf("count=%d", count), fmt.Sprintf("seek=%d", skip), "conv=notrunc"),
 			cmd.Stdin(limitedReader),
 		)
 		if err != nil {
@@ -183,7 +186,8 @@ func (f *PosixFile) CopyFrom(src io.Reader) (int64, error) {
 	counter := &iostream.ByteCounter{}
 
 	err := f.fs.Exec(
-		sh.Command("dd", "if=/dev/stdin", "of="+f.path, fmt.Sprintf("bs=%d", f.fsBlockSize()), fmt.Sprintf("seek=%d", f.pos), "conv=notrunc"),
+		// "if=" is omitted so dd reads stdin, see the note in Write above.
+		sh.Command("dd", "of="+f.path, fmt.Sprintf("bs=%d", f.fsBlockSize()), fmt.Sprintf("seek=%d", f.pos), "conv=notrunc"),
 		cmd.Stdin(io.TeeReader(src, counter)),
 	)
 	if err != nil {

--- a/remotefs/posixfile_test.go
+++ b/remotefs/posixfile_test.go
@@ -1,0 +1,72 @@
+package remotefs_test
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/remotefs"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+// openPosixFileForWriting mocks the stat probes PosixFS.OpenFile performs and
+// returns a PosixFile for an existing, empty, writable /tmp/file.
+func openPosixFileForWriting(t *testing.T, mr *rigtest.MockRunner) remotefs.File {
+	t.Helper()
+	// initStat: selects the GNU stat syntax.
+	mr.AddCommandSuccess(rigtest.Equal("stat -c %n /"))
+	// fsBlockSize probes the parent directory. Registered before the generic
+	// stat handler below so it is not swallowed by it.
+	mr.AddCommandOutput(rigtest.Contains(`stat -c "%s"`), "4096")
+	// Stat of the file itself: 0x81a4 = 0o100644 (regular file, rw-r--r--).
+	mr.AddCommandOutput(rigtest.Contains("-- /tmp/file"), "0x81a4 0 1234567890.000000000 ///tmp/file//")
+
+	f, err := remotefs.NewPosixFS(mr).OpenFile("/tmp/file", os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+	return f
+}
+
+// TestPosixFileWrite verifies that writes are piped into dd through stdin. dd
+// must not be told to read /dev/stdin explicitly — see PosixFS.WriteFile for the
+// coreutils implementations that reject that.
+func TestPosixFileWrite(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	var got []byte
+	mr.AddCommand(rigtest.HasPrefix("dd "), func(a *rigtest.A) error {
+		var err error
+		got, err = io.ReadAll(a.Stdin)
+		return err
+	})
+	f := openPosixFileForWriting(t, mr)
+
+	n, err := f.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "hello", string(got))
+	require.Equal(t, "dd of=/tmp/file bs=1 count=5 seek=0 conv=notrunc", mr.LastCommand())
+	require.NoError(t, mr.NotReceived(rigtest.Contains("/dev/stdin")))
+}
+
+// TestPosixFileCopyFrom verifies the same for the streaming copy path used by
+// remotefs.Upload.
+func TestPosixFileCopyFrom(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	var got []byte
+	mr.AddCommandSuccess(rigtest.HasPrefix("truncate"))
+	mr.AddCommand(rigtest.HasPrefix("dd "), func(a *rigtest.A) error {
+		var err error
+		got, err = io.ReadAll(a.Stdin)
+		return err
+	})
+	f := openPosixFileForWriting(t, mr)
+
+	n, err := f.CopyFrom(strings.NewReader("hello"))
+	require.NoError(t, err)
+	require.Equal(t, int64(5), n)
+	require.Equal(t, "hello", string(got))
+	require.Equal(t, "dd of=/tmp/file bs=4096 seek=0 conv=notrunc", mr.LastCommand())
+	require.NoError(t, mr.NotReceived(rigtest.Contains("/dev/stdin")))
+}

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -177,6 +177,25 @@ func posixBitsToFileMode(bits int64) fs.FileMode {
 	return mode
 }
 
+// fileModeToPosixBits is the inverse of posixBitsToFileMode for the bits chmod
+// understands: the permission bits plus setuid, setgid and sticky. The file
+// type bits have no chmod representation and are ignored.
+func fileModeToPosixBits(mode fs.FileMode) int64 {
+	bits := int64(mode.Perm())
+
+	if mode&fs.ModeSetuid != 0 {
+		bits |= 0o4000
+	}
+	if mode&fs.ModeSetgid != 0 {
+		bits |= 0o2000
+	}
+	if mode&fs.ModeSticky != 0 {
+		bits |= 0o1000
+	}
+
+	return bits
+}
+
 func (s *PosixFS) parseStat(stat string) (*FileInfo, error) {
 	// output looks like: 0x81a4 0 1699970097.220228000 //test_20231114155456.txt//
 	parts := strings.SplitN(stat, " ", 4)
@@ -339,9 +358,11 @@ func (s *PosixFS) Truncate(name string, size int64) error {
 	return nil
 }
 
-// Chmod changes the mode of the named file to mode.
+// Chmod changes the mode of the named file to mode. The permission bits and
+// the setuid, setgid and sticky bits are applied; the file type bits are
+// ignored, as chmod has no representation for them.
 func (s *PosixFS) Chmod(name string, mode fs.FileMode) error {
-	if err := s.Exec(sh.Command("chmod", fmt.Sprintf("%#o", mode), name)); err != nil {
+	if err := s.Exec(sh.Command("chmod", fmt.Sprintf("%#o", fileModeToPosixBits(mode)), name)); err != nil {
 		if isNotExist(err) {
 			return PathError("chmod", name, fs.ErrNotExist)
 		}
@@ -540,7 +561,7 @@ func (s *PosixFS) openNew(name string, flags int, perm fs.FileMode) (fs.FileInfo
 		return nil, PathErrorf(OpOpen, name, "%w: failed to stat parent directory", fs.ErrInvalid)
 	}
 
-	if err := s.Exec(sh.Command("install", "-m", fmt.Sprintf("%#o", perm), "/dev/null", name)); err != nil {
+	if err := s.Exec(sh.Command("install", "-m", fmt.Sprintf("%#o", fileModeToPosixBits(perm)), "/dev/null", name)); err != nil {
 		return nil, PathError(OpOpen, name, err)
 	}
 
@@ -698,6 +719,9 @@ func (s *PosixFS) TempDir() string {
 
 // MkdirAll creates a new directory structure with the specified name and permission bits.
 // If the directory already exists, MkDirAll does nothing and returns nil.
+//
+// The permission bits and the setgid, setuid and sticky bits of perm are
+// applied; the file type bits are ignored.
 func (s *PosixFS) MkdirAll(name string, perm fs.FileMode) error {
 	if existing, err := s.Stat(name); err == nil {
 		if existing.IsDir() {
@@ -706,7 +730,7 @@ func (s *PosixFS) MkdirAll(name string, perm fs.FileMode) error {
 		return fmt.Errorf("mkdir %s: %w", name, fs.ErrExist)
 	}
 
-	if err := s.Exec(sh.Command("install", "-d", "-m", fmt.Sprintf("%#o", perm), name)); err != nil {
+	if err := s.Exec(sh.Command("install", "-d", "-m", fmt.Sprintf("%#o", fileModeToPosixBits(perm)), name)); err != nil {
 		return fmt.Errorf("mkdir %s: %w", name, err)
 	}
 
@@ -714,17 +738,50 @@ func (s *PosixFS) MkdirAll(name string, perm fs.FileMode) error {
 }
 
 // Mkdir creates a new directory with the specified name and permission bits.
+//
+// The permission bits and the setgid, setuid and sticky bits of perm are
+// applied; the file type bits are ignored.
 func (s *PosixFS) Mkdir(name string, perm fs.FileMode) error {
-	if err := s.Exec(sh.Command("mkdir", "-m", fmt.Sprintf("%#o", perm), name)); err != nil {
+	if err := s.Exec(sh.Command("mkdir", "-m", fmt.Sprintf("%#o", fileModeToPosixBits(perm)), name)); err != nil {
 		return PathError("mkdir", name, err)
 	}
 
 	return nil
 }
 
-// WriteFile writes data to a file named by filename.
+// WriteFile writes data to a file named by filename. Any missing parent
+// directories are created.
+//
+// The file is created via a shell redirect instead of `install -m ... /dev/stdin`
+// because the uutils (Rust) reimplementation of coreutils, the default on Ubuntu
+// 25.10 and later, fails with "install: No such file or directory" when the
+// source is /dev/stdin and the destination already exists — which is exactly
+// what writing to a mktemp'd file does. See
+// https://github.com/uutils/coreutils/issues/12407.
+//
+// The umask keeps a newly created file from being more permissive than perm
+// while the content is written; the trailing chmod then applies perm's
+// permission bits along with its setuid, setgid and sticky bits, also to a file
+// that already existed. The file type bits of perm are ignored, as chmod has no
+// representation for them. A umask only covers the nine permission bits, so the
+// special bits come from the chmod alone — which is the safe ordering anyway, as
+// the content is fully written by then. The umask is set after mkdir so that it
+// does not affect the mode of the created parent directories.
+//
+// Missing parent directories get the remote default mode (0777 minus the remote
+// umask) instead of the fixed 0755 that GNU `install -D` used. Use MkdirAll if
+// the parent directories need a specific mode.
 func (s *PosixFS) WriteFile(filename string, data []byte, perm fs.FileMode) error {
-	if err := s.Exec(sh.Command("install", "-D", "-m", fmt.Sprintf("%#o", perm), "/dev/stdin", filename), cmd.Stdin(bytes.NewReader(data))); err != nil {
+	mode := fileModeToPosixBits(perm)
+
+	// "--" precedes the mode because BSD chmod stops parsing options at the
+	// first operand, where "chmod 0644 -- file" would treat "--" as a filename.
+	command := sh.CommandBuilder(sh.Command("mkdir", "-p", "--", s.Dir(filename))).
+		Raw("&&").Raw(fmt.Sprintf("umask %#o", fs.ModePerm&^perm.Perm())).
+		Raw("&&").Raw("cat").OutToFile(filename).
+		Raw("&&").Raw(sh.Command("chmod", "--", fmt.Sprintf("%#o", mode), filename))
+
+	if err := s.Exec(command.String(), cmd.Stdin(bytes.NewReader(data))); err != nil {
 		return fmt.Errorf("write file %s: %w", filename, err)
 	}
 	return nil

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -197,6 +197,151 @@ func TestPosixTouch(t *testing.T) {
 	})
 }
 
+func TestPosixWriteFile(t *testing.T) {
+	// The command must not name /dev/stdin as an input file: the uutils
+	// reimplementation of coreutils refuses non-regular files there.
+	t.Run("command", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		var got []byte
+		mr.AddCommand(rigtest.Contains("cat >"), func(a *rigtest.A) error {
+			var err error
+			got, err = io.ReadAll(a.Stdin)
+			return err
+		})
+		f := remotefs.NewPosixFS(mr)
+		require.NoError(t, f.WriteFile("/etc/k0s/k0s.yaml", []byte("hello"), 0o600))
+		require.Equal(t,
+			"mkdir -p -- /etc/k0s && umask 0177 && cat >/etc/k0s/k0s.yaml && chmod -- 0600 /etc/k0s/k0s.yaml",
+			mr.LastCommand(),
+		)
+		require.Equal(t, "hello", string(got))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("/dev/stdin")))
+	})
+
+	t.Run("umask complements the requested permissions", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			perm  fs.FileMode
+			umask string
+			chmod string
+		}{
+			{name: "executable", perm: 0o755, umask: "umask 022", chmod: "chmod -- 0755 /tmp/f"},
+			{name: "world readable", perm: 0o644, umask: "umask 0133", chmod: "chmod -- 0644 /tmp/f"},
+			{name: "no permissions", perm: 0, umask: "umask 0777", chmod: "chmod -- 0 /tmp/f"},
+			// The special bits are translated to their POSIX octal digit. A
+			// umask only covers the nine permission bits, so they are applied
+			// by the chmod alone.
+			{name: "setuid", perm: fs.ModeSetuid | 0o600, umask: "umask 0177", chmod: "chmod -- 04600 /tmp/f"},
+			{name: "setgid", perm: fs.ModeSetgid | 0o755, umask: "umask 022", chmod: "chmod -- 02755 /tmp/f"},
+			{name: "sticky", perm: fs.ModeSticky | 0o770, umask: "umask 07 &&", chmod: "chmod -- 01770 /tmp/f"},
+			// File type bits have no chmod representation and are ignored.
+			{name: "type bits ignored", perm: fs.ModeDir | 0o755, umask: "umask 022", chmod: "chmod -- 0755 /tmp/f"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				mr := rigtest.NewMockRunner()
+				mr.AddCommandSuccess(rigtest.Contains("cat >"))
+				f := remotefs.NewPosixFS(mr)
+				require.NoError(t, f.WriteFile("/tmp/f", []byte("x"), tc.perm))
+				require.Contains(t, mr.LastCommand(), tc.umask)
+				require.Contains(t, mr.LastCommand(), tc.chmod)
+			})
+		}
+	})
+
+	t.Run("quotes paths with spaces", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandSuccess(rigtest.Contains("cat >"))
+		f := remotefs.NewPosixFS(mr)
+		require.NoError(t, f.WriteFile("/tmp/my dir/file", []byte("x"), 0o644))
+		require.Equal(t,
+			`mkdir -p -- '/tmp/my dir' && umask 0133 && cat >'/tmp/my dir/file' && chmod -- 0644 '/tmp/my dir/file'`,
+			mr.LastCommand(),
+		)
+	})
+
+	t.Run("command fails", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Contains("cat >"), errors.New("permission denied"))
+		f := remotefs.NewPosixFS(mr)
+		err := f.WriteFile("/etc/k0s/k0s.yaml", []byte("hello"), 0o600)
+		require.ErrorContains(t, err, "write file /etc/k0s/k0s.yaml")
+	})
+}
+
+// modeCases covers the fs.FileMode → POSIX octal translation shared by every
+// command that takes a mode. The special bits live in the high bits of an
+// fs.FileMode, so formatting one directly would produce a nonsensical number.
+var modeCases = []struct {
+	name string
+	mode fs.FileMode
+	want string
+}{
+	{name: "permission bits", mode: 0o750, want: "0750"},
+	{name: "setuid", mode: fs.ModeSetuid | 0o755, want: "04755"},
+	{name: "setgid", mode: fs.ModeSetgid | 0o775, want: "02775"},
+	{name: "sticky", mode: fs.ModeSticky | 0o777, want: "01777"},
+	// File type bits have no chmod representation and are ignored.
+	{name: "type bits ignored", mode: fs.ModeDir | 0o700, want: "0700"},
+}
+
+func TestPosixMkdir(t *testing.T) {
+	for _, tc := range modeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := rigtest.NewMockRunner()
+			mr.AddCommandSuccess(rigtest.Contains("mkdir"))
+			f := remotefs.NewPosixFS(mr)
+			require.NoError(t, f.Mkdir("/tmp/dir", tc.mode))
+			require.Equal(t, "mkdir -m "+tc.want+" /tmp/dir", mr.LastCommand())
+		})
+	}
+}
+
+func TestPosixMkdirAll(t *testing.T) {
+	// MkdirAll stats the target first; an unmatched stat yields no output, which
+	// reads as "does not exist" and lets it proceed to install.
+	for _, tc := range modeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := rigtest.NewMockRunner()
+			mr.AddCommandSuccess(rigtest.Contains("install"))
+			f := remotefs.NewPosixFS(mr)
+			require.NoError(t, f.MkdirAll("/tmp/a/b", tc.mode))
+			require.Equal(t, "install -d -m "+tc.want+" /tmp/a/b", mr.LastCommand())
+		})
+	}
+}
+
+func TestPosixOpenFileCreate(t *testing.T) {
+	for _, tc := range modeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := rigtest.NewMockRunner()
+			// initStat probes for GNU stat.
+			mr.AddCommandSuccess(rigtest.Equal("stat -c %n /"))
+			var created bool
+			// 0x81a4 = 0o100644 (regular file, rw-r--r--). The file only exists
+			// once install has run.
+			mr.AddCommand(rigtest.Contains("-- /tmp/new"), func(a *rigtest.A) error {
+				if !created {
+					return nil
+				}
+				_, err := a.Stdout.Write([]byte("0x81a4 0 1234567890.000000000 ///tmp/new//\n"))
+				return err
+			})
+			mr.AddCommand(rigtest.Contains("install"), func(_ *rigtest.A) error {
+				created = true
+				return nil
+			})
+			// 0x41ed = 0o40755 (directory, rwxr-xr-x) for the parent.
+			mr.AddCommandOutput(rigtest.Contains("stat -c"), "0x41ed 0 1234567890.000000000 ///tmp//")
+
+			f := remotefs.NewPosixFS(mr)
+			file, err := f.OpenFile("/tmp/new", os.O_CREATE|os.O_WRONLY, tc.mode)
+			require.NoError(t, err)
+			require.NoError(t, file.Close())
+			require.NoError(t, mr.Received(rigtest.Equal("install -m "+tc.want+" /dev/null /tmp/new")))
+		})
+	}
+}
+
 func TestPosixDir(t *testing.T) {
 	f := remotefs.NewPosixFS(rigtest.NewMockRunner())
 	require.Equal(t, "/foo/bar", f.Dir("/foo/bar/baz"))
@@ -226,6 +371,27 @@ func TestPosixCommandExist(t *testing.T) {
 		mr.AddCommandFailure(rigtest.Equal("command -v curl"), errors.New("not found"))
 		f := remotefs.NewPosixFS(mr)
 		require.False(t, f.CommandExist("curl"))
+	})
+}
+
+func TestPosixChmod(t *testing.T) {
+	t.Run("modes", func(t *testing.T) {
+		for _, tc := range modeCases {
+			t.Run(tc.name, func(t *testing.T) {
+				mr := rigtest.NewMockRunner()
+				mr.AddCommandSuccess(rigtest.Contains("chmod"))
+				f := remotefs.NewPosixFS(mr)
+				require.NoError(t, f.Chmod("/tmp/file", tc.mode))
+				require.Equal(t, "chmod "+tc.want+" /tmp/file", mr.LastCommand())
+			})
+		}
+	})
+
+	t.Run("not exist", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Contains("chmod"), errors.New("No such file or directory"))
+		f := remotefs.NewPosixFS(mr)
+		require.ErrorIs(t, f.Chmod("/tmp/file", 0o644), fs.ErrNotExist)
 	})
 }
 
@@ -273,7 +439,6 @@ func TestPosixChownTreeInt(t *testing.T) {
 		require.ErrorIs(t, f.ChownTreeInt("/srv", 0, 0), fs.ErrNotExist)
 	})
 }
-
 
 func TestPosixInitStat(t *testing.T) {
 	// initStat selects between GNU and BSD stat by inspecting stat's capabilities.

--- a/remotefs/upload_test.go
+++ b/remotefs/upload_test.go
@@ -97,8 +97,8 @@ func (f *uploadFS) Chtimes(_ string, _, _ int64) error                    { pani
 func (f *uploadFS) Touch(_ string, _ ...time.Time) error                  { panic("not implemented") }
 func (f *uploadFS) Truncate(_ string, _ int64) error                      { panic("not implemented") }
 func (f *uploadFS) Getenv(_ string) string                                { panic("not implemented") }
-func (f *uploadFS) DownloadURL(_ string, _ string) error          { panic("not implemented") }
-func (f *uploadFS) FileContains(_ string, _ string) (bool, error) { panic("not implemented") }
+func (f *uploadFS) DownloadURL(_ string, _ string) error                  { panic("not implemented") }
+func (f *uploadFS) FileContains(_ string, _ string) (bool, error)         { panic("not implemented") }
 func (f *uploadFS) Follow(_ context.Context, _ string, _ io.Writer) error { panic("not implemented") }
 func (f *uploadFS) IsContainer() (bool, error)                            { panic("not implemented") }
 func (f *uploadFS) Hostname() (string, error)                             { panic("not implemented") }

--- a/remotefs/winfs_test.go
+++ b/remotefs/winfs_test.go
@@ -215,7 +215,6 @@ func TestWindowsChownVariantsNotSupported(t *testing.T) {
 	require.ErrorIs(t, f.ChownTreeInt("/tmp", 0, 0), remotefs.ErrNotSupported)
 }
 
-
 func TestWindowsCreateTemp(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
@@ -371,4 +370,3 @@ func TestWindowsShellQuote(t *testing.T) {
 		require.Equal(t, tc.want, fs.ShellQuote(tc.input), "input: %q", tc.input)
 	}
 }
-

--- a/sudo/sudo_test.go
+++ b/sudo/sudo_test.go
@@ -42,6 +42,11 @@ func TestSudoGolden(t *testing.T) {
 			want:  `sudo -n -- "${SHELL-sh}" -c 'k0s install controller --config /etc/k0s/k0s.yaml'`,
 		},
 		{
+			name:  "write-file compound with a redirect stays inside the sudo shell",
+			input: "mkdir -p -- /etc/k0s && umask 0177 && cat >/etc/k0s/k0s.yaml && chmod -- 0600 /etc/k0s/k0s.yaml",
+			want:  `sudo -n -- "${SHELL-sh}" -c 'mkdir -p -- /etc/k0s && umask 0177 && cat >/etc/k0s/k0s.yaml && chmod -- 0600 /etc/k0s/k0s.yaml'`,
+		},
+		{
 			name:  "command that already uses shell pipes",
 			input: "journalctl -u k0s | tail -20",
 			want:  `sudo -n -- "${SHELL-sh}" -c 'journalctl -u k0s | tail -20'`,


### PR DESCRIPTION
Fixes #410 

The uutils (Rust) reimplementation of coreutils, the default on Ubuntu 25.10 and later, fails with "install: No such file or directory" when the source is /dev/stdin and the destination already exists. PosixFS.WriteFile did exactly that, and rig writes through a mktemp'd file, so every k0sctl apply against such a host failed. Reproduced on uutils coreutils 0.2.2:

    f=$(mktemp); echo test | install -D -m 0600 /dev/stdin $f

Note the destination has to exist — with a fresh path the same command succeeds, which is why this looks unreproducible at first.

WriteFile now builds the file with a shell redirect instead:

    mkdir -p -- DIR && umask UMASK && cat >FILE && chmod -- MODE FILE

The umask is derived from the requested mode so a newly created file is never more permissive than asked for while the content is written, and it is set after mkdir so it does not apply to the created parent directories. The trailing chmod applies the mode exactly, also to a file that already existed. "--" precedes the mode because BSD chmod stops parsing options at the first operand and would otherwise treat "--" as a filename. Verified against GNU, busybox and BSD chmod.

One behaviour change: missing parent directories now get the remote default mode (0777 minus the remote umask) rather than the fixed 0755 that GNU install -D applied. uutils install -D already behaved this way.

PosixFile.Write and PosixFile.CopyFrom drop "if=/dev/stdin" from their dd invocations. dd reads stdin when if= is omitted, so behaviour is unchanged and the binary upload path can no longer trip over the same class of restriction. MkdirAll's "install -d" is untouched — it has no source file.