### PR TITLE
fix(remotefs): don't treat WinFS stat execution failures as ErrNotExist

### DIFF
--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -63,7 +63,7 @@ func (s *WinFS) Stat(name string) (fs.FileInfo, error) {
 		// An execution failure says nothing about the path. Absence is reported by
 		// a *successful* command that prints the marker handled below, so this
 		// branch must never claim fs.ErrNotExist.
-		return nil, PathErrorf(OpStat, name, "stat: %w", err)
+		return nil, PathError(OpStat, name, err)
 	}
 
 	fi := &winFileInfo{fs: s}

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -60,7 +60,10 @@ var statCmdTemplate = `if (Test-Path -LiteralPath %[1]s) {
 func (s *WinFS) Stat(name string) (fs.FileInfo, error) {
 	out, err := s.ExecOutput(fmt.Sprintf(statCmdTemplate, ps.DoubleQuotePath(name)), cmd.PS())
 	if err != nil {
-		return nil, PathErrorf(OpStat, name, "%w: %w", err, fs.ErrNotExist)
+		// An execution failure says nothing about the path. Absence is reported by
+		// a *successful* command that prints the marker handled below, so this
+		// branch must never claim fs.ErrNotExist.
+		return nil, PathErrorf(OpStat, name, "stat: %w", err)
 	}
 
 	fi := &winFileInfo{fs: s}

--- a/remotefs/winfs_test.go
+++ b/remotefs/winfs_test.go
@@ -370,3 +370,63 @@ func TestWindowsShellQuote(t *testing.T) {
 		require.Equal(t, tc.want, fs.ShellQuote(tc.input), "input: %q", tc.input)
 	}
 }
+
+func TestWindowsStat(t *testing.T) {
+	// A missing path is reported by a *successful* stat command that prints the
+	// {"Err":"does not exist"} marker, so an execution failure is never evidence
+	// that the path is absent.
+	const statOutput = `{"Err":"does not exist"}`
+
+	t.Run("missing file is ErrNotExist", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), statOutput)
+
+		_, err := remotefs.NewWindowsFS(mr).Stat("C:\\app\\missing.conf")
+		require.ErrorIs(t, err, fs.ErrNotExist)
+	})
+
+	for _, tc := range []struct {
+		name     string
+		failWith error
+	}{
+		{"not connected", errors.New("start command: runner start command: not connected")},
+		{"connection dropped", fmt.Errorf("create shell: %w", io.EOF)},
+		{"command failed on the host", errors.New("access is denied")},
+	} {
+		t.Run("execution failure: "+tc.name, func(t *testing.T) {
+			mr := rigtest.NewMockRunner()
+			mr.Windows = true
+			mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), tc.failWith)
+
+			_, err := remotefs.NewWindowsFS(mr).Stat("C:\\app\\existing.conf")
+			require.Error(t, err)
+			require.NotErrorIs(t, err, fs.ErrNotExist,
+				"a failure to run the stat command is not evidence that the path is absent")
+			require.ErrorIs(t, err, tc.failWith, "the original cause must stay reachable")
+		})
+	}
+}
+
+// TestWindowsPatchFileStatFailure is the data-loss regression guard: told the
+// file is absent, PatchFile with WithCreate rebuilds it from an empty base and
+// renames the result over content it never read.
+func TestWindowsPatchFileStatFailure(t *testing.T) {
+	connLost := errors.New("start command: runner start command: not connected")
+
+	mr := rigtest.NewMockRunner()
+	mr.Windows = true
+	mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), connLost)
+
+	err := remotefs.PatchFile(remotefs.NewWindowsFS(mr), "C:\\app\\existing.conf", []remotefs.Patch{
+		remotefs.AppendIfMissing("new_setting = 1"),
+	}, remotefs.WithCreate(0o644))
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, connLost)
+	require.NotErrorIs(t, err, fs.ErrNotExist)
+	// The decisive assertion: the failed stat is the only command sent. Checking
+	// the returned error alone would also pass against the unfixed code, which
+	// fails later on the write it should never have attempted.
+	require.Equal(t, 1, mr.Len(), "nothing may be attempted after a stat that never ran: %v", mr.Commands())
+}


### PR DESCRIPTION
WinFS.Stat mapped every failure of the PowerShell stat command onto fs.ErrNotExist, so a WinRM request that could not be made or a dropped connection came back satisfying errors.Is(err, fs.ErrNotExist) for a file that exists and was never looked at. PatchFile with WithCreate branches on that answer to mean "start from an empty base", so one disturbed request made it rebuild a remote file from nothing and rename it over content it never read, returning nil.

No heuristic is needed here: the stat script reports a missing path through a *successful* command that prints {"Err":"does not exist"}, and Stat already handles that result separately further down. The exec-failure branch therefore has no evidence for the claim and now surfaces the cause as itself.

OpenFile is the one in-tree caller whose behaviour changes. It swallowed the failure through its !errors.Is(err, fs.ErrNotExist) guard and went on to build the wrong handle type, reporting "cannot open directory" for a dropped connection; it now reports the connection failure.

Scope: this separates a transport or command-execution failure from the script's explicit "does not exist" result. It does not separate a genuinely absent path from one Test-Path cannot see for permission reasons -- both take the marker branch -- which would require the script to report why.

Fixes #427