### PR TITLE
fix(remotefs): don't report ErrNotExist when the stat command never ran

### DIFF
--- a/remotefs/patchfile_test.go
+++ b/remotefs/patchfile_test.go
@@ -3,6 +3,7 @@ package remotefs_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"path"
@@ -487,4 +488,38 @@ func TestPatchFilePosix(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, mr.Received(rigtest.Contains("mktemp")))
 	require.NoError(t, mr.Received(rigtest.Contains("mv -f")))
+}
+
+// TestPatchFilePosixStatConnectionLost is the data-loss regression guard: a
+// stat that never ran must not be read as "the file is not there yet", or
+// PatchFile with WithCreate rebuilds the remote file from an empty base and
+// renames it over content it never read.
+func TestPatchFilePosixStatConnectionLost(t *testing.T) {
+	connLost := fmt.Errorf("start session: %w", io.EOF)
+
+	mr := rigtest.NewMockRunner()
+	// initStat probe: select GNU mode.
+	mr.AddCommandSuccess(rigtest.Equal("stat -c %n /"))
+	// Only the stat of the target file is disturbed; every later command
+	// succeeds, which is what a momentary connection blip looks like.
+	mr.AddCommandFailure(rigtest.Match(`stat -c .+ -- /etc/env`), connLost)
+	mr.AddCommandOutput(rigtest.HasPrefix("cat "), "existing_setting = keep_me\n")
+	mr.AddCommandOutput(rigtest.Contains("stat -c"), "0x41ed 0 1234567890.000000000 ///etc//")
+	mr.AddCommandOutput(rigtest.Contains("mktemp"), "/etc/.tmp-abc123")
+	mr.AddCommandSuccess(rigtest.Contains("cat >"))
+	mr.AddCommandSuccess(rigtest.Contains("chmod"))
+	mr.AddCommandSuccess(rigtest.Contains("mv -f"))
+
+	f := remotefs.NewPosixFS(mr)
+	err := remotefs.PatchFile(f, "/etc/env", []remotefs.Patch{
+		remotefs.AppendIfMissing("new_setting = 1"),
+	}, remotefs.WithCreate(0o644))
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, connLost)
+	require.NotErrorIs(t, err, fs.ErrNotExist)
+	// The decisive assertion: nothing was written. Checking only the returned
+	// error would pass against the unfixed code once the write also fails.
+	require.NoError(t, mr.NotReceived(rigtest.Contains("cat >")))
+	require.NoError(t, mr.NotReceived(rigtest.Contains("mv -f")))
 }

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -297,6 +297,51 @@ func (s *PosixFS) parseStat(stat string) (*FileInfo, error) {
 	return res, nil
 }
 
+// exitStatuser is satisfied by the exit errors of the native SSH protocol,
+// which report the status the remote command exited with.
+type exitStatuser interface{ ExitStatus() int }
+
+// exitCoder is satisfied by the exit errors of the protocols that run a local
+// process, which report the code that process exited with.
+type exitCoder interface{ ExitCode() int }
+
+// localProcessFailureExit is the exit code the openssh client uses for its own
+// failures instead of relaying a status from the remote host. The openssh
+// protocol runs the ssh binary locally, so a failure to connect surfaces as an
+// ordinary non-zero exit of a local process and is otherwise indistinguishable
+// from a remote command that failed.
+//
+// This is a stat-specific convention, not a general contract. It is only sound
+// here because multiStat runs nothing but stat, and stat exits 0 or 1 when it
+// actually runs -- including for permission denied. It is deliberately not
+// applied to exitStatuser, where a status of 255 is one the remote host really
+// reported.
+const localProcessFailureExit = 255
+
+// commandRanAndFailed reports whether err describes a command that ran on the
+// host and exited non-zero, as opposed to one that never ran at all -- a
+// connection that could not be established, a session that could not be
+// started, or a connection that died mid-command.
+//
+// A negative status means the process was terminated without one, by a signal
+// or by a cancelled context. That is "did not complete", not "ran and failed",
+// so it is rejected on both branches.
+func commandRanAndFailed(err error) bool {
+	var withStatus exitStatuser
+	if errors.As(err, &withStatus) {
+		// x/crypto/ssh initialises its wait message with a status of -1 and only
+		// an "exit-status" request overwrites it, so a remote command killed by a
+		// signal reports -1.
+		return withStatus.ExitStatus() >= 0
+	}
+	var withCode exitCoder
+	if errors.As(err, &withCode) {
+		code := withCode.ExitCode()
+		return code >= 0 && code != localProcessFailureExit
+	}
+	return false
+}
+
 func (s *PosixFS) multiStat(names ...string) ([]fs.FileInfo, error) { //nolint:cyclop // TODO refactor
 	if err := s.initStat(); err != nil {
 		return nil, err
@@ -330,9 +375,12 @@ func (s *PosixFS) multiStat(names ...string) ([]fs.FileInfo, error) { //nolint:c
 			}
 			res = append(res, info)
 		}
-		if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		if err := scanner.Err(); err != nil {
 			if len(names) == 1 {
-				return nil, PathError(OpStat, names[0], fs.ErrNotExist)
+				if commandRanAndFailed(err) {
+					return nil, PathError(OpStat, names[0], fs.ErrNotExist)
+				}
+				return nil, PathErrorf(OpStat, names[0], "stat: %w", err)
 			}
 			return res, fmt.Errorf("stat %s: %w", names, err)
 		}
@@ -708,7 +756,7 @@ func (s *PosixFS) ReadDir(name string) ([]fs.DirEntry, error) {
 		items = append(items, scanner.Text())
 	}
 
-	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("read dir (find) %s: %w", name, err)
 	}
 

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -323,21 +323,25 @@ const localProcessFailureExit = 255
 // connection that could not be established, a session that could not be
 // started, or a connection that died mid-command.
 //
-// A negative status means the process was terminated without one, by a signal
-// or by a cancelled context. That is "did not complete", not "ran and failed",
-// so it is rejected on both branches.
+// Only a status strictly greater than zero qualifies. A negative one means the
+// process was terminated without a status, by a signal or by a cancelled
+// context, which is "did not complete" rather than "ran and failed". Zero is
+// rejected because it does not describe a failure at all: neither *ssh.ExitError
+// nor *exec.ExitError is constructed for a successful command, so an error
+// carrying zero comes from something other than a command that ran, and the
+// safe answer for anything unrecognised here is false.
 func commandRanAndFailed(err error) bool {
 	var withStatus exitStatuser
 	if errors.As(err, &withStatus) {
 		// x/crypto/ssh initialises its wait message with a status of -1 and only
 		// an "exit-status" request overwrites it, so a remote command killed by a
 		// signal reports -1.
-		return withStatus.ExitStatus() >= 0
+		return withStatus.ExitStatus() > 0
 	}
 	var withCode exitCoder
 	if errors.As(err, &withCode) {
 		code := withCode.ExitCode()
-		return code >= 0 && code != localProcessFailureExit
+		return code > 0 && code != localProcessFailureExit
 	}
 	return false
 }

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -829,13 +829,24 @@ var (
 	_ interface{ ExitCode() int }   = (*osexec.ExitError)(nil)
 )
 
+// exitCommand returns a command line that makes the platform's shell exit with
+// the given code. localhost and openssh run their processes through a local
+// shell, so the fixtures below use the same one the tests run on.
+func exitCommand(code int) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd.exe", []string{"/c", fmt.Sprintf("exit %d", code)}
+	}
+	return "sh", []string{"-c", fmt.Sprintf("exit %d", code)}
+}
+
 // localExitError runs a local process that exits with the given code and
 // returns the resulting *exec.ExitError. A zero value of that type is
-// unsuitable as a fixture: it reports ExitCode() == -1, which models a
-// signal-killed process rather than a normal non-zero exit.
+// unsuitable as a fixture: it reports ExitCode() == -1, which models a process
+// terminated without a code rather than a normal non-zero exit.
 func localExitError(t *testing.T, code int) error {
 	t.Helper()
-	err := osexec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+	name, args := exitCommand(code)
+	err := osexec.Command(name, args...).Run()
 	require.Error(t, err)
 	var exitErr *osexec.ExitError
 	require.ErrorAs(t, err, &exitErr)
@@ -845,8 +856,16 @@ func localExitError(t *testing.T, code int) error {
 
 // signalKilledError runs a local process that kills itself with SIGKILL and
 // returns the resulting *exec.ExitError, whose ExitCode() is -1.
+//
+// Windows has no signals, and TerminateProcess always supplies a code, so no
+// local process there can report a negative one. The case is skipped rather
+// than approximated: the classification it pins is about the absence of a code,
+// which Windows cannot produce.
 func signalKilledError(t *testing.T) error {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("a local process cannot exit without a code on Windows")
+	}
 	err := osexec.Command("sh", "-c", "kill -9 $$").Run()
 	require.Error(t, err)
 	var exitErr *osexec.ExitError

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -8,17 +8,22 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/k0sproject/rig/v2/cmd"
+	"github.com/k0sproject/rig/v2/protocol/localhost"
 	"github.com/k0sproject/rig/v2/remotefs"
 	"github.com/k0sproject/rig/v2/rigtest"
 	"github.com/k0sproject/rig/v2/sh"
 	"github.com/k0sproject/rig/v2/sudo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 )
 
 func TestPosixMachineID(t *testing.T) {
@@ -802,4 +807,165 @@ func TestPosixNotExistThroughSudo(t *testing.T) {
 	err := remotefs.NewPosixFS(sudoRunner).Chmod(longPath, 0o644)
 	require.ErrorIs(t, err, fs.ErrNotExist, "the full stderr must survive a chained runner")
 	require.NoError(t, mr.Received(rigtest.HasPrefix("sudo")))
+}
+
+// sshExitError stands in for the exit error of the native SSH protocol, whose
+// real type cannot be constructed with a chosen status. sshExitStatusPinned
+// below asserts that the real type has the shape modelled here.
+type sshExitError struct {
+	status int
+}
+
+func (e sshExitError) Error() string { return fmt.Sprintf("Process exited with status %d", e.status) }
+
+func (e sshExitError) ExitStatus() int { return e.status }
+
+// The classification in multiStat reads these two interfaces off the errors the
+// protocols produce. Pinning them here turns an upstream type change into a
+// build failure rather than a silent regression.
+var (
+	_ interface{ ExitStatus() int } = (*ssh.ExitError)(nil)
+	_ interface{ ExitStatus() int } = sshExitError{}
+	_ interface{ ExitCode() int }   = (*osexec.ExitError)(nil)
+)
+
+// localExitError runs a local process that exits with the given code and
+// returns the resulting *exec.ExitError. A zero value of that type is
+// unsuitable as a fixture: it reports ExitCode() == -1, which models a
+// signal-killed process rather than a normal non-zero exit.
+func localExitError(t *testing.T, code int) error {
+	t.Helper()
+	err := osexec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+	require.Error(t, err)
+	var exitErr *osexec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, code, exitErr.ExitCode())
+	return err
+}
+
+// signalKilledError runs a local process that kills itself with SIGKILL and
+// returns the resulting *exec.ExitError, whose ExitCode() is -1.
+func signalKilledError(t *testing.T) error {
+	t.Helper()
+	err := osexec.Command("sh", "-c", "kill -9 $$").Run()
+	require.Error(t, err)
+	var exitErr *osexec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	require.Negative(t, exitErr.ExitCode())
+	return err
+}
+
+func TestPosixStatCommandFailure(t *testing.T) {
+	// A stat that never ran says nothing about the file, so only a stat that ran
+	// on the host and exited non-zero may be reported as fs.ErrNotExist. Every
+	// other failure must surface as itself, with the original cause reachable.
+	cases := []struct {
+		name         string
+		failWith     func(t *testing.T) error
+		wantNotExist bool
+	}{
+		{
+			name:         "remote stat ran and exited 1",
+			failWith:     func(*testing.T) error { return sshExitError{status: 1} },
+			wantNotExist: true,
+		},
+		{
+			name:         "remote command exited 255",
+			failWith:     func(*testing.T) error { return sshExitError{status: 255} },
+			wantNotExist: true,
+		},
+		{
+			name:         "remote command killed by a signal",
+			failWith:     func(*testing.T) error { return sshExitError{status: -1} },
+			wantNotExist: false,
+		},
+		{
+			name: "session could not be started",
+			failWith: func(*testing.T) error {
+				return errors.New("start session: connection lost")
+			},
+			wantNotExist: false,
+		},
+		{
+			name: "connection died mid-command",
+			failWith: func(*testing.T) error {
+				return fmt.Errorf("start session: %w", io.EOF)
+			},
+			wantNotExist: false,
+		},
+		{
+			name:         "local process ran and exited 1",
+			failWith:     func(t *testing.T) error { return localExitError(t, 1) },
+			wantNotExist: true,
+		},
+		{
+			name:         "openssh client could not connect",
+			failWith:     func(t *testing.T) error { return localExitError(t, 255) },
+			wantNotExist: false,
+		},
+		{
+			name:         "local process killed by a signal",
+			failWith:     signalKilledError,
+			wantNotExist: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			failWith := tc.failWith(t)
+
+			mr := rigtest.NewMockRunner()
+			mr.AddCommandSuccess(rigtest.Equal("stat -c %n /"))
+			mr.AddCommandFailure(rigtest.Contains("LC_ALL=C stat -c"), failWith)
+
+			_, err := remotefs.NewPosixFS(mr).Stat("/etc/app.conf")
+			require.Error(t, err)
+
+			if tc.wantNotExist {
+				require.ErrorIs(t, err, fs.ErrNotExist)
+				return
+			}
+			require.NotErrorIs(t, err, fs.ErrNotExist,
+				"a failure that says nothing about the file must not be reported as ErrNotExist")
+			require.ErrorIs(t, err, failWith, "the original cause must stay reachable")
+		})
+	}
+}
+
+func TestPosixStatLocalhost(t *testing.T) {
+	// The compatibility-critical direction, through the real localhost protocol
+	// with no mocks: an existing file stats cleanly and a missing one is
+	// ErrNotExist.
+	if runtime.GOOS == "windows" {
+		t.Skip("PosixFS is never paired with a Windows host")
+	}
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "existing.conf")
+	require.NoError(t, os.WriteFile(existing, []byte("keep me\n"), 0o600))
+
+	conn, err := localhost.NewConnection()
+	require.NoError(t, err)
+	fsys := remotefs.NewPosixFS(cmd.NewExecutor(conn))
+
+	info, err := fsys.Stat(existing)
+	require.NoError(t, err)
+	require.Equal(t, int64(len("keep me\n")), info.Size())
+
+	_, err = fsys.Stat(filepath.Join(dir, "missing.conf"))
+	require.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestPosixReadDirConnectionLost(t *testing.T) {
+	// A find that died mid-command reports a wrapped io.EOF. That is a lost
+	// connection, not an empty or missing directory, and must not collapse into
+	// fs.ErrNotExist.
+	connLost := fmt.Errorf("start session: %w", io.EOF)
+
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandFailure(rigtest.Contains("find"), connLost)
+
+	_, err := remotefs.NewPosixFS(mr).ReadDir("/etc")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, fs.ErrNotExist)
+	require.ErrorIs(t, err, connLost)
 }

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -899,6 +899,13 @@ func TestPosixStatCommandFailure(t *testing.T) {
 			wantNotExist: false,
 		},
 		{
+			// A zero status does not describe a failure, so an error carrying one
+			// did not come from a command that ran and failed.
+			name:         "error carrying a zero exit status",
+			failWith:     func(*testing.T) error { return sshExitError{status: 0} },
+			wantNotExist: false,
+		},
+		{
 			name: "session could not be started",
 			failWith: func(*testing.T) error {
 				return errors.New("start session: connection lost")


### PR DESCRIPTION
PosixFS.Stat collapsed every stat failure into fs.ErrNotExist once statCmd had been initialized, so a dropped session or a session that could not be started answered "the file is not there" about a file that exists and was never looked at. PatchFile with WithCreate branches on that answer to mean "start from an empty base", so one connection blip made it rebuild a remote file from nothing and rename it over content it never read, returning nil.

multiStat now classifies on the exit status carried by the error: only a command that ran on the host and exited non-zero may become ErrNotExist. Every other failure surfaces as itself, with the original cause reachable through errors.Is.

The io.EOF exclusion is dropped as well. A connection dying mid-command produces a wrapped io.EOF, which skipped the error branch entirely and fell through to Stat's zero-results case -- that is the route the data loss actually took, and a fix to the error branch alone leaves it intact. A successful stat leaves scanner.Err() nil, so nothing depended on the exclusion. ReadDir had the same io.EOF hole and is fixed along with it.

The 255 exclusion is deliberately narrowed to the ExitCode() branch, which only the protocols running a local process reach: openssh runs the ssh binary, so a failure to connect is an ordinary non-zero exit of a local process. A status of 255 arriving through ExitStatus() is one the remote host really reported, and stays classified as a command that ran and failed.

Scope: this separates "never ran" from "ran and failed". It does not separate a missing path from a permission failure, because stat exits 1 for both and the command discards stderr.

Fixes #426