### PR TITLE
Fix uutils mkdirall and touch

### DIFF
--- a/remotefs/patchfile_test.go
+++ b/remotefs/patchfile_test.go
@@ -467,7 +467,8 @@ func TestPatchFilePosix(t *testing.T) {
 	// ReadFile via cat. Matched by prefix so it does not also catch the "cat >"
 	// redirect that WriteFile uses.
 	mr.AddCommandOutput(rigtest.HasPrefix("cat "), "FOO=old\nBAR=keep\n")
-	// WriteFileAtomic: MkdirAll probes Stat("/etc") — return directory so no install -d is needed.
+	// WriteFileAtomic: MkdirAll probes Stat("/etc") — return directory so it does
+	// not go on to create anything.
 	// 0x41ed = 0o040755 (directory, rwxr-xr-x). This fires for any remaining stat -c call.
 	mr.AddCommandOutput(rigtest.Contains("stat -c"), "0x41ed 0 1234567890.000000000 ///etc//")
 	// CreateTemp.

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -29,13 +29,27 @@ var (
 	errGrepFailed              = errors.New("grep failed")
 	errTestFailed              = errors.New("test failed")
 	errStatInitFailed          = errors.New("stat command not found or unsupported stat implementation")
-	statCmdGNU                 = `env -i PATH="$PATH" LC_ALL=C stat -c '%%#f %%s %%.9Y //%%n//' -- %s 2> /dev/null`
-	statCmdBSD                 = `env -i PATH="$PATH" LC_ALL=C stat -f '%%#p %%z %%Fm //%%N//' -- %s 2> /dev/null`
+
+	// The modification time is read from %y, which spells the timestamp out, rather
+	// than from the epoch seconds of %.9Y: the uutils (Rust) reimplementation of
+	// coreutils, the default on Ubuntu 25.10 and later, formats %.9Y through a float
+	// and truncates the outcome onto a 100ns grid, leaving the time it reports up to
+	// ~200ns away from the one the file actually has. %y is exact there, GNU coreutils
+	// prints the same layout, and busybox, which ignores the precision of %.9Y
+	// altogether, does too.
+	statCmdGNU = `env -i PATH="$PATH" LC_ALL=C stat -c '%%#f %%s %%y //%%n//' -- %s 2> /dev/null`
+	statCmdBSD = `env -i PATH="$PATH" LC_ALL=C stat -f '%%#p %%z %%Fm //%%N//' -- %s 2> /dev/null`
 )
 
 const (
 	defaultBlockSize = 4096
 	supportedFlags   = os.O_RDONLY | os.O_WRONLY | os.O_RDWR | os.O_CREATE | os.O_EXCL | os.O_TRUNC | os.O_APPEND | os.O_SYNC
+
+	// statTimeLayout is the timestamp format of stat -c %y under LC_ALL=C: a date, a
+	// time with a fraction of a second and a UTC offset.
+	statTimeLayout = "2006-01-02 15:04:05.999999999 -0700"
+	// statDateLayout is the date the %y timestamp starts with, its first field.
+	statDateLayout = "2006-01-02"
 )
 
 // PosixFS implements fs.FS for a remote filesystem that uses POSIX commands for access.
@@ -71,17 +85,21 @@ func (s *PosixFS) initStat() error {
 	return errStatInitFailed
 }
 
-// second precision touch for busybox.
-func (s *PosixFS) secChtimes(name string, atime, mtime int64) error {
+// chtimes sets the access and modification times of name from timestamps in the
+// -d format of touch, the access time first.
+//
+// The times are set in separate invocations because -d is a single valued option:
+// uutils coreutils rejects a repeated --date outright ("the argument '--date
+// <STRING>' cannot be used multiple times") and GNU touch silently lets the last
+// one win, which would set the access time to the modification timestamp.
+func (s *PosixFS) chtimes(name string, timestamps [2]string) error {
 	accessOrMod := [2]rune{'a', 'm'}
-	// only supports setting one of them at a time
-	for i, t := range [2]int64{atime, mtime} {
-		ts := int64ToTime(t)
-		utc := ts.UTC()
-		cmd := fmt.Sprintf(`[ -e %[3]s ] && env -i PATH="$PATH" LC_ALL=C TZ=UTC touch -%[1]c -d @%[2]d -- %[3]s`,
+	escapedName := shellescape.Quote(name)
+	for i, ts := range timestamps {
+		cmd := fmt.Sprintf(`[ -e %[3]s ] && env -i PATH="$PATH" LC_ALL=C TZ=UTC touch -%[1]c -d %[2]s -- %[3]s`,
 			accessOrMod[i],
-			utc.Unix(),
-			shellescape.Quote(name),
+			ts,
+			escapedName,
 		)
 		if err := s.Exec(cmd); err != nil {
 			return fmt.Errorf("touch %s (%ctime): %w", name, accessOrMod[i], err)
@@ -90,23 +108,23 @@ func (s *PosixFS) secChtimes(name string, atime, mtime int64) error {
 	return nil
 }
 
+// second precision touch for busybox.
+func (s *PosixFS) secChtimes(name string, atime, mtime int64) error {
+	var timestamps [2]string
+	for i, t := range [2]int64{atime, mtime} {
+		timestamps[i] = fmt.Sprintf("@%d", int64ToTime(t).UTC().Unix())
+	}
+	return s.chtimes(name, timestamps)
+}
+
 // nanosecond precision touch for stats that support it.
 func (s *PosixFS) nsecChtimes(name string, atime, mtime int64) error {
-	atimeTS := int64ToTime(atime)
-	mtimeTS := int64ToTime(mtime)
-	utcA := atimeTS.UTC()
-	utcM := mtimeTS.UTC()
-	escapedName := shellescape.Quote(name)
-	cmd := fmt.Sprintf(`[ -e %s ] && env -i PATH="$PATH" LC_ALL=C TZ=UTC touch -a -d %s.%09d -m -d %s.%09d -- %s`,
-		escapedName,
-		utcA.Format("2006-01-02T15:04:05"), utcA.Nanosecond(),
-		utcM.Format("2006-01-02T15:04:05"), utcM.Nanosecond(),
-		escapedName,
-	)
-	if err := s.Exec(cmd); err != nil {
-		return fmt.Errorf("touch (ns) %s: %w", name, err)
+	var timestamps [2]string
+	for i, t := range [2]int64{atime, mtime} {
+		utc := int64ToTime(t).UTC()
+		timestamps[i] = fmt.Sprintf("%s.%09d", utc.Format("2006-01-02T15:04:05"), utc.Nanosecond())
 	}
-	return nil
+	return s.chtimes(name, timestamps)
 }
 
 func (s *PosixFS) initTouch() error {
@@ -196,8 +214,50 @@ func fileModeToPosixBits(mode fs.FileMode) int64 {
 	return bits
 }
 
+// isStatDate reports whether a stat timestamp field is the date a %y timestamp starts
+// with instead of epoch seconds. An epoch can carry a leading minus, but no dash of its own.
+func isStatDate(field string) bool {
+	return len(field) == len(statDateLayout) && field[4] == '-' && field[7] == '-'
+}
+
+// parseStatModTime reads the modification time from the trailing fields of a stat line
+// and returns it along with the remainder, which holds the file name.
+//
+// The %y timestamp of a GNU style stat is spread over three space separated fields -
+// date, time and UTC offset - so it reaches into rest, while the %Fm of a BSD stat is a
+// single epoch field and leaves rest alone.
+func parseStatModTime(field, rest string) (time.Time, string, error) {
+	if isStatDate(field) {
+		timeParts := strings.SplitN(rest, " ", 3)
+		if len(timeParts) != 3 {
+			return time.Time{}, "", fmt.Errorf("%w: timestamp is missing its time or offset", errInvalid)
+		}
+		modTime, err := time.Parse(statTimeLayout, field+" "+timeParts[0]+" "+timeParts[1])
+		if err != nil {
+			return time.Time{}, "", fmt.Errorf("parse timestamp: %w", err)
+		}
+		return modTime, timeParts[2], nil
+	}
+
+	epochParts := strings.SplitN(field, ".", 2)
+	seconds, err := strconv.ParseInt(epochParts[0], 10, 64)
+	if err != nil {
+		return time.Time{}, "", fmt.Errorf("parse epoch seconds: %w", err)
+	}
+	var nanoseconds int64
+	if len(epochParts) == 2 {
+		nanoseconds, err = strconv.ParseInt(epochParts[1], 10, 64)
+		if err != nil {
+			return time.Time{}, "", fmt.Errorf("parse epoch nanoseconds: %w", err)
+		}
+	}
+
+	return time.Unix(seconds, nanoseconds), rest, nil
+}
+
 func (s *PosixFS) parseStat(stat string) (*FileInfo, error) {
-	// output looks like: 0x81a4 0 1699970097.220228000 //test_20231114155456.txt//
+	// output looks like: 0x81a4 0 2023-11-14 15:54:56.220228000 +0000 //test.txt//
+	// or, from a BSD stat: 0x81a4 0 1699970097.220228000 //test.txt//
 	parts := strings.SplitN(stat, " ", 4)
 	if len(parts) != 4 {
 		return nil, fmt.Errorf("%w: parse stat output %s", errInvalid, stat)
@@ -227,20 +287,12 @@ func (s *PosixFS) parseStat(stat string) (*FileInfo, error) {
 	}
 	res.FSize = size
 
-	timeParts := strings.SplitN(parts[2], ".", 2)
-	mtime, err := strconv.ParseInt(timeParts[0], 10, 64)
+	modTime, name, err := parseStatModTime(parts[2], parts[3])
 	if err != nil {
 		return nil, fmt.Errorf("parse stat mtime %s: %w", stat, err)
 	}
-	var mtimeNano int64
-	if len(timeParts) == 2 {
-		mtimeNano, err = strconv.ParseInt(timeParts[1], 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("parse stat mtime ns %s: %w", stat, err)
-		}
-	}
-	res.FModTime = time.Unix(mtime, mtimeNano)
-	res.FName = strings.TrimSuffix(strings.TrimPrefix(parts[3], "//"), "//")
+	res.FModTime = modTime
+	res.FName = strings.TrimSuffix(strings.TrimPrefix(name, "//"), "//")
 
 	return res, nil
 }

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -720,8 +720,21 @@ func (s *PosixFS) TempDir() string {
 // MkdirAll creates a new directory structure with the specified name and permission bits.
 // If the directory already exists, MkDirAll does nothing and returns nil.
 //
-// The permission bits and the setgid, setuid and sticky bits of perm are
-// applied; the file type bits are ignored.
+// The permission bits of perm are applied to every directory that is created,
+// like os.MkdirAll does; directories that already exist are left alone. The
+// setgid, setuid and sticky bits of perm are applied to the last directory of
+// the path only. The file type bits are ignored.
+//
+// The mode comes from a umask instead of `install -d -m ...` because the uutils
+// (Rust) reimplementation of coreutils, the default on Ubuntu 25.10 and later,
+// applies -m only to the last component of the path while GNU install applies it
+// to every directory it creates, leaving the intermediate directories at the
+// remote default mode. A umask covers all of them, but only the nine permission
+// bits, so the special bits need the trailing chmod.
+//
+// Note that a perm without u+wx makes creating nested directories fail for a
+// non-root user, as it does with os.MkdirAll: the intermediate directory can't
+// be written to once it has been created.
 func (s *PosixFS) MkdirAll(name string, perm fs.FileMode) error {
 	if existing, err := s.Stat(name); err == nil {
 		if existing.IsDir() {
@@ -730,7 +743,19 @@ func (s *PosixFS) MkdirAll(name string, perm fs.FileMode) error {
 		return fmt.Errorf("mkdir %s: %w", name, fs.ErrExist)
 	}
 
-	if err := s.Exec(sh.Command("install", "-d", "-m", fmt.Sprintf("%#o", fileModeToPosixBits(perm)), name)); err != nil {
+	mode := fileModeToPosixBits(perm)
+	hasSpecialBits := mode&^int64(fs.ModePerm) != 0
+
+	command := sh.CommandBuilder(fmt.Sprintf("umask %#o", fs.ModePerm&^perm.Perm())).
+		Raw("&&").Raw(sh.Command("mkdir", "-p", "--", name))
+
+	if hasSpecialBits {
+		// "--" precedes the mode because BSD chmod stops parsing options at the
+		// first operand, where "chmod 0644 -- file" would treat "--" as a filename.
+		command = command.Raw("&&").Raw(sh.Command("chmod", "--", fmt.Sprintf("%#o", mode), name))
+	}
+
+	if err := s.Exec(command.String()); err != nil {
 		return fmt.Errorf("mkdir %s: %w", name, err)
 	}
 

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -298,14 +298,28 @@ func TestPosixMkdir(t *testing.T) {
 
 func TestPosixMkdirAll(t *testing.T) {
 	// MkdirAll stats the target first; an unmatched stat yields no output, which
-	// reads as "does not exist" and lets it proceed to install.
-	for _, tc := range modeCases {
+	// reads as "does not exist" and lets it proceed to create the directories.
+	//
+	// The permission bits come from a umask so that they also apply to the
+	// intermediate directories; only the special bits need a chmod, which reaches
+	// the last directory of the path alone.
+	for _, tc := range []struct {
+		name string
+		mode fs.FileMode
+		want string
+	}{
+		{name: "permission bits", mode: 0o750, want: "umask 027 && mkdir -p -- /tmp/a/b"},
+		{name: "setuid", mode: fs.ModeSetuid | 0o755, want: "umask 022 && mkdir -p -- /tmp/a/b && chmod -- 04755 /tmp/a/b"},
+		{name: "setgid", mode: fs.ModeSetgid | 0o775, want: "umask 02 && mkdir -p -- /tmp/a/b && chmod -- 02775 /tmp/a/b"},
+		{name: "sticky", mode: fs.ModeSticky | 0o777, want: "umask 0 && mkdir -p -- /tmp/a/b && chmod -- 01777 /tmp/a/b"},
+		{name: "type bits ignored", mode: fs.ModeDir | 0o700, want: "umask 077 && mkdir -p -- /tmp/a/b"},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			mr := rigtest.NewMockRunner()
-			mr.AddCommandSuccess(rigtest.Contains("install"))
+			mr.AddCommandSuccess(rigtest.Contains("mkdir -p"))
 			f := remotefs.NewPosixFS(mr)
 			require.NoError(t, f.MkdirAll("/tmp/a/b", tc.mode))
-			require.Equal(t, "install -d -m "+tc.want+" /tmp/a/b", mr.LastCommand())
+			require.Equal(t, tc.want, mr.LastCommand())
 		})
 	}
 }

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -194,6 +196,75 @@ func TestPosixTouch(t *testing.T) {
 		f := remotefs.NewPosixFS(mr)
 		ts := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 		require.NoError(t, f.Touch("/tmp/file", ts))
+	})
+}
+
+// touchCommands returns the touch commands the runner received for name, in the
+// order they were issued.
+func touchCommands(mr *rigtest.MockRunner, name string) []string {
+	var commands []string
+	for _, command := range mr.Commands() {
+		if strings.Contains(command, "TZ=UTC touch") && strings.Contains(command, name) {
+			commands = append(commands, command)
+		}
+	}
+	return commands
+}
+
+func TestPosixChtimes(t *testing.T) {
+	atime := time.Date(2024, 1, 15, 10, 30, 0, 123456789, time.UTC)
+	mtime := time.Date(2025, 2, 16, 11, 31, 1, 987654321, time.UTC)
+
+	// The access and modification times must be set in separate invocations: -d
+	// is a single valued option, so a repeated one is either an error (uutils
+	// coreutils) or silently ignored in favor of the last one (GNU touch), which
+	// would leave the access time set to the modification timestamp.
+	t.Run("nanosecond precision", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.Equal("echo ${TMPDIR:-/tmp}"), "/tmp")
+		// initStat probes for GNU stat, initTouch for a non-busybox touch.
+		mr.AddCommandSuccess(rigtest.Equal("stat -c %n /"))
+		mr.AddCommandOutput(rigtest.Equal("touch --help 2>&1"), "touch (GNU coreutils) 9.7")
+		// initTouch probes nanosecond support on a temp file it creates and then
+		// removes. Creating it stats the parent directory first; 0x41ed is 0o40755
+		// (directory, rwxr-xr-x). The matchers are consulted in the order they were
+		// added, so this one has to precede the one for the temp file itself.
+		mr.AddCommandOutput(rigtest.Contains("-- /tmp 2>"), "0x41ed 4096 0.000000000 ///tmp//\n")
+		// The temp file only exists once the create command has run; 0x8180 is
+		// 0o100600 (regular file, rw-------).
+		var created bool
+		mr.AddCommand(rigtest.Contains("install -m 0600 /dev/null"), func(_ *rigtest.A) error {
+			created = true
+			return nil
+		})
+		mr.AddCommand(rigtest.Contains("stat -c '%#f"), func(a *rigtest.A) error {
+			if !created {
+				return nil
+			}
+			_, err := fmt.Fprintf(a.Stdout, "0x8180 0 0.000000000 //%s//\n", "/tmp/probe")
+			return err
+		})
+		mr.AddCommandSuccess(rigtest.Contains("TZ=UTC touch"))
+		mr.AddCommandSuccess(rigtest.HasPrefix("rm -f"))
+		f := remotefs.NewPosixFS(mr)
+		require.NoError(t, f.Chtimes("/tmp/file", atime.UnixNano(), mtime.UnixNano()))
+		require.Equal(t, []string{
+			`[ -e /tmp/file ] && env -i PATH="$PATH" LC_ALL=C TZ=UTC touch -a -d 2024-01-15T10:30:00.123456789 -- /tmp/file`,
+			`[ -e /tmp/file ] && env -i PATH="$PATH" LC_ALL=C TZ=UTC touch -m -d 2025-02-16T11:31:01.987654321 -- /tmp/file`,
+		}, touchCommands(mr, "/tmp/file"))
+	})
+
+	t.Run("second precision", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		// A busybox touch takes the second precision path, which needs no probing.
+		mr.AddCommandOutput(rigtest.Equal("touch --help 2>&1"), "BusyBox v1.35")
+		mr.AddCommandSuccess(rigtest.Contains("TZ=UTC touch"))
+		f := remotefs.NewPosixFS(mr)
+		require.NoError(t, f.Chtimes("/tmp/file", atime.UnixNano(), mtime.UnixNano()))
+		require.Equal(t, []string{
+			`[ -e /tmp/file ] && env -i PATH="$PATH" LC_ALL=C TZ=UTC touch -a -d @1705314600 -- /tmp/file`,
+			`[ -e /tmp/file ] && env -i PATH="$PATH" LC_ALL=C TZ=UTC touch -m -d @1739705461 -- /tmp/file`,
+		}, touchCommands(mr, "/tmp/file"))
 	})
 }
 
@@ -487,6 +558,51 @@ func TestPosixInitStat(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestPosixStatModTime(t *testing.T) {
+	// The modification time is the third field of the stat output: a GNU style stat
+	// prints it as the date, time and UTC offset of %y, a BSD one as the epoch seconds
+	// of %Fm. Both forms are parsed, and the file name follows the timestamp in both.
+	const (
+		modTimeNano = int64(1699977296220228000) // 2023-11-14 15:54:56.220228 UTC
+		wholeSecond = int64(1699977296000000000)
+	)
+	cases := []struct {
+		name        string
+		output      string
+		wantModTime int64
+		wantName    string
+		wantErr     string
+	}{
+		{"date and time", "0x81a4 12 2023-11-14 15:54:56.220228000 +0000 ///tmp/file//", modTimeNano, "file", ""},
+		{"date and time in another zone", "0x81a4 12 2023-11-14 17:54:56.220228000 +0200 ///tmp/file//", modTimeNano, "file", ""},
+		{"date and time without a fraction", "0x81a4 12 2023-11-14 15:54:56 +0000 ///tmp/file//", wholeSecond, "file", ""},
+		{"epoch with a fraction", "0x81a4 12 1699977296.220228000 ///tmp/file//", modTimeNano, "file", ""},
+		{"epoch without a fraction", "0x81a4 12 1699977296 ///tmp/file//", wholeSecond, "file", ""},
+		{"name with spaces", "0x81a4 12 2023-11-14 15:54:56.220228000 +0000 ///tmp/two words//", modTimeNano, "two words", ""},
+		{"timestamp without an offset", "0x81a4 12 2023-11-14 15:54:56.220228000 ///tmp/file//", 0, "", "missing its time or offset"},
+		{"date that does not exist", "0x81a4 12 2023-13-45 15:54:56.220228000 +0000 ///tmp/file//", 0, "", "parse timestamp"},
+		{"epoch that is not a number", "0x81a4 12 not-a-time ///tmp/file//", 0, "", "parse epoch seconds"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := rigtest.NewMockRunner()
+			// initStat probes for GNU stat.
+			mr.AddCommandSuccess(rigtest.Equal("stat -c %n /"))
+			mr.AddCommandOutput(rigtest.Contains("LC_ALL=C stat -c"), tc.output)
+
+			info, err := remotefs.NewPosixFS(mr).Stat("/tmp/file")
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantModTime, info.ModTime().UnixNano())
+			assert.Equal(t, tc.wantName, info.Name())
+			assert.Equal(t, int64(12), info.Size())
 		})
 	}
 }

--- a/test/rig_test.go
+++ b/test/rig_test.go
@@ -352,24 +352,26 @@ func (s *OSSuite) TestTouch() {
 	f := s.TempPath()
 	s.Require().NoError(s.fs.Touch(f))
 	now := time.Now()
+	// The second round sets a timestamp the file does not already have, so that a
+	// Chtimes that quietly leaves an existing file alone can't pass as a success.
 	for _, tt := range []time.Time{now, now.Add(1 * time.Hour)} {
 		s.Run("Update timestamp "+tt.String(), func() {
-			s.Require().NoError(s.fs.Chtimes(f, now.UnixNano(), now.UnixNano()))
+			s.Require().NoError(s.fs.Chtimes(f, tt.UnixNano(), tt.UnixNano()))
 		})
 
 		s.Run("File exists and has correct timestamp "+tt.String(), func() {
 			stat, err := s.fs.Stat(f)
 			s.Require().NoError(err)
 			s.NotNil(stat)
-			s.Equal(now.Unix(), stat.ModTime().Unix())
+			s.Equal(tt.Unix(), stat.ModTime().Unix())
 			if s.Host.IsWindows() {
 				s.T().Log("Testing millisecond precision on windows")
-				s.Equal(now.UnixMilli(), stat.ModTime().UnixMilli(), "expected %d (%s), got %d (%s)", now.UnixMilli(), now, stat.ModTime().UnixMilli(), stat.ModTime())
+				s.Equal(tt.UnixMilli(), stat.ModTime().UnixMilli(), "expected %d (%s), got %d (%s)", tt.UnixMilli(), tt, stat.ModTime().UnixMilli(), stat.ModTime())
 			} else if stat.ModTime().Nanosecond() != 0 {
 				s.T().Log("Testing nanosecond precision")
-				s.Equal(now.UnixNano(), stat.ModTime().UnixNano())
+				s.Equal(tt.UnixNano(), stat.ModTime().UnixNano())
 			}
-			s.True(stattime.Equal(now, stat.ModTime()))
+			s.True(stattime.Equal(tt, stat.ModTime()))
 		})
 	}
 }

--- a/test/rig_test.go
+++ b/test/rig_test.go
@@ -465,7 +465,7 @@ func (s *FSSuite) TestMkdir() {
 		_ = s.fs.RemoveAll(testPath)
 	}()
 	s.Run("Create directory", func() {
-		s.Require().NoError(s.fs.MkdirAll(testPath, 0755))
+		s.Require().NoError(s.fs.MkdirAll(testPath, 0700))
 	})
 	s.Run("Verify directory exists", func() {
 		stat, err := s.fs.Stat(testPath)
@@ -474,10 +474,10 @@ func (s *FSSuite) TestMkdir() {
 			if s.Host.IsWindows() {
 				s.T().Skip("Windows does not support chmod permissions")
 			}
-			s.Equal(os.FileMode(0755), stat.Mode().Perm())
+			s.Equal(os.FileMode(0700), stat.Mode().Perm())
 			parent, err := s.fs.Stat(s.TempPath("test"))
 			s.Require().NoError(err)
-			s.Equal(os.FileMode(0755), parent.Mode().Perm())
+			s.Equal(os.FileMode(0700), parent.Mode().Perm())
 		})
 	})
 }


### PR DESCRIPTION
Fix bugs found when updating the bootloose images in #435 

```
    fix(remotefs): set access and modification times in separate touch calls

    `touch -a -d T1 -m -d T2 -- file` looks like it sets the two timestamps
    independently, but -d is a single valued option: uutils coreutils, the default
    on Ubuntu 25.10 and later, refuses it with "the argument '--date <STRING>'
    cannot be used multiple times", and GNU touch silently lets the last -d win, so
    the access time was being set to the modification timestamp.

    Both effects were invisible: initTouch probes the nanosecond command on a temp
    file and falls back to the second precision path when it fails, so uutils hosts
    quietly lost nanosecond precision, and on GNU hosts nothing reported the wrong
    access time.

    secChtimes and nsecChtimes now share a chtimes helper that issues one
    invocation per timestamp, which is what secChtimes already did.
```

and

```
    fix(remotefs): apply MkdirAll's mode to every directory it creates

    `install -d -m MODE a/b/c` only sets MODE on the last component of the path
    under uutils coreutils, the default on Ubuntu 25.10 and later; the intermediate
    directories are left at the remote default mode (0777 minus the umask). GNU
    install applies MODE to every directory it creates, which is what MkdirAll
    promised.

    MkdirAll now derives a umask from perm and runs plain `mkdir -p`, which covers
    every directory it creates on any coreutils, and leaves existing directories
    alone like os.MkdirAll does. A umask only reaches the nine permission bits, so
    a perm carrying setuid, setgid or sticky still gets a chmod, which applies to
    the last directory of the path.

    The integration test asked for 0755, which is identical to 0777 minus the
    common 0022 umask, so the assertion could not tell an applied mode from a
    default one. It now asks for 0700, which is what surfaced this: the
    ubuntu26.04 job saw 0775 on the parent directory, the GitHub runner umask
    being 0002.
```