### PR TITLE
fix(remotefs): inspect the stat error in WinFS Remove and RemoveAll

### DIFF
--- a/remotefs/patchfile_test.go
+++ b/remotefs/patchfile_test.go
@@ -50,6 +50,7 @@ func (f *patchFS) WriteFile(_ string, data []byte, _ fs.FileMode) error {
 func (f *patchFS) Chmod(_ string, mode fs.FileMode) error { f.writtenPerm = mode; return nil }
 func (f *patchFS) Rename(_, _ string) error               { return nil }
 func (f *patchFS) Remove(_ string) error                  { return nil }
+func (f *patchFS) RemoveAll(_ string) error               { return nil }
 
 // Unused FS methods — panic on call so any unexpected usage is caught immediately.
 func (f *patchFS) Open(_ string) (fs.File, error)          { panic("not implemented") }
@@ -59,7 +60,6 @@ func (f *patchFS) OpenFile(_ string, _ int, _ fs.FileMode) (remotefs.File, error
 }
 func (f *patchFS) Sha256(_ string) (string, error)                       { panic("not implemented") }
 func (f *patchFS) DownloadURL(_, _ string) error                         { panic("not implemented") }
-func (f *patchFS) RemoveAll(_ string) error                              { panic("not implemented") }
 func (f *patchFS) Mkdir(_ string, _ fs.FileMode) error                   { panic("not implemented") }
 func (f *patchFS) MkdirTemp(_, _ string) (string, error)                 { panic("not implemented") }
 func (f *patchFS) FileExist(_ string) bool                               { panic("not implemented") }

--- a/remotefs/patherror.go
+++ b/remotefs/patherror.go
@@ -1,6 +1,7 @@
 package remotefs
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 )
@@ -14,4 +15,15 @@ func PathError(op, path string, err error) *fs.PathError {
 // sprintf style format string and arguments.
 func PathErrorf(op, path string, template string, args ...any) *fs.PathError {
 	return PathError(op, path, fmt.Errorf(template, args...)) //nolint:err113
+}
+
+// pathErrorCause unwraps a *fs.PathError so that an operation implemented on
+// top of another can report itself without nesting a second one. Nesting gets
+// the outer Op right but repeats the path in the message, as in
+// "remove C:\\x: stat C:\\x: ...".
+func pathErrorCause(err error) error {
+	if pathErr, ok := errors.AsType[*fs.PathError](err); ok {
+		return pathErr.Err
+	}
+	return err
 }

--- a/remotefs/patherror_test.go
+++ b/remotefs/patherror_test.go
@@ -1,0 +1,20 @@
+package remotefs_test
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// requirePathErrorOp asserts that err carries a *fs.PathError naming op. The Op
+// a caller reads must be the call it made, not one of the commands used to
+// carry it out -- Remove reporting "stat" would name an operation the caller
+// never asked for.
+func requirePathErrorOp(t *testing.T, err error, op string) {
+	t.Helper()
+	var pathErr *fs.PathError
+	require.ErrorAs(t, err, &pathErr, "the failure must be reported as an fs.PathError")
+	require.Equal(t, op, pathErr.Op, "fs.PathError.Op must name the operation the caller invoked")
+	require.Error(t, pathErr.Err, "the cause must be preserved under the PathError")
+}

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -797,9 +797,9 @@ func (s *PosixFS) Remove(name string) error {
 	// stdin is a terminal.
 	if err := s.Exec(sh.Command("rm", "--", name)); err != nil {
 		if isNotExist(err) {
-			return PathError("remove", name, fs.ErrNotExist)
+			return PathError(OpRemove, name, fs.ErrNotExist)
 		}
-		return fmt.Errorf("delete %s: %w", name, err)
+		return PathError(OpRemove, name, err)
 	}
 	return nil
 }
@@ -834,7 +834,7 @@ func isNotExist(err error) bool {
 // exist is not an error, matching os.RemoveAll.
 func (s *PosixFS) RemoveAll(name string) error {
 	if err := s.Exec(sh.Command("rm", "-rf", name)); err != nil {
-		return fmt.Errorf("remove all %s: %w", name, err)
+		return PathError(OpRemoveAll, name, err)
 	}
 	return nil
 }

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -784,9 +784,21 @@ func (s *PosixFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	return res, err
 }
 
-// Remove deletes the named file or (empty) directory.
+// Remove deletes the named file. A path that does not exist is an error,
+// matching os.Remove.
+//
+// Unlike os.Remove it does not delete an empty directory: rm refuses one
+// without an option POSIX does not require it to have. Use RemoveAll for a
+// directory.
 func (s *PosixFS) Remove(name string) error {
-	if err := s.Exec(sh.Command("rm", "-f", name)); err != nil {
+	// Deliberately not "rm -f": -f makes a missing path succeed, which the OS
+	// interface, modeled after the os package, says it must not. rm still does
+	// not prompt for a write-protected file here, because it only does so when
+	// stdin is a terminal.
+	if err := s.Exec(sh.Command("rm", "--", name)); err != nil {
+		if isNotExist(err) {
+			return PathError("remove", name, fs.ErrNotExist)
+		}
 		return fmt.Errorf("delete %s: %w", name, err)
 	}
 	return nil
@@ -818,7 +830,8 @@ func isNotExist(err error) bool {
 	return strings.Contains(err.Error(), errNoSuchFile)
 }
 
-// RemoveAll removes path and any children it contains.
+// RemoveAll removes path and any children it contains. A path that does not
+// exist is not an error, matching os.RemoveAll.
 func (s *PosixFS) RemoveAll(name string) error {
 	if err := s.Exec(sh.Command("rm", "-rf", name)); err != nil {
 		return fmt.Errorf("remove all %s: %w", name, err)

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -403,6 +403,45 @@ func TestPosixMkdirAll(t *testing.T) {
 	}
 }
 
+func TestPosixRemove(t *testing.T) {
+	// The OS interface is modeled after the os package, so a missing path is an
+	// error for Remove and not for RemoveAll -- on both FS implementations.
+	const name = "/tmp/app/missing.conf"
+
+	t.Run("existing file", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandSuccess(rigtest.Contains("rm"))
+		require.NoError(t, remotefs.NewPosixFS(mr).Remove(name))
+		// -f would make a missing path succeed, which os.Remove does not.
+		require.NoError(t, mr.Received(rigtest.Equal(`rm -- /tmp/app/missing.conf`)))
+	})
+
+	t.Run("missing path is an error", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommand(rigtest.Contains("rm"), func(a *rigtest.A) error {
+			fmt.Fprintf(a.Stderr, "rm: cannot remove '%s': No such file or directory\n", name)
+			return errors.New("exit status 1")
+		})
+		err := remotefs.NewPosixFS(mr).Remove(name)
+		require.ErrorIs(t, err, fs.ErrNotExist, "os.Remove errors on a missing path")
+	})
+
+	t.Run("other failures keep their cause", func(t *testing.T) {
+		denied := errors.New("exit status 1")
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Contains("rm"), denied)
+		err := remotefs.NewPosixFS(mr).Remove(name)
+		require.ErrorIs(t, err, denied)
+		require.NotErrorIs(t, err, fs.ErrNotExist)
+	})
+
+	t.Run("RemoveAll accepts a missing path", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandSuccess(rigtest.Contains("rm -rf"))
+		require.NoError(t, remotefs.NewPosixFS(mr).RemoveAll(name))
+	})
+}
+
 func TestPosixOpenFileCreate(t *testing.T) {
 	for _, tc := range modeCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -424,6 +424,7 @@ func TestPosixRemove(t *testing.T) {
 		})
 		err := remotefs.NewPosixFS(mr).Remove(name)
 		require.ErrorIs(t, err, fs.ErrNotExist, "os.Remove errors on a missing path")
+		requirePathErrorOp(t, err, remotefs.OpRemove)
 	})
 
 	t.Run("other failures keep their cause", func(t *testing.T) {
@@ -433,6 +434,7 @@ func TestPosixRemove(t *testing.T) {
 		err := remotefs.NewPosixFS(mr).Remove(name)
 		require.ErrorIs(t, err, denied)
 		require.NotErrorIs(t, err, fs.ErrNotExist)
+		requirePathErrorOp(t, err, remotefs.OpRemove)
 	})
 
 	t.Run("RemoveAll accepts a missing path", func(t *testing.T) {

--- a/remotefs/upload.go
+++ b/remotefs/upload.go
@@ -93,7 +93,9 @@ func Upload(fsys FS, src, dst string, opts ...UploadOption) error {
 	if err != nil {
 		return fmt.Errorf("create temp file for upload: %w", err)
 	}
-	defer func() { _ = fsys.Remove(tmpPath) }()
+	// RemoveAll rather than Remove: on the success path the rename has already
+	// moved tmpPath away, and only RemoveAll accepts a path that is not there.
+	defer func() { _ = fsys.RemoveAll(tmpPath) }()
 
 	if err := copyAndVerifyUpload(fsys, tmpPath, local); err != nil {
 		return err

--- a/remotefs/upload_test.go
+++ b/remotefs/upload_test.go
@@ -76,12 +76,18 @@ func (f *uploadFS) Remove(p string) error {
 	return nil
 }
 
+// RemoveAll is what Upload's cleanup defer calls, so that a temp file already
+// renamed away is not an error.
+func (f *uploadFS) RemoveAll(p string) error {
+	f.removedPaths = append(f.removedPaths, p)
+	return nil
+}
+
 // FS interface stubs — not exercised by Upload.
 func (f *uploadFS) Open(_ string) (fs.File, error)                        { panic("not implemented") }
 func (f *uploadFS) Stat(_ string) (fs.FileInfo, error)                    { panic("not implemented") }
 func (f *uploadFS) ReadFile(_ string) ([]byte, error)                     { panic("not implemented") }
 func (f *uploadFS) ReadDir(_ string) ([]fs.DirEntry, error)               { panic("not implemented") }
-func (f *uploadFS) RemoveAll(_ string) error                              { panic("not implemented") }
 func (f *uploadFS) Mkdir(_ string, _ fs.FileMode) error                   { panic("not implemented") }
 func (f *uploadFS) MkdirAll(_ string, _ fs.FileMode) error                { panic("not implemented") }
 func (f *uploadFS) MkdirTemp(_, _ string) (string, error)                 { panic("not implemented") }

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -109,26 +109,45 @@ func (s *WinFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	return dir.ReadDir(-1)
 }
 
-// Remove deletes the named file or (empty) directory.
+// Remove deletes the named file or (empty) directory. A path that does not
+// exist is an error, matching os.Remove.
 func (s *WinFS) Remove(name string) error {
-	if existing, err := s.Stat(name); err == nil && existing.IsDir() {
+	existing, err := s.Stat(name)
+	if err != nil {
+		// Covers both a path that is genuinely absent -- an error for os.Remove --
+		// and a stat that could not be performed. Neither may fall through to del:
+		// a transport failure is not evidence of anything about the path.
+		return fmt.Errorf("remove %s: %w", name, err)
+	}
+	if existing.IsDir() {
 		return s.removeDir(name)
 	}
 
-	if err := s.Exec("cmd.exe /c del " + ps.DoubleQuotePath(name)); err != nil {
-		return fmt.Errorf("remove %s: %w", name, err)
-	}
-
-	return nil
+	return s.removeFile(name)
 }
 
-// RemoveAll deletes the named file or directory and all its child items.
+// RemoveAll deletes the named file or directory and all its child items. A path
+// that does not exist is not an error, matching os.RemoveAll.
 func (s *WinFS) RemoveAll(name string) error {
-	if existing, err := s.Stat(name); err == nil && existing.IsDir() {
+	existing, err := s.Stat(name)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("remove all %s: %w", name, err)
+	case existing.IsDir():
 		return s.removeDirAll(name)
 	}
 
-	return s.Remove(name)
+	return s.removeFile(name)
+}
+
+func (s *WinFS) removeFile(name string) error {
+	if err := s.Exec("cmd.exe /c del " + ps.DoubleQuotePath(name)); err != nil {
+		return fmt.Errorf("del %s: %w", name, err)
+	}
+
+	return nil
 }
 
 func (s *WinFS) removeDir(name string) error {

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -111,40 +111,62 @@ func (s *WinFS) ReadDir(name string) ([]fs.DirEntry, error) {
 
 // Remove deletes the named file or (empty) directory. A path that does not
 // exist is an error, matching os.Remove.
+//
+// Every failure is reported as a *fs.PathError whose Op is OpRemove, so a
+// caller reading it sees the call it made rather than one of the commands used
+// to carry it out.
 func (s *WinFS) Remove(name string) error {
 	existing, err := s.Stat(name)
 	if err != nil {
 		// Covers both a path that is genuinely absent -- an error for os.Remove --
 		// and a stat that could not be performed. Neither may fall through to del:
 		// a transport failure is not evidence of anything about the path.
-		return fmt.Errorf("remove %s: %w", name, err)
+		return PathError(OpRemove, name, pathErrorCause(err))
 	}
 	if existing.IsDir() {
-		return s.removeDir(name)
+		err = s.removeDir(name)
+	} else {
+		err = s.removeFile(name)
+	}
+	if err != nil {
+		return PathError(OpRemove, name, err)
 	}
 
-	return s.removeFile(name)
+	return nil
 }
 
 // RemoveAll deletes the named file or directory and all its child items. A path
 // that does not exist is not an error, matching os.RemoveAll.
+//
+// Failures are reported as a *fs.PathError whose Op is OpRemoveAll, on the same
+// reasoning as Remove.
 func (s *WinFS) RemoveAll(name string) error {
 	existing, err := s.Stat(name)
-	switch {
-	case errors.Is(err, fs.ErrNotExist):
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil
-	case err != nil:
-		return fmt.Errorf("remove all %s: %w", name, err)
-	case existing.IsDir():
-		return s.removeDirAll(name)
+	}
+	if err != nil {
+		return PathError(OpRemoveAll, name, pathErrorCause(err))
+	}
+	if existing.IsDir() {
+		err = s.removeDirAll(name)
+	} else {
+		err = s.removeFile(name)
+	}
+	if err != nil {
+		return PathError(OpRemoveAll, name, err)
 	}
 
-	return s.removeFile(name)
+	return nil
 }
+
+// The helpers below name the command that failed but not the path: their
+// callers wrap them in a PathError that carries it, and repeating it would put
+// it in the message twice.
 
 func (s *WinFS) removeFile(name string) error {
 	if err := s.Exec("cmd.exe /c del " + ps.DoubleQuotePath(name)); err != nil {
-		return fmt.Errorf("del %s: %w", name, err)
+		return fmt.Errorf("del: %w", err)
 	}
 
 	return nil
@@ -152,14 +174,14 @@ func (s *WinFS) removeFile(name string) error {
 
 func (s *WinFS) removeDir(name string) error {
 	if err := s.Exec("cmd.exe /c rmdir /q " + ps.DoubleQuotePath(name)); err != nil {
-		return fmt.Errorf("rmdir %s: %w", name, err)
+		return fmt.Errorf("rmdir: %w", err)
 	}
 	return nil
 }
 
 func (s *WinFS) removeDirAll(name string) error {
 	if err := s.Exec("cmd.exe /c rmdir /s /q " + ps.DoubleQuotePath(name)); err != nil {
-		return fmt.Errorf("rmdir %s: %w", name, err)
+		return fmt.Errorf("rmdir /s: %w", err)
 	}
 
 	return nil

--- a/remotefs/winfs_test.go
+++ b/remotefs/winfs_test.go
@@ -476,6 +476,7 @@ func TestWindowsRemove(t *testing.T) {
 		mr := newRunner(statMissingJSON, nil)
 		err := remotefs.NewWindowsFS(mr).Remove(name)
 		require.ErrorIs(t, err, fs.ErrNotExist, "os.Remove errors on a missing path")
+		requirePathErrorOp(t, err, remotefs.OpRemove)
 		require.NoError(t, mr.NotReceived(rigtest.Contains("del")))
 	})
 
@@ -485,6 +486,7 @@ func TestWindowsRemove(t *testing.T) {
 		err := remotefs.NewWindowsFS(mr).Remove(name)
 		require.ErrorIs(t, err, connLost, "the transport cause must stay reachable")
 		require.NotErrorIs(t, err, fs.ErrNotExist)
+		requirePathErrorOp(t, err, remotefs.OpRemove)
 		require.NoError(t, mr.NotReceived(rigtest.Contains("del")))
 		require.NoError(t, mr.NotReceived(rigtest.Contains("rmdir")))
 	})
@@ -493,7 +495,9 @@ func TestWindowsRemove(t *testing.T) {
 		delFailed := errors.New("exit code 1")
 		mr := newRunner(statJSON(name, "-a----"), nil)
 		mr.AddCommandFailure(rigtest.Contains("del"), delFailed)
-		require.ErrorIs(t, remotefs.NewWindowsFS(mr).Remove(name), delFailed)
+		err := remotefs.NewWindowsFS(mr).Remove(name)
+		require.ErrorIs(t, err, delFailed)
+		requirePathErrorOp(t, err, remotefs.OpRemove)
 	})
 }
 
@@ -542,6 +546,7 @@ func TestWindowsRemoveAll(t *testing.T) {
 		require.ErrorIs(t, err, connLost, "the transport cause must stay reachable")
 		require.NotErrorIs(t, err, fs.ErrNotExist,
 			"a stat that never ran must not read as 'nothing to remove'")
+		requirePathErrorOp(t, err, remotefs.OpRemoveAll)
 		// The regression guard: the tree survived and the caller was told a
 		// non-recursive rmdir found it non-empty, never mentioning the connection.
 		require.NoError(t, mr.NotReceived(rigtest.Contains("rmdir")))
@@ -552,6 +557,8 @@ func TestWindowsRemoveAll(t *testing.T) {
 		rmdirFailed := errors.New("exit code 145")
 		mr := newRunner(statJSON(name, "d-----"), nil)
 		mr.AddCommandFailure(rigtest.Contains("rmdir"), rmdirFailed)
-		require.ErrorIs(t, remotefs.NewWindowsFS(mr).RemoveAll(name), rmdirFailed)
+		err := remotefs.NewWindowsFS(mr).RemoveAll(name)
+		require.ErrorIs(t, err, rmdirFailed)
+		requirePathErrorOp(t, err, remotefs.OpRemoveAll)
 	})
 }

--- a/remotefs/winfs_test.go
+++ b/remotefs/winfs_test.go
@@ -430,3 +430,128 @@ func TestWindowsPatchFileStatFailure(t *testing.T) {
 	// fails later on the write it should never have attempted.
 	require.Equal(t, 1, mr.Len(), "nothing may be attempted after a stat that never ran: %v", mr.Commands())
 }
+
+// statJSON is the stat output for an existing path. mode is the PowerShell Mode
+// string, whose leading "d" marks a directory.
+func statJSON(name, mode string) string {
+	return fmt.Sprintf(
+		`{"Name":%q,"FullName":%q,"Mode":%q,"Length":0,"IsReadOnly":false,"LastWriteTime":"\/Date(1700000000000)\/"}`,
+		name, name, mode,
+	)
+}
+
+const statMissingJSON = `{"Err":"does not exist"}`
+
+func TestWindowsRemove(t *testing.T) {
+	// Remove must never decide "not a directory" from a stat it could not
+	// perform, and never fall through to del on a stat failure.
+	const name = `C:\app\tree`
+
+	newRunner := func(statOut string, statErr error) *rigtest.MockRunner {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		if statErr != nil {
+			mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), statErr)
+		} else {
+			mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), statOut)
+		}
+		return mr
+	}
+
+	t.Run("existing file", func(t *testing.T) {
+		mr := newRunner(statJSON(name, "-a----"), nil)
+		mr.AddCommandSuccess(rigtest.Contains("del"))
+		require.NoError(t, remotefs.NewWindowsFS(mr).Remove(name))
+		require.NoError(t, mr.Received(rigtest.Contains(`del "C:\app\tree"`)))
+	})
+
+	t.Run("existing directory", func(t *testing.T) {
+		mr := newRunner(statJSON(name, "d-----"), nil)
+		mr.AddCommandSuccess(rigtest.Contains("rmdir"))
+		require.NoError(t, remotefs.NewWindowsFS(mr).Remove(name))
+		require.NoError(t, mr.Received(rigtest.Contains(`rmdir /q "C:\app\tree"`)))
+	})
+
+	t.Run("missing path is an error", func(t *testing.T) {
+		mr := newRunner(statMissingJSON, nil)
+		err := remotefs.NewWindowsFS(mr).Remove(name)
+		require.ErrorIs(t, err, fs.ErrNotExist, "os.Remove errors on a missing path")
+		require.NoError(t, mr.NotReceived(rigtest.Contains("del")))
+	})
+
+	t.Run("stat transport failure", func(t *testing.T) {
+		connLost := errors.New("start command: runner start command: not connected")
+		mr := newRunner("", connLost)
+		err := remotefs.NewWindowsFS(mr).Remove(name)
+		require.ErrorIs(t, err, connLost, "the transport cause must stay reachable")
+		require.NotErrorIs(t, err, fs.ErrNotExist)
+		require.NoError(t, mr.NotReceived(rigtest.Contains("del")))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("rmdir")))
+	})
+
+	t.Run("delete command failure", func(t *testing.T) {
+		delFailed := errors.New("exit code 1")
+		mr := newRunner(statJSON(name, "-a----"), nil)
+		mr.AddCommandFailure(rigtest.Contains("del"), delFailed)
+		require.ErrorIs(t, remotefs.NewWindowsFS(mr).Remove(name), delFailed)
+	})
+}
+
+func TestWindowsRemoveAll(t *testing.T) {
+	// RemoveAll must reach the recursive delete whenever the path really is a
+	// directory, and must never fall back to the non-recursive rmdir -- or return
+	// success -- because the stat could not be performed.
+	const name = `C:\app\tree`
+
+	newRunner := func(statOut string, statErr error) *rigtest.MockRunner {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		if statErr != nil {
+			mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), statErr)
+		} else {
+			mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), statOut)
+		}
+		return mr
+	}
+
+	t.Run("existing file", func(t *testing.T) {
+		mr := newRunner(statJSON(name, "-a----"), nil)
+		mr.AddCommandSuccess(rigtest.Contains("del"))
+		require.NoError(t, remotefs.NewWindowsFS(mr).RemoveAll(name))
+		require.NoError(t, mr.Received(rigtest.Contains(`del "C:\app\tree"`)))
+	})
+
+	t.Run("populated directory", func(t *testing.T) {
+		mr := newRunner(statJSON(name, "d-----"), nil)
+		mr.AddCommandSuccess(rigtest.Contains("rmdir"))
+		require.NoError(t, remotefs.NewWindowsFS(mr).RemoveAll(name))
+		require.NoError(t, mr.Received(rigtest.Contains(`rmdir /s /q "C:\app\tree"`)))
+	})
+
+	t.Run("missing path is not an error", func(t *testing.T) {
+		mr := newRunner(statMissingJSON, nil)
+		require.NoError(t, remotefs.NewWindowsFS(mr).RemoveAll(name), "os.RemoveAll accepts a missing path")
+		require.NoError(t, mr.NotReceived(rigtest.Contains("del")))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("rmdir")))
+	})
+
+	t.Run("stat transport failure", func(t *testing.T) {
+		connLost := errors.New("start command: runner start command: not connected")
+		mr := newRunner("", connLost)
+		err := remotefs.NewWindowsFS(mr).RemoveAll(name)
+		require.ErrorIs(t, err, connLost, "the transport cause must stay reachable")
+		require.NotErrorIs(t, err, fs.ErrNotExist,
+			"a stat that never ran must not read as 'nothing to remove'")
+		// The regression guard: the tree survived and the caller was told a
+		// non-recursive rmdir found it non-empty, never mentioning the connection.
+		require.NoError(t, mr.NotReceived(rigtest.Contains("rmdir")))
+		require.NoError(t, mr.NotReceived(rigtest.Contains("del")))
+	})
+
+	t.Run("recursive delete failure", func(t *testing.T) {
+		rmdirFailed := errors.New("exit code 145")
+		mr := newRunner(statJSON(name, "d-----"), nil)
+		mr.AddCommandFailure(rigtest.Contains("rmdir"), rmdirFailed)
+		require.ErrorIs(t, remotefs.NewWindowsFS(mr).RemoveAll(name), rmdirFailed)
+	})
+}

--- a/remotefs/withname.go
+++ b/remotefs/withname.go
@@ -4,14 +4,16 @@ import "io/fs"
 
 // Operation constants for remote filesystem operations.
 const (
-	OpClose    = "close"     // OpClose Close operation
-	OpOpen     = "open"      // OpOpen Open operation
-	OpRead     = "read"      // OpRead Read operation
-	OpSeek     = "seek"      // OpSeek Seek operation
-	OpStat     = "stat"      // OpStat Stat operation
-	OpWrite    = "write"     // OpWrite Write operation
-	OpCopyTo   = "copy-to"   // OpCopyTo CopyTo operation
-	OpCopyFrom = "copy-from" // OpCopyFrom CopyFrom operation
+	OpClose     = "close"      // OpClose Close operation
+	OpOpen      = "open"       // OpOpen Open operation
+	OpRead      = "read"       // OpRead Read operation
+	OpRemove    = "remove"     // OpRemove Remove operation
+	OpRemoveAll = "remove all" // OpRemoveAll RemoveAll operation
+	OpSeek      = "seek"       // OpSeek Seek operation
+	OpStat      = "stat"       // OpStat Stat operation
+	OpWrite     = "write"      // OpWrite Write operation
+	OpCopyTo    = "copy-to"    // OpCopyTo CopyTo operation
+	OpCopyFrom  = "copy-from"  // OpCopyFrom CopyFrom operation
 )
 
 type withPath struct {

--- a/remotefs/writefileatomic.go
+++ b/remotefs/writefileatomic.go
@@ -8,7 +8,7 @@ import (
 // WriteFileAtomic writes data to path atomically: a temp file is created in the
 // same directory, written with restricted permissions, chmod'd to perm, then
 // renamed into place. Parent directories are created as needed. Cleanup of the
-// temp file is always attempted; if Remove fails the error is ignored.
+// temp file is always attempted; if it fails the error is ignored.
 func WriteFileAtomic(host OS, path string, data []byte, perm fs.FileMode) error {
 	dir := host.Dir(path)
 	if err := host.MkdirAll(dir, 0o755); err != nil {
@@ -18,7 +18,9 @@ func WriteFileAtomic(host OS, path string, data []byte, perm fs.FileMode) error 
 	if err != nil {
 		return fmt.Errorf("write-file-atomic %s: %w", path, err)
 	}
-	defer func() { _ = host.Remove(tmp) }()
+	// RemoveAll rather than Remove: on the success path the rename has already
+	// moved tmp away, and only RemoveAll accepts a path that is not there.
+	defer func() { _ = host.RemoveAll(tmp) }()
 	if err := host.WriteFile(tmp, data, 0o600); err != nil {
 		return fmt.Errorf("write-file-atomic %s: %w", path, err)
 	}

--- a/remotefs/writefileatomic_test.go
+++ b/remotefs/writefileatomic_test.go
@@ -36,8 +36,14 @@ func (o *atomicOS) Chmod(_ string, _ fs.FileMode) error               { return o
 func (o *atomicOS) Rename(_, _ string) error                          { return o.renameErr }
 func (o *atomicOS) Remove(p string) error                             { o.removedPaths = append(o.removedPaths, p); return nil }
 
+// RemoveAll is what the cleanup defer calls, so that a temp file already
+// renamed away is not an error.
+func (o *atomicOS) RemoveAll(p string) error {
+	o.removedPaths = append(o.removedPaths, p)
+	return nil
+}
+
 // Unused methods — panic on call so misuse is caught immediately.
-func (o *atomicOS) RemoveAll(_ string) error                              { panic("not implemented") }
 func (o *atomicOS) Mkdir(_ string, _ fs.FileMode) error                   { panic("not implemented") }
 func (o *atomicOS) MkdirTemp(_, _ string) (string, error)                 { panic("not implemented") }
 func (o *atomicOS) FileExist(_ string) bool                               { panic("not implemented") }
@@ -80,9 +86,9 @@ func TestWriteFileAtomic(t *testing.T) {
 		o := &atomicOS{createTempPath: tmp}
 		err := remotefs.WriteFileAtomic(o, target, data, 0o755)
 		require.NoError(t, err)
-		// After a successful rename the temp path no longer exists; Remove is
-		// still called by defer but the error is ignored.
-		require.Contains(t, o.removedPaths, tmp, "deferred Remove must be called")
+		// After a successful rename the temp path no longer exists, which is why
+		// the defer calls RemoveAll: it accepts a path that is not there.
+		require.Contains(t, o.removedPaths, tmp, "deferred RemoveAll must be called")
 	})
 
 	t.Run("write failure cleans up temp", func(t *testing.T) {
@@ -140,4 +146,9 @@ func TestWriteFileAtomicPosix(t *testing.T) {
 	require.NoError(t, mr.Received(rigtest.Contains("mktemp")))
 	require.NoError(t, mr.Received(rigtest.Contains("chmod")))
 	require.NoError(t, mr.Received(rigtest.Contains("mv -f")))
+	// The rename has moved the temp file away by the time the cleanup defer runs,
+	// so the cleanup must be the one that tolerates a path that is not there.
+	// "rm --" would fail on every successful write.
+	require.NoError(t, mr.Received(rigtest.Contains("rm -rf")))
+	require.NoError(t, mr.NotReceived(rigtest.Contains("rm --")))
 }


### PR DESCRIPTION
Both decided whether a path is a directory with `err == nil` on a Stat call and never looked at the error, so any stat failure read as "not a directory". For RemoveAll on a populated directory that skipped the recursive delete, fell through to Remove, and ran the non-recursive rmdir instead: the tree survived and the caller was told "the directory is not empty" by the one function whose purpose is deleting non-empty directories, with nothing in the error mentioning the connection.

Both now branch on what the error actually says, following the os package:

  - path is a file            -> del
  - path is a directory       -> rmdir, recursive for RemoveAll
  - path does not exist       -> error for Remove, nil for RemoveAll
  - stat failed at transport  -> propagate, never fall through to del

The del is factored into removeFile so RemoveAll no longer reaches it via Remove, which re-stat'ed the same path.

Behaviour change: Remove on a missing path is now an error, matching os.Remove, where del previously exited zero and the call returned nil. Every in-tree caller either discards that error or removes a path it just created.

Prerequisite carried along: this also contains the one-line WinFS.Stat fix from #427, which stops an execution failure being reported as fs.ErrNotExist. It is required here rather than optional -- RemoveAll now treats ErrNotExist as "nothing to remove", so without it a dropped connection would return nil and turn today's loud failure into a silent one. Drop this hunk if #427 has already landed.

Fixes #428