### PR TITLE
ci: test against latest and previous bootloose images

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,10 +7,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Latest and previous release of each distro family that bootloose
+        # ships images for. See the "Choosing the OS image to run" section of
+        # https://github.com/k0sproject/bootloose for the current image list.
         image:
-          - quay.io/k0sproject/bootloose-ubuntu24.04
-          - quay.io/k0sproject/bootloose-debian12
-          - quay.io/k0sproject/bootloose-alpine3.22
+          - quay.io/k0sproject/bootloose-ubuntu26.04:latest
+          - quay.io/k0sproject/bootloose-ubuntu24.04:latest
+          - quay.io/k0sproject/bootloose-debian13:latest
+          - quay.io/k0sproject/bootloose-debian12:latest
+          - quay.io/k0sproject/bootloose-alpine3.23:latest
+          - quay.io/k0sproject/bootloose-alpine3.22:latest
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 test/rigtest
-test/footloose.yaml
+test/bootloose.yaml
 test/Library
 test/.ssh
 test/*.iid

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,7 @@ KEY_SIZE ?= 4096
 KEY_PASSPHRASE ?= ""
 KEY_PATH ?= ".ssh/id_ed25519"
 REPLICAS ?= 1
-LINUX_IMAGE ?= "quay.io/k0sproject/bootloose-ubuntu20.04"
+LINUX_IMAGE ?= "quay.io/k0sproject/bootloose-ubuntu26.04:latest"
 
 .PHONY: test
 test: gomod 


### PR DESCRIPTION
The integration matrix had drifted behind the images bootloose actually ships: it used ubuntu24.04, debian12 and alpine3.22, none of which are the newest of their family. Bump it to the latest and previous release of each of the three families, taken from the "Choosing the OS image to run" list in the bootloose README.

The test/Makefile default was ubuntu20.04, which is on bootloose's retired image list, so `make test` with no override pulled an unmaintained image. It now tracks the newest ubuntu.

All refs carry an explicit :latest. That was already the effective behaviour for untagged refs, and pinning to a version tag is not possible uniformly — :latest is only re-pushed when an image changes, so the established repos have a newer vX.Y.Z tag than their :latest while the newest repos have only :latest.

Also fix the .gitignore entry left over from the footloose rename: the Makefile generates test/bootloose.yaml, not test/footloose.yaml, so the generated config was never actually ignored.