### PR TITLE
fix(cmd,sudo): impose a POSIX shell instead of trusting $SHELL

### DIFF
--- a/aliases.go
+++ b/aliases.go
@@ -90,8 +90,9 @@ func GetOSRelease(runner cmd.SimpleRunner) (*os.Release, error) {
 	return os, nil
 }
 
-// NewRunner returns a new cmd.Runner for the connection.
+// NewRunner returns a new cmd.Runner for the connection. Like the runner a
+// [Client] sets up, it imposes a POSIX shell on non-Windows hosts.
 // Currently the error is always nil.
 func NewRunner(conn protocol.Connection) (cmd.Runner, error) {
-	return cmd.NewExecutor(conn), nil
+	return newDefaultRunner(conn), nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -407,6 +407,57 @@ func TestClientExecInteractiveNotSupported(t *testing.T) {
 	require.ErrorContains(t, err, "interactive")
 }
 
+// TestPosixShellImposed guards the fix for k0sproject/k0sctl#1135: rig's commands
+// are POSIX, the remote user's login shell is not necessarily POSIX (fish, csh),
+// and sshd runs commands through that login shell. Every command a client sends
+// to a non-Windows host must therefore be handed to an explicit POSIX shell and
+// must not rely on shell features the login shell may not have.
+func TestPosixShellImposed(t *testing.T) {
+	t.Run("plain command", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		client, err := rig.NewClient(rig.WithConnection(conn))
+		require.NoError(t, err)
+		require.NoError(t, client.Exec("echo hello"))
+		rigtest.ReceivedEqual(t, conn, `/bin/sh -c -- 'echo hello'`)
+	})
+
+	t.Run("sudo command", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		forceSudo(conn)
+		client, err := rig.NewClient(rig.WithConnection(conn))
+		require.NoError(t, err)
+		require.NoError(t, client.Sudo().Exec("echo hello"))
+
+		// The inner shell is sudo's (sudo execs directly, so compound commands
+		// need one), the outer shell replaces the login shell. Neither may be
+		// applied twice.
+		rigtest.ReceivedEqual(t, conn, `/bin/sh -c -- 'sudo -n -- /bin/sh -c -- '"'"'echo hello'"'"''`)
+		// The sudo availability probe is the command that actually failed in
+		// k0sctl#1135, so it must be wrapped as well.
+		rigtest.ReceivedEqual(t, conn, `/bin/sh -c -- 'sudo -n -- /bin/sh -c -- true'`)
+		// The root check is the very first command a client sends, and it is
+		// also the one that resolves the host's OS. Wrapping must not depend on
+		// a previous command having established that.
+		rigtest.ReceivedEqual(t, conn, `/bin/sh -c -- '[ "$(id -u)" = 0 ]'`)
+
+		// No command sent while setting sudo up may need a non-POSIX shell to
+		// expand it either - the sudo and doas probes used to interpolate
+		// "${SHELL-sh}", which is a syntax error in fish.
+		for _, command := range conn.Commands() {
+			assert.NotContains(t, command, "${", "commands must not rely on parameter expansion by the login shell")
+		}
+	})
+
+	t.Run("windows host", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		conn.Windows = true
+		client, err := rig.NewClient(rig.WithConnection(conn))
+		require.NoError(t, err)
+		require.NoError(t, client.Exec("echo hello"))
+		rigtest.ReceivedEqual(t, conn, "cmd.exe /C echo hello")
+	})
+}
+
 var errNotRoot = errors.New("not root")
 
 // forceSudo makes the sudo registry deterministically select the "sudo"

--- a/clientoptions.go
+++ b/clientoptions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/k0sproject/rig/v2/packagemanager"
 	"github.com/k0sproject/rig/v2/protocol"
 	"github.com/k0sproject/rig/v2/remotefs"
+	"github.com/k0sproject/rig/v2/sh"
 	"github.com/k0sproject/rig/v2/sudo"
 )
 
@@ -179,7 +180,16 @@ func (o *ClientOptions) GetRunner(conn protocol.Connection) cmd.Runner {
 	if o.runner != nil {
 		return o.runner
 	}
+	return newDefaultRunner(conn)
+}
+
+// newDefaultRunner returns rig's default runner for a connection: an executor
+// that imposes a POSIX shell on non-Windows hosts, so that the remote user's
+// login shell does not get to interpret rig's POSIX command strings.
+// See [cmd.Executor.SetShell].
+func newDefaultRunner(conn protocol.Connection) *cmd.Executor {
 	runner := cmd.NewExecutor(conn)
+	runner.SetShell(sh.DefaultShell)
 	return runner
 }
 

--- a/cmd/execoptions.go
+++ b/cmd/execoptions.go
@@ -57,10 +57,31 @@ type ExecOptions struct {
 
 // Format returns the command string with all per-call decorators applied.
 func (o *ExecOptions) Format(cmd string) string {
-	for _, decorator := range o.decorateFuncs {
-		cmd = decorator(cmd)
+	return applyDecorators(cmd, o.decorateFuncs, nil)
+}
+
+// formatMasked is [ExecOptions.Format] with a mask applied after every decorator.
+// See [applyDecorators].
+func (o *ExecOptions) formatMasked(cmd string, mask func(string) string) string {
+	return applyDecorators(cmd, o.decorateFuncs, mask)
+}
+
+// hasRedaction reports whether any secrets are registered for redaction.
+func (o *ExecOptions) hasRedaction() bool {
+	return len(o.redactStrings) > 0
+}
+
+// needsMaskedReplay reports whether masking the formatted command could miss a
+// registered secret. Quoting only ever rewrites single quotes and backslashes,
+// so a secret containing neither stays contiguous however many times the command
+// is quoted, and can be masked in the formatted command directly.
+func (o *ExecOptions) needsMaskedReplay() bool {
+	for _, secret := range o.redactStrings {
+		if strings.ContainsAny(secret, `'\`) {
+			return true
+		}
 	}
-	return cmd
+	return false
 }
 
 // AllowWinStderr returns the allowWinStderr option.

--- a/cmd/executor.go
+++ b/cmd/executor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/k0sproject/rig/v2/iostream"
 	"github.com/k0sproject/rig/v2/log"
 	"github.com/k0sproject/rig/v2/protocol"
+	"github.com/k0sproject/rig/v2/sh"
 )
 
 // validate interfaces.
@@ -51,6 +52,7 @@ type Executor struct {
 	osKnown    atomic.Bool
 	tracer     Tracer
 	gate       CommandGate
+	shell      string
 }
 
 func isWinFunc(conn protocol.ProcessStarter) func() bool {
@@ -93,12 +95,85 @@ func (r *Executor) SetCommandGate(gate CommandGate) {
 	r.gate = gate
 }
 
-func (r *Executor) formatCommandForOS(command string, execOpts *ExecOptions, isWindows bool) string {
-	cmd := r.Format(execOpts.Format(command))
+// SetShell imposes an explicit shell for running commands on non-Windows hosts.
+// When set, commands are wrapped in `<shell> -c <quoted command>` so that the
+// remote user's login shell, which is not guaranteed to be POSIX compatible,
+// never gets to interpret rig's POSIX command strings. POSIX shells and fish are
+// covered; see [shellescape.QuoteForLoginShell] for what a csh login shell can
+// still break.
+// Use [sh.DefaultShell] unless the host is known to keep its POSIX shell
+// somewhere else. An empty shell disables the wrapping.
+//
+// Windows commands are never wrapped, and neither are commands formatted before
+// the host's OS has been determined, in which case [Executor.Explain] reports
+// OSWrappingKnown: false. Decorators that bring a shell of their own, like the
+// ones in the sudo package, keep using [sh.DefaultShell] regardless of this
+// setting; they only need a shell for the command they elevate, and the shell
+// set here still wraps the result.
+//
+// SetShell must not be called concurrently with Start, Exec, or any other
+// command-execution method.
+func (r *Executor) SetShell(shell string) {
+	r.shell = shell
+}
+
+// windowsShellPrefix runs a command that is not an executable through cmd.exe on
+// Windows hosts. We don't know whether the default shell there is cmd or
+// powershell, so non-prefixed commands consistently go through cmd.exe.
+func windowsShellPrefix(cmd string, isWindows bool) string {
 	if isWindows && !isExe(cmd) {
-		cmd = "cmd.exe /C " + cmd
+		return "cmd.exe /C " + cmd
 	}
 	return cmd
+}
+
+// applyDecorators runs the decorators in order. When mask is set it runs after
+// every decorator, so a secret is masked at the first point it appears in full,
+// before a later decorator quotes it into pieces a literal redacter can no
+// longer match.
+func applyDecorators(cmd string, decorators []DecorateFunc, mask func(string) string) string {
+	for _, decorator := range decorators {
+		cmd = decorator(cmd)
+		if mask != nil {
+			cmd = mask(cmd)
+		}
+	}
+	return cmd
+}
+
+func (r *Executor) formatCommandForOS(command string, execOpts *ExecOptions, isWindows bool) string {
+	return windowsShellPrefix(r.Format(execOpts.Format(command)), isWindows)
+}
+
+// parentFormat applies the formatting that every parent runner contributes,
+// masking after each of their decorators when mask is set. A chained runner - the
+// sudo runners wrap the base one - has its command formatted by its parents too,
+// which is how an imposed shell reaches a sudo-decorated command.
+//
+// Start applies this itself and starts the process on the connection underneath
+// the parents (see [Executor.baseConnection]), so that each decorator runs once
+// for a command and the string reported to logs, tracers and a [CommandGate] is
+// the very one that gets sent.
+func (r *Executor) parentFormat(cmd string, mask func(string) string) string {
+	for parent, ok := r.connection.(*Executor); ok; parent, ok = parent.connection.(*Executor) {
+		cmd = parent.format(cmd, mask)
+	}
+	return cmd
+}
+
+// baseConnection returns the first connection in the chain that is not an
+// [Executor], which is the one Start hands a fully formatted command to. Every
+// Executor in between has already contributed its formatting via parentFormat;
+// going through their StartProcess would apply their decorators a second time.
+func (r *Executor) baseConnection() protocol.ProcessStarter {
+	conn := r.connection
+	for {
+		parent, ok := conn.(*Executor)
+		if !ok {
+			return conn
+		}
+		conn = parent.connection
+	}
 }
 
 // formatCommand returns the fully decorated command string.
@@ -106,6 +181,8 @@ func (r *Executor) formatCommand(command string, execOpts *ExecOptions) string {
 	return r.formatCommandForOS(command, execOpts, r.IsWindows())
 }
 
+// explainCommand returns the command as this runner formats it, before any
+// parent runner formats it again, and whether the host's OS was known.
 func (r *Executor) explainCommand(command string, execOpts *ExecOptions) (string, bool) {
 	if !r.osKnown.Load() {
 		return r.formatCommandForOS(command, execOpts, false), false
@@ -113,18 +190,54 @@ func (r *Executor) explainCommand(command string, execOpts *ExecOptions) (string
 	return r.formatCommandForOS(command, execOpts, r.IsWindows()), true
 }
 
+// redactedForm returns the human-readable form of a command for logging and for
+// a [CommandGate]: registered secrets are masked and PowerShell -EncodedCommand
+// payloads are decoded. formatted must be the command as the host receives it,
+// including what parent runners add; with nothing to mask, decoding it is all
+// this has to do.
+//
+// A secret that contains a single quote or a backslash needs more care, because
+// both the sudo decorators and the imposed shell quote what they wrap, and
+// quoting rewrites exactly those two characters - splitting the secret into
+// pieces a literal redacter can no longer match. For those, the command is
+// formatted a second time starting from the masked original, masking again after
+// every decorator so that a secret a decorator introduces itself is caught
+// before the next decorator or the shell wrapping quotes it.
+//
+// That second pass feeds decorators an input the host never sees, so a decorator
+// whose output depends on the content of the command it is given can describe a
+// command that differs from the one sent (see [DecorateFunc]). That is accepted:
+// the alternative is printing the secret. Every other secret - one without a
+// quote or a backslash in it - survives quoting intact and is masked in the
+// formatted command directly, with no second pass at all.
+func (r *Executor) redactedForm(command, formatted string, execOpts *ExecOptions, isWindows bool) string {
+	if !execOpts.hasRedaction() {
+		return decodeEncoded(formatted)
+	}
+	mask := execOpts.Redacter().Redact
+	if !execOpts.needsMaskedReplay() {
+		return mask(decodeEncoded(formatted))
+	}
+	cmd := execOpts.formatMasked(mask(command), mask)
+	cmd = r.format(cmd, mask)
+	cmd = r.parentFormat(windowsShellPrefix(cmd, isWindows), mask)
+	return mask(decodeEncoded(cmd))
+}
+
 // Explain returns the formatted command without running it. Use this to
-// inspect the effect of decorators, sudo wrapping, PowerShell encoding,
-// and redaction without executing anything. Explain never probes the host
+// inspect the effect of decorators, sudo wrapping, shell imposition,
+// PowerShell encoding, and redaction without executing anything. Explain never probes the host
 // to determine OS-specific wrapping; wrapping is included only when the OS
 // has already been determined (see OSWrappingKnown in the returned Explanation).
 func (r *Executor) Explain(command string, opts ...ExecOption) Explanation {
 	execOpts := Build(opts...)
-	formatted, osWrappingKnown := r.explainCommand(command, execOpts)
+	ownFormatted, osWrappingKnown := r.explainCommand(command, execOpts)
+	// What the host receives includes the formatting the parent runners add.
+	formatted := r.parentFormat(ownFormatted, nil)
 	decoded := decodeEncoded(formatted)
 	logged := ""
 	if execOpts.LogCommand() {
-		logged = execOpts.Redact(decoded)
+		logged = r.redactedForm(command, formatted, execOpts, osWrappingKnown && r.IsWindows())
 	}
 	return Explanation{
 		Formatted:       formatted,
@@ -135,12 +248,33 @@ func (r *Executor) Explain(command string, opts ...ExecOption) Explanation {
 	}
 }
 
-// Format returns the command string decorated with the runner's global decorators.
+// Format returns the command string decorated with the runner's global
+// decorators and, when a shell has been imposed via [Executor.SetShell],
+// wrapped in an explicit shell invocation.
 func (r *Executor) Format(cmd string) string {
-	for _, decorator := range r.decorators {
-		cmd = decorator(cmd)
+	return r.format(cmd, nil)
+}
+
+// format applies the global decorators and the imposed shell wrapping, masking
+// after every decorator when mask is set. See [applyDecorators].
+func (r *Executor) format(cmd string, mask func(string) string) string {
+	cmd = applyDecorators(cmd, r.decorators, mask)
+	if r.shellWrapApplies() {
+		cmd = sh.ShellWith(r.shell, cmd)
 	}
 	return cmd
+}
+
+// shellWrapApplies reports whether the imposed shell should wrap a command.
+// The OS check is deliberately probe-free: the command-execution path resolves
+// and caches the host's OS before Format runs (Start evaluates IsWindows to
+// build the formatCommandForOS argument), while Explain must not probe and
+// leaves out OS-specific wrapping until the OS is known.
+func (r *Executor) shellWrapApplies() bool {
+	if r.shell == "" || !r.osKnown.Load() {
+		return false
+	}
+	return !r.isWin()
 }
 
 // Proc returns a Proc bound to this runner for the given command.
@@ -360,11 +494,17 @@ func (r *Executor) Start(ctx context.Context, command string, opts ...ExecOption
 	// non-prefixed commands through cmd.exe.
 	cmd := r.formatCommand(command, execOpts)
 
+	// fullCmd is the command as the host receives it: this runner's formatting
+	// plus what every parent runner contributes. It is both what gets sent (to
+	// the connection underneath the parents, so their decorators are not applied
+	// twice) and what tracers, the gate and the logs describe.
+	fullCmd := r.parentFormat(cmd, nil)
+
 	// redactedCmd is the human-readable command (secrets masked, PowerShell
 	// -EncodedCommand decoded), computed once and reused for gating and every
-	// log line below. Tracer callbacks deliberately receive the raw formatted
-	// cmd, as their contract documents.
-	redactedCmd := execOpts.Redact(decodeEncoded(cmd))
+	// log line below. Tracer callbacks deliberately receive the unredacted
+	// command, as their contract documents.
+	redactedCmd := r.redactedForm(command, fullCmd, execOpts, r.IsWindows())
 
 	// Consult the gate before emitting any command-logging or tracer
 	// lifecycle events so a rejected command produces no dangling
@@ -381,14 +521,14 @@ func (r *Executor) Start(ctx context.Context, command string, opts ...ExecOption
 	}
 
 	if tracer != nil {
-		tracer.CommandFormatted(r.String(), cmd)
+		tracer.CommandFormatted(r.String(), fullCmd)
 	}
 
 	stdout := execOpts.Stdout()
 	stderr := execOpts.Stderr()
 	traceClosers = append(traceClosers, execOpts.OutputClosers()...)
 
-	waiter, err := r.connection.StartProcess(ctx, cmd, execOpts.Stdin(), stdout, stderr) //nolint:contextcheck // Stdin() uses trace logger which takes context
+	waiter, err := r.baseConnection().StartProcess(ctx, fullCmd, execOpts.Stdin(), stdout, stderr) //nolint:contextcheck // Stdin() uses trace logger which takes context
 	if err != nil {
 		closeAll(traceClosers)
 		log.Trace(ctx, "start process failed", log.HostAttr(r), log.KeyCommand, redactedCmd, log.KeyError, err)
@@ -403,7 +543,7 @@ func (r *Executor) Start(ctx context.Context, command string, opts ...ExecOption
 
 	started := time.Now()
 	if tracer != nil {
-		tracer.ProcessStarted(r.String(), cmd)
+		tracer.ProcessStarted(r.String(), fullCmd)
 	}
 
 	return &waiterWrapper{
@@ -412,7 +552,7 @@ func (r *Executor) Start(ctx context.Context, command string, opts ...ExecOption
 		isWindows:    r.IsWindows(),
 		tracer:       tracer,
 		host:         r.String(),
-		formatted:    cmd,
+		formatted:    fullCmd,
 		started:      started,
 		traceClosers: traceClosers,
 	}, nil
@@ -525,6 +665,15 @@ func (r *Executor) ExecScanner(command string, opts ...ExecOption) *bufio.Scanne
 // StartProcess calls the connection's StartProcess method. This is done to satisfy the
 // connection interface and thus allow chaining of runners.
 func (r *Executor) StartProcess(ctx context.Context, command string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (protocol.Waiter, error) {
+	// With a shell imposed, resolve the host's OS first. The wrapping decision in
+	// Format is deliberately probe-free so that Explain never probes, which means
+	// the OS has to be known by the time Format runs, and a runner that is not an
+	// Executor can reach this method without going through Start. Skipped when no
+	// shell is imposed: there is no wrapping decision to make, and probing would
+	// cost a command on a connection that cannot report its OS by itself.
+	if r.shell != "" {
+		r.IsWindows()
+	}
 	waiter, err := r.connection.StartProcess(ctx, r.Format(command), stdin, stdout, stderr)
 	if err != nil {
 		return nil, fmt.Errorf("runner start process: %w", err)

--- a/cmd/executor_test.go
+++ b/cmd/executor_test.go
@@ -1,13 +1,16 @@
 package cmd_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/k0sproject/rig/v2/cmd"
 	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/k0sproject/rig/v2/sh"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,6 +31,242 @@ func TestWindowsShell(t *testing.T) {
 	rigtest.ReceivedEqual(t, mr, "cmd.exe /C echo hello", "commands should by default be run through cmd.exe")
 	_ = mr.Exec("foo.exe foo")
 	rigtest.ReceivedWithPrefix(t, mr, "foo.exe", "commands starting with *.exe should be run directly")
+}
+
+func TestSetShell(t *testing.T) {
+	t.Run("posix commands are wrapped", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		runner := cmd.NewExecutor(conn)
+		runner.SetShell(sh.DefaultShell)
+		require.NoError(t, runner.Exec("echo hello"))
+		rigtest.ReceivedEqual(t, conn, `/bin/sh -c -- 'echo hello'`,
+			"the imposed shell must run the command instead of the remote user's login shell")
+	})
+
+	t.Run("no shell means no wrapping", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		runner := cmd.NewExecutor(conn)
+		require.NoError(t, runner.Exec("echo hello"))
+		rigtest.ReceivedEqual(t, conn, "echo hello")
+	})
+
+	t.Run("windows commands are not wrapped", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		conn.Windows = true
+		runner := cmd.NewExecutor(conn)
+		runner.SetShell(sh.DefaultShell)
+		require.NoError(t, runner.Exec("echo hello"))
+		rigtest.ReceivedEqual(t, conn, "cmd.exe /C echo hello")
+		rigtest.NotReceivedContains(t, conn, sh.DefaultShell)
+	})
+
+	t.Run("chained runners wrap once", func(t *testing.T) {
+		conn := rigtest.NewMockConnection()
+		base := cmd.NewExecutor(conn)
+		base.SetShell(sh.DefaultShell)
+		// A decorated runner on top of the base one, like the sudo runners are.
+		chained := cmd.NewExecutor(base, func(command string) string { return "sudo -n -- " + sh.Shell(command) })
+		require.NoError(t, chained.Exec("echo hello"))
+
+		// The inner shell belongs to the decorator, the outer one to the base
+		// runner. The base runner must not add a second layer of its own.
+		rigtest.ReceivedEqual(t, conn, `/bin/sh -c -- 'sudo -n -- /bin/sh -c -- '"'"'echo hello'"'"''`)
+	})
+}
+
+// TestRedactSurvivesQuoting covers a secret that contains a single quote. Both
+// the sudo decorators and the imposed shell quote what they wrap, which splits
+// such a secret into pieces a literal redacter can no longer match, so
+// redaction has to happen before the command is formatted.
+func TestRedactSurvivesQuoting(t *testing.T) {
+	const secret = "pa'ss"
+
+	var gated string
+	conn := rigtest.NewMockConnection()
+	runner := cmd.NewExecutor(conn)
+	runner.SetShell(sh.DefaultShell)
+	runner.SetCommandGate(cmd.CommandGateFunc(func(_ context.Context, _, command string) error {
+		gated = command
+		return nil
+	}))
+
+	require.NoError(t, runner.Exec(`login "`+secret+`"`, cmd.Redact(secret)))
+
+	require.NotContains(t, gated, secret, "the gate must not be shown the secret")
+	require.Contains(t, gated, "[REDACTED]")
+	// The host still gets the real command: the mask is for humans only. The
+	// secret itself is not contiguous there, since quoting it is what broke
+	// redaction in the first place.
+	rigtest.NotReceivedContains(t, conn, "[REDACTED]", "the mask must never be sent to the host")
+	rigtest.ReceivedContains(t, conn, "login")
+
+	explanation := runner.Explain(`login "`+secret+`"`, cmd.Redact(secret))
+	require.NotContains(t, explanation.Logged, secret, "Explain's loggable form must not contain the secret")
+}
+
+// TestRedactOrdinarySecretNeedsNoReplay covers the common case: a secret that
+// quoting cannot split is masked in the formatted command itself. The decorators
+// must not be re-run for it, so the described command is exactly the one sent,
+// even for a decorator that varies with the command it is given.
+func TestRedactOrdinarySecretNeedsNoReplay(t *testing.T) {
+	const secret = "s3cr3t"
+
+	var gated string
+	conn := rigtest.NewMockConnection()
+	// A decorator that looks at the command it is given. Formatting a masked
+	// command would take the other branch.
+	runner := cmd.NewExecutor(conn, func(command string) string {
+		if strings.Contains(command, secret) {
+			return "with-secret " + command
+		}
+		return "without-secret " + command
+	})
+	runner.SetShell(sh.DefaultShell)
+	runner.SetCommandGate(cmd.CommandGateFunc(func(_ context.Context, _, command string) error {
+		gated = command
+		return nil
+	}))
+
+	require.NoError(t, runner.Exec("login "+secret, cmd.Redact(secret)))
+
+	require.NotContains(t, gated, secret)
+	require.Contains(t, gated, "with-secret", "the described command must be the one that ran")
+	rigtest.ReceivedContains(t, conn, "with-secret")
+}
+
+// TestRedactSecretIntroducedByDecorator covers a secret that is not in the
+// command at all but added by a decorator, which a later decorator or the shell
+// wrapping then quotes. Masking has to happen after each decorator for this to
+// be caught.
+func TestRedactSecretIntroducedByDecorator(t *testing.T) {
+	const secret = "pa'ss"
+
+	var gated string
+	conn := rigtest.NewMockConnection()
+	runner := cmd.NewExecutor(conn, func(command string) string {
+		return `PASSWORD="` + secret + `" ` + command
+	})
+	runner.SetShell(sh.DefaultShell)
+	runner.SetCommandGate(cmd.CommandGateFunc(func(_ context.Context, _, command string) error {
+		gated = command
+		return nil
+	}))
+
+	require.NoError(t, runner.Exec("login", cmd.Redact(secret)))
+
+	require.NotContains(t, gated, secret, "a secret added by a decorator must be masked too")
+	require.Contains(t, gated, "[REDACTED]")
+}
+
+// TestChainedRunnerReportsFullCommand covers a chained runner, as the sudo
+// runners are: the shell is imposed by the base runner, so part of the command
+// comes from a runner further down the chain. Logs, the gate, tracers and Explain
+// must describe the command the host receives, not just this runner's part of it.
+func TestChainedRunnerReportsFullCommand(t *testing.T) {
+	const want = `/bin/sh -c -- 'sudo -n -- /bin/sh -c -- '"'"'echo hello'"'"''`
+
+	var gated string
+	conn := rigtest.NewMockConnection()
+	base := cmd.NewExecutor(conn)
+	base.SetShell(sh.DefaultShell)
+	chained := cmd.NewExecutor(base, func(command string) string { return "sudo -n -- " + sh.Shell(command) })
+	chained.SetCommandGate(cmd.CommandGateFunc(func(_ context.Context, _, command string) error {
+		gated = command
+		return nil
+	}))
+	tracer := &tracerRecorder{}
+	chained.SetTracer(tracer)
+
+	require.NoError(t, chained.Exec("echo hello"))
+
+	rigtest.ReceivedEqual(t, conn, want)
+	require.Equal(t, want, gated, "the gate must see the command as the host receives it")
+	// The Tracer contract promises the final command after all wrapping.
+	require.Contains(t, tracer.events, "formatted:"+want)
+	require.Contains(t, tracer.events, "started:"+want)
+
+	explanation := chained.Explain("echo hello")
+	require.Equal(t, want, explanation.Formatted)
+	// Logged must not stack a second parent layer on top of Formatted.
+	require.Equal(t, want, explanation.Logged)
+}
+
+// TestChainedRunnerRunsDecoratorsOnce pins that a parent runner's decorators are
+// applied once per command. A decorator is an exported callback, so running one
+// twice can have side effects of its own and, if it is not a pure function of its
+// input, produce a command that differs from the one reported.
+func TestChainedRunnerRunsDecoratorsOnce(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	calls := 0
+	base := cmd.NewExecutor(conn, func(command string) string {
+		calls++
+		return "env VAR=1 " + command
+	})
+	base.SetShell(sh.DefaultShell)
+	chained := cmd.NewExecutor(base, func(command string) string { return "sudo -n -- " + sh.Shell(command) })
+
+	require.NoError(t, chained.Exec("echo hello"))
+
+	require.Equal(t, 1, calls, "the parent's decorator must run once per command")
+	require.Equal(t, 1, strings.Count(conn.LastCommand(), "env VAR=1"), "got %q", conn.LastCommand())
+}
+
+// TestStartProcessImposesShell covers the chaining entry point. Start resolves
+// the host's OS before formatting, but a runner that is not a [cmd.Executor] can
+// call StartProcess directly, and the imposed shell must not be skipped just
+// because nothing has probed the OS yet.
+func TestStartProcessImposesShell(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	runner := cmd.NewExecutor(conn)
+	runner.SetShell(sh.DefaultShell)
+
+	waiter, err := runner.StartProcess(context.Background(), "echo hello", nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, waiter.Wait())
+
+	rigtest.ReceivedEqual(t, conn, `/bin/sh -c -- 'echo hello'`)
+}
+
+// TestRedactSecretIntroducedByParentDecorator is
+// [TestRedactSecretIntroducedByDecorator] for a decorator on the parent runner,
+// whose formatting is replayed to describe what a chained runner sends.
+func TestRedactSecretIntroducedByParentDecorator(t *testing.T) {
+	const secret = "pa'ss"
+
+	var gated string
+	conn := rigtest.NewMockConnection()
+	base := cmd.NewExecutor(conn, func(command string) string {
+		return `PASSWORD="` + secret + `" ` + command
+	})
+	base.SetShell(sh.DefaultShell)
+	chained := cmd.NewExecutor(base, func(command string) string { return "sudo -n -- " + sh.Shell(command) })
+	chained.SetCommandGate(cmd.CommandGateFunc(func(_ context.Context, _, command string) error {
+		gated = command
+		return nil
+	}))
+
+	require.NoError(t, chained.Exec("login", cmd.Redact(secret)))
+
+	require.NotContains(t, gated, secret, "a secret added by a parent decorator must be masked too")
+	require.Contains(t, gated, "[REDACTED]")
+}
+
+func TestSetShellExplain(t *testing.T) {
+	conn := rigtest.NewMockConnection()
+	runner := cmd.NewExecutor(conn)
+	runner.SetShell(sh.DefaultShell)
+
+	// Explain must not probe the host for its OS, so before anything has run the
+	// OS-specific wrapping is left out and flagged as such.
+	explanation := runner.Explain("echo hello")
+	require.Equal(t, "echo hello", explanation.Formatted)
+	require.False(t, explanation.OSWrappingKnown)
+
+	require.NoError(t, runner.Exec("echo hello"))
+
+	explanation = runner.Explain("echo hello")
+	require.Equal(t, `/bin/sh -c -- 'echo hello'`, explanation.Formatted)
+	require.True(t, explanation.OSWrappingKnown)
 }
 
 func TestPrintfErrors(t *testing.T) {

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -23,6 +23,14 @@ var (
 )
 
 // DecorateFunc is a function that takes a string and returns a decorated string.
+//
+// It should wrap or transform the command without depending on what the command
+// says, and must not carry state. When a secret containing a quote or a backslash
+// is registered for redaction, the command is formatted a second time from the
+// masked original to build the form shown in logs and to a [CommandGate], so a
+// decorator that is stateful, non-deterministic, or varies with the content of
+// its argument can describe a command that differs from the one sent to the host.
+// All of rig's own decorators are content-independent wrappers.
 type DecorateFunc func(string) string
 
 // Formatter is an interface that can format commands by applying decorators.

--- a/example_test.go
+++ b/example_test.go
@@ -138,6 +138,9 @@ func ExampleClient_Sudo() {
 // command; returning false aborts the command with [cmd.ErrCommandRejected]
 // before it reaches the host. This applies to the client and every runner it
 // derives (sudo, filesystem, services).
+//
+// The command is passed in the exact form it would run in, which on non-Windows
+// hosts includes the POSIX shell rig imposes over the remote user's login shell.
 func ExampleWithConfirmFunc() {
 	conn := rigtest.NewMockConnection()
 	conn.AddCommand(rigtest.Match("."), func(_ *rigtest.A) error { return nil })
@@ -165,8 +168,8 @@ func ExampleWithConfirmFunc() {
 		fmt.Println("blocked")
 	}
 	// Output:
-	// confirm "systemctl restart nginx" -> true
-	// confirm "rm -rf /important" -> false
+	// confirm "/bin/sh -c -- 'systemctl restart nginx'" -> true
+	// confirm "/bin/sh -c -- 'rm -rf /important'" -> false
 	// blocked
 }
 

--- a/sh/command.go
+++ b/sh/command.go
@@ -5,6 +5,11 @@ import (
 	"github.com/k0sproject/rig/v2/sh/shellescape"
 )
 
+// DefaultShell is the shell rig uses to run commands on non-Windows hosts.
+// An absolute path is used on purpose: the whole point of imposing a shell is
+// to not depend on the remote environment, and that includes PATH.
+const DefaultShell = "/bin/sh"
+
 // CommandBuilder is a builder for shell commands. It is based on string and can be
 // converted to one using string(CommandBuilder("foo")) or calling the String method.
 type CommandBuilder string
@@ -78,6 +83,35 @@ func (c CommandBuilder) Raw(arg string) CommandBuilder {
 // it is here to avoid importing shellescape separately.
 func Quote(s string) string {
 	return shellescape.Quote(s)
+}
+
+// Shell returns the command wrapped in an explicit invocation of [DefaultShell]:
+//
+//	sh.Shell("echo foo | tee bar")
+//	// resulting command: /bin/sh -c -- 'echo foo | tee bar'
+//
+// Use this when a command must be interpreted by a POSIX shell, either because
+// it is a compound expression handed to something that execs directly (like
+// sudo) or because whatever runs it may not be a POSIX shell, such as a remote
+// user's fish login shell.
+//
+// This is the one place a rig command is quoted for a shell nobody chose, so the
+// quoting comes from [shellescape.QuoteForLoginShell], which covers POSIX shells
+// and fish. A csh login shell can still reject a command containing ! or an
+// embedded newline.
+func Shell(command string) string {
+	return ShellWith(DefaultShell, command)
+}
+
+// ShellWith is [Shell] with an explicit shell. An empty shell means [DefaultShell].
+func ShellWith(shell, command string) string {
+	if shell == "" {
+		shell = DefaultShell
+	}
+	// The option terminator keeps a command that starts with a dash from being
+	// read as shell options: `sh -c -x` reports an invalid option instead of
+	// running anything.
+	return shellescape.QuoteForLoginShell(shell) + " -c -- " + shellescape.QuoteForLoginShell(command)
 }
 
 // Command returns a shell escaped command string.

--- a/sh/command_test.go
+++ b/sh/command_test.go
@@ -14,6 +14,48 @@ func TestCommand(t *testing.T) {
 	assert.Equal(t, "echo 'foo bar'", sh.Command("echo", "foo bar"))
 }
 
+func TestShell(t *testing.T) {
+	assert.Equal(t, `/bin/sh -c -- 'echo foo | tee bar'`, sh.Shell("echo foo | tee bar"))
+	assert.Equal(t, `/bin/sh -c -- 'echo foo'`, sh.ShellWith("", "echo foo"))
+	assert.Equal(t, `/usr/xpg4/bin/sh -c -- 'echo foo'`, sh.ShellWith("/usr/xpg4/bin/sh", "echo foo"))
+}
+
+// TestShellQuoting pins the quoting of payloads that a non-POSIX login shell
+// would otherwise reinterpret on the way to the shell that runs them.
+//
+// The expectations were verified by hand by running each wrapped command through
+// sh, bash, dash, zsh, ksh and fish. The integration suite exercises the wrapping
+// end to end on every command it runs, both against the POSIX login shells of its
+// images (bash, dash, ash) and against fish, which the
+// rig_test_regular_user_fish_login_shell case in test/test.sh installs and assigns
+// as the SSH user's login shell. What these fixtures add is the byte-exact quoting,
+// which the integration suite can only observe indirectly.
+func TestShellQuoting(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{name: "plain", command: "true", want: `/bin/sh -c -- true`},
+		{name: "spaces", command: "echo foo bar", want: `/bin/sh -c -- 'echo foo bar'`},
+		{name: "single quotes", command: `bash -c 'true'`, want: `/bin/sh -c -- 'bash -c '"'"'true'"'"''`},
+		{name: "backslash", command: `printf a\b`, want: `/bin/sh -c -- 'printf a'\\'b'`},
+		{name: "consecutive backslashes", command: `printf \\n`, want: `/bin/sh -c -- 'printf '\\''\\'n'`},
+		{
+			// The sed expression from os/darwin.go carries consecutive backslashes.
+			name:    "darwin os release sed expression",
+			command: `sed -E "s/^.*FOR (.+)\\\/\1/"`,
+			want:    `/bin/sh -c -- 'sed -E "s/^.*FOR (.+)'\\''\\''\\'/'\\'1/"'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sh.Shell(tt.command))
+		})
+	}
+}
+
 func TestCommandBuilder(t *testing.T) {
 	assert.Equal(t, "echo foo | grep -q foo", sh.CommandBuilder("echo").Arg("foo").Pipe("grep", "-q").Arg("foo").String())
 	assert.Equal(t, "echo foo 'bar baz'", sh.CommandBuilder("echo").Args("foo", "bar baz").String())

--- a/sh/golden_test.go
+++ b/sh/golden_test.go
@@ -73,8 +73,8 @@ func TestCommandBuilderGolden(t *testing.T) {
 		{
 			name: "pipe grep filters output",
 			got:  sh.CommandBuilder("cat /etc/os-release").Pipe("grep", "^ID=").String(),
-			// Note: ^ is not in shellescape's special-char set so ^ID= is not quoted.
-			want: "cat /etc/os-release | grep ^ID=",
+			// ^ is in shellescape's special-char set, so the pattern is quoted.
+			want: "cat /etc/os-release | grep '^ID='",
 		},
 		{
 			name: "stderr to null suppresses errors",

--- a/sh/shellescape/shellescape.go
+++ b/sh/shellescape/shellescape.go
@@ -8,10 +8,15 @@ package shellescape
 import (
 	"strings"
 	"unicode"
-	"unicode/utf8"
 )
 
 // classify returns whether the string is empty, contains single quotes, or contains special characters.
+//
+// The set of special characters covers everything the reference implementation
+// this package replaces treats as unsafe - anything outside [\w@%+=:,./-] - plus
+// the percent sign, which that implementation considers safe but fish uses for
+// process expansion. Backtick and caret used to be missing from the set, which
+// meant a string like "`id`" came back unquoted for a shell to substitute.
 func classify(s string) (bool, bool, bool) {
 	if len(s) == 0 {
 		return true, false, false
@@ -21,7 +26,7 @@ func classify(s string) (bool, bool, bool) {
 		switch r {
 		case '\'':
 			singleQ = true
-		case ' ', '\t', '\n', '\r', '\f', '\v', '$', '&', '"', '|', ';', '<', '>', '(', ')', '*', '?', '[', ']', '#', '~', '%', '!', '{', '}', '\\':
+		case ' ', '\t', '\n', '\r', '\f', '\v', '$', '&', '"', '|', ';', '<', '>', '(', ')', '*', '?', '[', ']', '#', '~', '%', '!', '{', '}', '\\', '`', '^':
 			special = true
 		}
 		if singleQ && special {
@@ -40,24 +45,24 @@ func wrapTo(str string, builder *strings.Builder) {
 	builder.WriteByte('\'')
 }
 
-// wrap in single quotes and escape single quotes and backslashes.
+// wrap in single quotes and escape single quotes.
+//
+// Bytes are copied as they are rather than decoded into runes: a file name on a
+// POSIX host is a byte string that need not be valid UTF-8, and ranging over
+// runes would rewrite every invalid byte into U+FFFD, quoting a name that is not
+// the one asked for. The characters that need escaping are all ASCII, and UTF-8
+// never encodes those as part of a multi-byte sequence.
 func escapeTo(str string, builder *strings.Builder) {
 	builder.Grow(len(str) + 10)
 	builder.WriteByte('\'')
-	for _, c := range str { //nolint:varnamelen
-		if c == '\'' {
+	for i := range len(str) {
+		if str[i] == '\'' {
 			// quoting single quotes requires 4 extra chars, assume there's a closing quote too
 			builder.Grow(10)
 			builder.WriteString(`'"'"'`)
 			continue
 		}
-		// According to strings.Map source code, this is faster than
-		// always using WriteRune.
-		if c < utf8.RuneSelf {
-			builder.WriteByte(byte(c)) //nolint:gosec // G115: c < utf8.RuneSelf guarantees safe conversion
-		} else {
-			builder.WriteRune(c)
-		}
+		builder.WriteByte(str[i])
 	}
 	builder.WriteByte('\'')
 }
@@ -83,6 +88,75 @@ func Quote(str string) string {
 		wrapTo(str, builder)
 	} else {
 		escapeTo(str, builder)
+	}
+	return builder.String()
+}
+
+// escapeForLoginShellTo wraps str in single quotes, escaping single quotes and
+// backslashes outside of the quoted runs, where every supported shell agrees on
+// their meaning. Bytes are copied as they are, for the reason given on [escapeTo].
+func escapeForLoginShellTo(str string, builder *strings.Builder) {
+	builder.Grow(len(str) + 10)
+	builder.WriteByte('\'')
+	for i := range len(str) {
+		switch str[i] {
+		case '\'':
+			builder.Grow(10)
+			builder.WriteString(`'"'"'`)
+		case '\\':
+			// Leave the quoted run, write an escaped backslash, and resume it.
+			// Both POSIX shells and fish read \\ outside quotes as one
+			// backslash, while inside single quotes they disagree.
+			builder.Grow(10)
+			builder.WriteString(`'\\'`)
+		default:
+			builder.WriteByte(str[i])
+		}
+	}
+	builder.WriteByte('\'')
+}
+
+// QuoteForLoginShell safely encloses a string in single quotes for a shell that
+// the program did not choose: in practice the remote user's login shell, which
+// sshd hands the command line to before anything else sees it.
+//
+// Use it for that boundary and nothing else. [Quote] is correct, shorter and
+// easier to read for every layer inside it, because those are parsed by the
+// POSIX shell that rig imposes on the command (see cmd.Executor.SetShell) rather
+// than by whatever the remote user's shell happens to be.
+//
+// The difference is backslashes. fish reads \\ and \' as escapes inside single
+// quotes, where POSIX shells pass them through verbatim, so a POSIX-quoted
+// 'a\\b' reaches the imposed shell as a\b. Wrapping a command in a shell
+// invocation is therefore not by itself enough to protect it: the darwin OS
+// release detection sends a sed expression carrying consecutive backslashes, and
+// under a fish login shell that expression silently changed meaning. This
+// function escapes single quotes and backslashes outside the quoted runs
+// instead, where both shells agree that \\ means one backslash.
+//
+// The csh family is not covered: it expands ! before it considers quoting, and
+// takes no embedded newline inside quotes at all. Both fail loudly rather than
+// changing the command.
+func QuoteForLoginShell(str string) string {
+	empty, singleQ, special := classify(str)
+	if empty {
+		return "''"
+	}
+	if !singleQ && !special {
+		return str
+	}
+
+	builder, ok := builderPool.Get().(*strings.Builder)
+	if !ok {
+		builder = &strings.Builder{}
+	}
+	defer builderPool.Put(builder)
+	defer builder.Reset()
+
+	if !singleQ && !strings.ContainsRune(str, '\\') {
+		wrapTo(str, builder)
+	} else {
+		escapeForLoginShellTo(str, builder)
 	}
 	return builder.String()
 }

--- a/sh/shellescape/shellescape_test.go
+++ b/sh/shellescape/shellescape_test.go
@@ -21,11 +21,65 @@ func TestQuote(t *testing.T) {
 		{"Single Invalid", ";", `';'`}, // this could be returned as \;
 		{"All Invalid", `;${}`, `';${}'`},
 		{"Clean String", "foo.example.com", `foo.example.com`},
+		// An unquoted backtick would have the shell run the command inside it,
+		// so a filename like this must not come back verbatim.
+		{"Command Substitution", "`id`", "'`id`'"},
+		// Caret is outside the safe set of the implementation this package
+		// replaces, and was a pipe in pre-POSIX shells.
+		{"Caret", "^ID=", `'^ID='`},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, shellescape.Quote(tt.input))
+		})
+	}
+}
+
+func TestQuoteForLoginShell(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty", input: "", want: "''"},
+		{name: "nothing to quote", input: "foo", want: "foo"},
+		{name: "spaces", input: "foo bar", want: "'foo bar'"},
+		{name: "single quote", input: "foo'bar", want: `'foo'"'"'bar'`},
+		{name: "backslash leaves the quoted run", input: `foo\bar`, want: `'foo'\\'bar'`},
+		{name: "consecutive backslashes", input: `foo\\bar`, want: `'foo'\\''\\'bar'`},
+		{name: "backslash before quote", input: `\'`, want: `''\\''"'"''`},
+		{name: "other specials stay quoted", input: `$foo ${bar} *`, want: `'$foo ${bar} *'`},
+		// An unquoted backtick would have the shell run the command inside it.
+		{name: "backticks", input: "`id`", want: "'`id`'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shellescape.QuoteForLoginShell(tt.input))
+		})
+	}
+}
+
+// TestQuotePreservesInvalidUTF8 guards against decoding the input into runes. A
+// file name on a POSIX host is a byte string that need not be valid UTF-8, and
+// rewriting an invalid byte into U+FFFD would quote a name other than the one
+// asked for. The input here also carries a space and a quote, so both the
+// wrapping and the escaping paths are taken.
+func TestQuotePreservesInvalidUTF8(t *testing.T) {
+	const name = "/tmp/a\xffb 'c"
+
+	tests := []struct {
+		name string
+		got  string
+	}{
+		{"Quote", shellescape.Quote(name)},
+		{"QuoteForLoginShell", shellescape.QuoteForLoginShell(name)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Contains(t, tt.got, "\xff", "the invalid byte must survive verbatim")
+			assert.NotContains(t, tt.got, "�", "the invalid byte must not become the replacement character")
 		})
 	}
 }

--- a/sudo/doas.go
+++ b/sudo/doas.go
@@ -2,12 +2,15 @@ package sudo
 
 import (
 	"github.com/k0sproject/rig/v2/cmd"
-	"github.com/k0sproject/rig/v2/sh/shellescape"
+	"github.com/k0sproject/rig/v2/sh"
 )
 
 // Doas is a DecorateFunc that will wrap the given command in a doas call.
+//
+// The command runs through an explicit POSIX shell for the same reasons as in
+// [Sudo].
 func Doas(cmd string) string {
-	return `doas -n -- "${SHELL-sh}" -c ` + shellescape.Quote(cmd)
+	return "doas -n -- " + sh.Shell(cmd)
 }
 
 // RegisterDoas registers a doas DecorateFunc with the given repository.

--- a/sudo/doas_test.go
+++ b/sudo/doas_test.go
@@ -17,17 +17,17 @@ func TestDoasGolden(t *testing.T) {
 		{
 			name:  "simple command",
 			input: "apt-get install -y docker.io",
-			want:  `doas -n -- "${SHELL-sh}" -c 'apt-get install -y docker.io'`,
+			want:  `doas -n -- /bin/sh -c -- 'apt-get install -y docker.io'`,
 		},
 		{
 			name:  "command with embedded single quotes",
 			input: "bash -c 'systemctl restart k0s'",
-			want:  "doas -n -- \"${SHELL-sh}\" -c 'bash -c '\"'\"'systemctl restart k0s'\"'\"''",
+			want:  "doas -n -- /bin/sh -c -- 'bash -c '\"'\"'systemctl restart k0s'\"'\"''",
 		},
 		{
 			name:  "plain path",
 			input: "cat /etc/k0s/k0s.yaml",
-			want:  `doas -n -- "${SHELL-sh}" -c 'cat /etc/k0s/k0s.yaml'`,
+			want:  `doas -n -- /bin/sh -c -- 'cat /etc/k0s/k0s.yaml'`,
 		},
 	}
 

--- a/sudo/sudo.go
+++ b/sudo/sudo.go
@@ -2,12 +2,17 @@ package sudo
 
 import (
 	"github.com/k0sproject/rig/v2/cmd"
-	"github.com/k0sproject/rig/v2/sh/shellescape"
+	"github.com/k0sproject/rig/v2/sh"
 )
 
 // Sudo is a DecorateFunc that will wrap the given command in a sudo call.
+//
+// The command runs through an explicit POSIX shell: sudo execs its argument
+// directly, so compound expressions (pipes, redirections, boolean lists) need a
+// shell to interpret them, and rig's commands are POSIX, which the target
+// user's login shell is not guaranteed to be.
 func Sudo(cmd string) string {
-	return `sudo -n -- "${SHELL-sh}" -c ` + shellescape.Quote(cmd)
+	return "sudo -n -- " + sh.Shell(cmd)
 }
 
 // RegisterSudo registers a sudo DecorateFunc with the given repository.

--- a/sudo/sudo_test.go
+++ b/sudo/sudo_test.go
@@ -19,37 +19,37 @@ func TestSudoGolden(t *testing.T) {
 		{
 			name:  "simple command with flags",
 			input: "apt-get install -y docker.io",
-			want:  `sudo -n -- "${SHELL-sh}" -c 'apt-get install -y docker.io'`,
+			want:  `sudo -n -- /bin/sh -c -- 'apt-get install -y docker.io'`,
 		},
 		{
 			name:  "command with embedded single-quoted argument",
 			input: "bash -c 'systemctl restart k0s'",
-			want:  "sudo -n -- \"${SHELL-sh}\" -c 'bash -c '\"'\"'systemctl restart k0s'\"'\"''",
+			want:  "sudo -n -- /bin/sh -c -- 'bash -c '\"'\"'systemctl restart k0s'\"'\"''",
 		},
 		{
 			name:  "plain path without special characters",
 			input: "cat /etc/k0s/k0s.yaml",
-			want:  `sudo -n -- "${SHELL-sh}" -c 'cat /etc/k0s/k0s.yaml'`,
+			want:  `sudo -n -- /bin/sh -c -- 'cat /etc/k0s/k0s.yaml'`,
 		},
 		{
 			name:  "path with spaces requires quoting",
 			input: "cat \"/etc/k0s/my config/k0s.yaml\"",
-			want:  `sudo -n -- "${SHELL-sh}" -c 'cat "/etc/k0s/my config/k0s.yaml"'`,
+			want:  `sudo -n -- /bin/sh -c -- 'cat "/etc/k0s/my config/k0s.yaml"'`,
 		},
 		{
 			name:  "k0s install command with full config path",
 			input: "k0s install controller --config /etc/k0s/k0s.yaml",
-			want:  `sudo -n -- "${SHELL-sh}" -c 'k0s install controller --config /etc/k0s/k0s.yaml'`,
+			want:  `sudo -n -- /bin/sh -c -- 'k0s install controller --config /etc/k0s/k0s.yaml'`,
 		},
 		{
 			name:  "write-file compound with a redirect stays inside the sudo shell",
 			input: "mkdir -p -- /etc/k0s && umask 0177 && cat >/etc/k0s/k0s.yaml && chmod -- 0600 /etc/k0s/k0s.yaml",
-			want:  `sudo -n -- "${SHELL-sh}" -c 'mkdir -p -- /etc/k0s && umask 0177 && cat >/etc/k0s/k0s.yaml && chmod -- 0600 /etc/k0s/k0s.yaml'`,
+			want:  `sudo -n -- /bin/sh -c -- 'mkdir -p -- /etc/k0s && umask 0177 && cat >/etc/k0s/k0s.yaml && chmod -- 0600 /etc/k0s/k0s.yaml'`,
 		},
 		{
 			name:  "command that already uses shell pipes",
 			input: "journalctl -u k0s | tail -20",
-			want:  `sudo -n -- "${SHELL-sh}" -c 'journalctl -u k0s | tail -20'`,
+			want:  `sudo -n -- /bin/sh -c -- 'journalctl -u k0s | tail -20'`,
 		},
 	}
 

--- a/test/rig_test.go
+++ b/test/rig_test.go
@@ -46,6 +46,7 @@ var (
 	privateKey      string
 	enableMultiplex bool
 	traceLog        bool
+	expectSudo      bool
 )
 
 func pathBase(p string) string {
@@ -68,6 +69,7 @@ func TestMain(m *testing.M) {
 	flag.BoolVar(&useHTTPS, "winrm-https", false, "use https for winrm")
 	flag.BoolVar(&enableMultiplex, "openssh-multiplex", true, "use ssh multiplexing")
 	flag.BoolVar(&onlyConnect, "connect", false, "only connect to host, dont run other tests")
+	flag.BoolVar(&expectSudo, "expect-sudo", false, "the host has passwordless privilege escalation configured, fail instead of skipping when rig does not detect it")
 	flag.BoolVar(&traceLog, "trace", false, "turn on trace logging")
 
 	// Parse the flags
@@ -298,15 +300,20 @@ type OSSuite struct {
 
 // TestSudoCompoundCommands guards against regressing the sudo decorator into handing
 // compound shell expressions to sudo verbatim. v2 already wraps commands in
-// `sudo -n -- "${SHELL-sh}" -c <quoted>` (see sudo.Sudo), so this is a regression guard,
+// `sudo -n -- /bin/sh -c -- <quoted>` (see sudo.Sudo), so this is a regression guard,
 // not a bug fix. It only has teeth when the suite runs as a non-root user with passwordless
-// escalation (the rig_test_regular_user path in test.sh).
+// escalation (the rig_test_regular_user paths in test.sh), which pass -expect-sudo so that
+// escalation rig fails to detect is reported instead of quietly skipped.
 func (s *OSSuite) TestSudoCompoundCommands() {
 	if s.Host.IsWindows() {
 		s.T().Skip("sudo not supported on windows")
 		return
 	}
 	if _, err := s.Host.Sudo().ExecOutput("true"); err != nil {
+		// Detection runs commands of its own, so a login shell that mangles them takes
+		// escalation away without any test asserting on it. That is how the fish login
+		// shell of k0sproject/k0sctl#1135 went unnoticed.
+		s.Require().Falsef(expectSudo, "the host has passwordless privilege escalation configured but rig did not detect it: %v", err)
 		s.T().Skip("passwordless privilege escalation (sudo/doas) not configured")
 		return
 	}

--- a/test/test.sh
+++ b/test/test.sh
@@ -222,7 +222,23 @@ rig_test_key_from_default_location() {
 
 rig_test_regular_user() {
   color_echo "- Testing regular user"
+  run_suite_as_rigtest_user
+}
+
+rig_test_regular_user_fish_login_shell() {
+  color_echo "- Testing regular user with a fish login shell"
+  run_suite_as_rigtest_user fish
+}
+
+# run_suite_as_rigtest_user provisions an unprivileged rigtest-user with
+# passwordless privilege escalation on node0 and runs the suite as that user.
+# $1 is an optional package name for a login shell to install and assign to the
+# user; sshd runs every command through that shell, so a non-POSIX one puts the
+# shell imposition of cmd.Executor.SetShell and the sudo decorators to the test.
+run_suite_as_rigtest_user() {
+  local shellPkg="${1:-}"
   make create-host
+  local sshPort
   sshPort=$(ssh_port node0)
 
   set -- -T -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i .ssh/id_ed25519 -p "$sshPort"
@@ -232,16 +248,28 @@ rig_test_regular_user() {
     return 0
   }
 
-  ssh "$@" root@127.0.0.1 sh -euxC - <<EOF
+  # shellcheck disable=SC2029 # the package name is meant to expand on this side
+  ssh "$@" root@127.0.0.1 "LOGIN_SHELL_PKG='$shellPkg' sh -euxC -" <<'EOF'
+    # The login shell, when one was requested, has to exist before the user that
+    # gets it. command -v fails the script if the package did not deliver it.
+    if [ -n "${LOGIN_SHELL_PKG:-}" ]; then
+      if command -v apk >/dev/null 2>&1; then
+        apk add --no-cache "$LOGIN_SHELL_PKG"
+      else
+        DEBIAN_FRONTEND=noninteractive apt-get update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y "$LOGIN_SHELL_PKG"
+      fi
+      set -- -s "$(command -v "$LOGIN_SHELL_PKG")"
+    fi
     if command -v groupadd >/dev/null 2>&1; then
       groupadd --system rig-wheel
       groupadd --system rigtest-user || true
-      useradd -d /var/lib/rigtest-user -g rigtest-user -G rig-wheel -p '*' rigtest-user
+      useradd -d /var/lib/rigtest-user -g rigtest-user -G rig-wheel -p '*' "$@" rigtest-user
       passwd -d rigtest-user || true
     else
       addgroup -S rig-wheel
       addgroup -S rigtest-user || true
-      adduser -D -h /var/lib/rigtest-user -G rigtest-user rigtest-user
+      adduser -D -h /var/lib/rigtest-user -G rigtest-user "$@" rigtest-user
       addgroup rigtest-user rig-wheel
       passwd -u rigtest-user || true
     fi
@@ -269,7 +297,27 @@ EOF
     return 0
   }
 
-  HOME="$(pwd)" go test -v ./ -args -host 127.0.0.1 -port "$sshPort" -user rigtest-user -ssh-keypath .ssh/id_ed25519
+  # Make sure the login shell really is in the way of what rig sends, otherwise this
+  # silently degrades into a copy of rig_test_regular_user. The expansion is the one
+  # that broke sudo detection in k0sproject/k0sctl#1135: a POSIX shell echoes a shell
+  # path, fish refuses to parse it and echoes nothing. Only the output can tell them
+  # apart - fish 3.x still exits 0 after the parse error, which is what made the
+  # original bug so quiet.
+  if [ -n "$shellPkg" ] && [ -n "$(ssh "$@" rigtest-user@127.0.0.1 'echo ${SHELL-sh}' 2>/dev/null)" ]; then
+    RET=1
+    color_echo "login shell $shellPkg parsed a POSIX parameter expansion, it is not in use" >&2
+    return 0
+  fi
+
+  # Provisioning only configures sudo or doas when the image ships one. Where it did,
+  # rig has to find it, and -expect-sudo makes the suite say so instead of skipping the
+  # escalation tests - the failure mode a mangled detection command leads to.
+  local -a sudoArgs=()
+  if ssh "$@" rigtest-user@127.0.0.1 'sudo -n -- true || doas -n -- true' >/dev/null 2>&1; then
+    sudoArgs+=(-expect-sudo)
+  fi
+
+  HOME="$(pwd)" go test -v ./ -args -host 127.0.0.1 -port "$sshPort" -user rigtest-user -ssh-keypath .ssh/id_ed25519 "${sudoArgs[@]}"
 }
 
 rig_test_openssh_client() {


### PR DESCRIPTION
## Problem

sshd runs a command through the remote user's login shell, and rig's commands are
POSIX. When that login shell isn't, rig's commands are parsed by a shell that
doesn't understand them.

The sudo and doas decorators made this immediately fatal: they expanded
`"${SHELL-sh}"`, which is a syntax error in fish, so privilege escalation
detection failed before anything else could run:

```
executing command  command="sudo -n -- \"${SHELL-sh}\" -c true"
fish: ${ is not a valid variable in fish.
```

Even where it expanded, `$SHELL` *is* the login shell, so the POSIX command was
handed straight back to fish. Non-sudo commands were affected too — the issue log
also shows the posixfs stat probe failing.

  ## Fix

  - **sudo/doas** run their command through `/bin/sh`. They still need a shell of
    their own: sudo execs its argument directly and rig hands it compound
    expressions (pipes, redirections, boolean lists).
  - **`cmd.Executor.SetShell`** wraps every command for a non-Windows host in
    `<shell> -c -- <quoted>`. `rig.Client` and `rig.NewRunner` set it to
    `sh.DefaultShell` (`/bin/sh`), so the login shell no longer interprets anything
    rig sends — it only execs `/bin/sh`. The wrapping is applied in `Format`, so it
    lands exactly once, outermost, for both direct and sudo-decorated runners.
    An absolute path is deliberate: resolving `sh` via `PATH` would depend on the
    environment this change exists to distrust.
  - **`shellescape.QuoteForLoginShell`** quotes that outermost string. POSIX
    quoting is not enough there: fish reads `\\` and `\'` as escapes inside single
    quotes, which silently changed the `sed` expression in `os/darwin.go`. This
    escapes them outside the quoted runs, where both shells agree.

  Two pre-existing bugs surfaced on the way, both in `shellescape` and both
  affecting `Quote`/`Join` beyond this change:

  - Backtick and caret were missing from the special-character set, so
    ``sh.Command("stat", "`id`")`` produced ``stat `id` `` and the shell **ran
    `id`** — command substitution through any backtick-bearing argument.
  - The escaper decoded input into runes, so any byte of a non-UTF-8 filename
    became U+FFFD and the command referred to a different file.

  Reporting was tightened so the described command matches the executed one: logs,
  tracers, `Explain` and a `CommandGate` now include what parent runners add, each
  decorator runs once per command, and redaction happens before quoting when a
  secret contains a quote or a backslash (quoting splits it otherwise, which leaked
  the secret into logs).

  ## Shell support

  POSIX shells and fish. The csh family is **not** covered: it expands `!` before it
  considers quoting and accepts no embedded newline inside quotes. Both fail loudly
  rather than changing the command.
  
  ## Behaviour changes

- Logs and gate prompts now show `/bin/sh -c -- '<command>'`.
- Command lines carry `-c --`, so a command starting with a dash is not read as
  shell options (`protocol/localhost` already invoked sh this way).
- Arguments containing a backtick or caret are now quoted.
- Chained runners lose one layer of error wrapping (`"runner start process:"`),
  since parents no longer format the command again in `StartProcess`.

## Testing

Unit tests pin the emitted strings, including the darwin `sed` fixture. The
quoting was verified by hand by running each wrapped command through sh, bash,
dash, zsh, ksh and fish, and the byte-for-byte round trip holds in all six. The
integration suite exercises the wrapping on every command it runs against the POSIX login shells (bash, dash, ash) and by setting the login shell to fish.

Fixes k0sproject/k0sctl#1135