### PR TITLE
fix(cmd,remotefs): classify ErrNotExist on the full stderr, not the m…

### DIFF
--- a/cmd/executor.go
+++ b/cmd/executor.go
@@ -349,17 +349,19 @@ type waiterWrapper struct {
 
 var xmlTagRe = regexp.MustCompile(`<.+?>`)
 
-func formatStderr(stderr string, isWindows bool) string {
-	if stderr != "" {
-		stderr = strings.TrimSpace(strings.ReplaceAll(stderr, "\n", " "))
-		if isWindows {
-			stderr = strings.ReplaceAll(stderr, "\r", "")
-			stderr = strings.TrimPrefix(stderr, "#<CLIXML")
-			stderr = xmlTagRe.ReplaceAllString(stderr, "")
-		}
-		if len(stderr) > 100 {
-			stderr = stderr[:97] + "..."
-		}
+// cleanStderr collapses a command's stderr into a single line and strips the
+// CLIXML framing PowerShell wraps its error records in. It deliberately does not
+// shorten the result: that happens in [ProcessError.Error], so the full output
+// stays available to callers through [StderrOf].
+func cleanStderr(stderr string, isWindows bool) string {
+	if stderr == "" {
+		return ""
+	}
+	stderr = strings.TrimSpace(strings.ReplaceAll(stderr, "\n", " "))
+	if isWindows {
+		stderr = strings.ReplaceAll(stderr, "\r", "")
+		stderr = strings.TrimPrefix(stderr, "#<CLIXML")
+		stderr = xmlTagRe.ReplaceAllString(stderr, "")
 	}
 	return stderr
 }
@@ -373,17 +375,13 @@ func (w *waiterWrapper) Wait() error {
 		_ = c.Close()
 	}
 
-	stderr := formatStderr(w.opts.ErrString(), w.isWindows)
+	stderr := cleanStderr(w.opts.ErrString(), w.isWindows)
 	if waitErr == nil && w.isWindows && !w.opts.AllowWinStderr() && len(stderr) > 0 {
 		waitErr = ErrWroteStderr
 	}
 	var result error
 	if waitErr != nil {
-		if len(stderr) > 0 {
-			result = fmt.Errorf("process finished with error: %w (%s)", waitErr, stderr)
-		} else {
-			result = fmt.Errorf("process finished with error: %w", waitErr)
-		}
+		result = &ProcessError{err: waitErr, stderr: stderr}
 	}
 	if w.tracer != nil {
 		w.tracer.ProcessFinished(w.host, w.formatted, time.Since(w.started), result)

--- a/cmd/processerror.go
+++ b/cmd/processerror.go
@@ -26,9 +26,9 @@ type ProcessError struct {
 // form of the command's stderr when it wrote any.
 func (e *ProcessError) Error() string {
 	if e.stderr == "" {
-		return fmt.Sprintf("process finished with error: %s", e.err)
+		return fmt.Sprintf("process finished with error: %v", e.err)
 	}
-	return fmt.Sprintf("process finished with error: %s (%s)", e.err, truncateStderr(e.stderr))
+	return fmt.Sprintf("process finished with error: %v (%s)", e.err, truncateStderr(e.stderr))
 }
 
 // Unwrap returns the error the command finished with.

--- a/cmd/processerror.go
+++ b/cmd/processerror.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+)
+
+// stderrMessageMax is how much of a command's stderr the error message carries.
+// The limit keeps a single log line readable; the output is not lost, it stays
+// available in full through [ProcessError.Stderr].
+const stderrMessageMax = 100
+
+// ProcessError reports a command that finished unsuccessfully.
+//
+// Its message carries a shortened form of what the command wrote to stderr, so
+// that logging an error stays readable. Callers that need to act on the output
+// -- classifying "no such file or directory" as [io/fs.ErrNotExist], say --
+// must read [ProcessError.Stderr] instead of matching on the message, which
+// drops the tail of a long one.
+type ProcessError struct {
+	err    error
+	stderr string
+}
+
+// Error returns the message of the underlying error, followed by a shortened
+// form of the command's stderr when it wrote any.
+func (e *ProcessError) Error() string {
+	if e.stderr == "" {
+		return fmt.Sprintf("process finished with error: %s", e.err)
+	}
+	return fmt.Sprintf("process finished with error: %s (%s)", e.err, truncateStderr(e.stderr))
+}
+
+// Unwrap returns the error the command finished with.
+func (e *ProcessError) Unwrap() error {
+	return e.err
+}
+
+// Stderr returns everything the command wrote to its standard error, without
+// the shortening applied to the error message.
+func (e *ProcessError) Stderr() string {
+	return e.stderr
+}
+
+// StderrOf returns everything the command that produced err wrote to its
+// standard error, or an empty string if err does not come from a command or the
+// command wrote nothing.
+//
+// Prefer this over matching on err.Error() when a decision depends on what a
+// command reported: the message carries only the first [stderrMessageMax]
+// characters, and a diagnostic that puts its reason last -- as coreutils do,
+// after the path -- can be cut off entirely by a long enough path.
+func StderrOf(err error) string {
+	if procErr, ok := errors.AsType[*ProcessError](err); ok {
+		return procErr.stderr
+	}
+	return ""
+}
+
+// truncateStderr shortens stderr to something a log line can carry.
+func truncateStderr(stderr string) string {
+	if len(stderr) <= stderrMessageMax {
+		return stderr
+	}
+	return stderr[:stderrMessageMax-3] + "..."
+}

--- a/cmd/processerror_test.go
+++ b/cmd/processerror_test.go
@@ -1,0 +1,75 @@
+package cmd_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/cmd"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+// execWithStderr runs a failing command that writes stderr and returns the
+// resulting error, built by the real Executor rather than by hand.
+func execWithStderr(t *testing.T, stderr string) error {
+	t.Helper()
+	failed := errors.New("exit status 1")
+	mr := rigtest.NewMockRunner()
+	mr.AddCommand(rigtest.Equal("foo"), func(a *rigtest.A) error {
+		fmt.Fprintln(a.Stderr, stderr)
+		return failed
+	})
+	err := mr.Exec("foo")
+	require.Error(t, err)
+	require.ErrorIs(t, err, failed)
+	return err
+}
+
+func TestProcessErrorStderr(t *testing.T) {
+	t.Run("short stderr appears in full in the message", func(t *testing.T) {
+		err := execWithStderr(t, "chmod: /tmp/x: No such file or directory")
+
+		require.Contains(t, err.Error(), "chmod: /tmp/x: No such file or directory")
+		require.Equal(t, "chmod: /tmp/x: No such file or directory", cmd.StderrOf(err))
+	})
+
+	t.Run("long stderr is shortened in the message but kept in full", func(t *testing.T) {
+		longPath := "/tmp/" + strings.Repeat("nested/", 30) + "missing.conf"
+		stderr := "chmod: cannot access '" + longPath + "': No such file or directory"
+		require.Greater(t, len(stderr), 100, "the fixture must exceed the message limit")
+
+		err := execWithStderr(t, stderr)
+
+		require.NotContains(t, err.Error(), "No such file or directory",
+			"the reason is what the shortened message loses")
+		require.Contains(t, err.Error(), "...")
+		require.Equal(t, stderr, cmd.StderrOf(err), "the full output must survive on the error value")
+	})
+
+	t.Run("no stderr", func(t *testing.T) {
+		failed := errors.New("exit status 1")
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Equal("foo"), failed)
+
+		err := mr.Exec("foo")
+		require.ErrorIs(t, err, failed)
+		require.Empty(t, cmd.StderrOf(err))
+		require.Equal(t, "command result: process finished with error: exit status 1", err.Error())
+	})
+
+	t.Run("unrelated error carries no stderr", func(t *testing.T) {
+		require.Empty(t, cmd.StderrOf(errors.New("boom")))
+		require.Empty(t, cmd.StderrOf(nil))
+	})
+
+	t.Run("ProcessError is reachable with errors.As", func(t *testing.T) {
+		err := execWithStderr(t, "boom")
+
+		var procErr *cmd.ProcessError
+		require.ErrorAs(t, err, &procErr)
+		require.Equal(t, "boom", procErr.Stderr())
+		require.EqualError(t, procErr.Unwrap(), "exit status 1")
+	})
+}

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -740,8 +740,30 @@ func (s *PosixFS) Remove(name string) error {
 	return nil
 }
 
+// errNoSuchFile is the reason coreutils give for a path that is not there. They
+// print the path first and the reason last, so the reason is exactly what is
+// lost when a message is shortened.
+const errNoSuchFile = "No such file or directory"
+
+// isNotExist reports whether err means the path was not there.
+//
+// Commands that do not report absence in a structured form leave only their
+// diagnostic to go on. That is read from the command's full stderr rather than
+// from the error message, which carries a shortened form: with a long enough
+// path, matching the message alone makes the answer depend on how long the path
+// is. The message is still consulted as a fallback, for errors that do not come
+// from a command and so carry no stderr of their own.
 func isNotExist(err error) bool {
-	return err != nil && (errors.Is(err, fs.ErrNotExist) || strings.Contains(err.Error(), "No such file or directory"))
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return true
+	}
+	if strings.Contains(cmd.StderrOf(err), errNoSuchFile) {
+		return true
+	}
+	return strings.Contains(err.Error(), errNoSuchFile)
 }
 
 // RemoveAll removes path and any children it contains.

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -12,8 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k0sproject/rig/v2/cmd"
 	"github.com/k0sproject/rig/v2/remotefs"
 	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/k0sproject/rig/v2/sh"
+	"github.com/k0sproject/rig/v2/sudo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -724,4 +727,79 @@ func TestPosixShellQuote(t *testing.T) {
 	for _, tc := range cases {
 		require.Equal(t, tc.want, pfs.ShellQuote(tc.input), "input: %q", tc.input)
 	}
+}
+
+func TestPosixNotExistByPathLength(t *testing.T) {
+	// Whether a missing file is recognised as such must not depend on how long
+	// its path is. The operations below have no structured way of reporting
+	// absence, so they read the command's diagnostic -- and coreutils put the
+	// path first and the reason last, so a long path is exactly what pushes the
+	// reason out of a shortened message.
+	ops := []struct {
+		name string
+		call func(fsys *remotefs.PosixFS, path string) error
+	}{
+		{"Sha256", func(fsys *remotefs.PosixFS, path string) error {
+			_, err := fsys.Sha256(path)
+			return err
+		}},
+		{"Chmod", func(fsys *remotefs.PosixFS, path string) error {
+			return fsys.Chmod(path, 0o644)
+		}},
+		{"Chown", func(fsys *remotefs.PosixFS, path string) error {
+			return fsys.Chown(path, "root:root")
+		}},
+		{"ChownInt", func(fsys *remotefs.PosixFS, path string) error {
+			return fsys.ChownInt(path, 0, 0)
+		}},
+		{"ChownTree", func(fsys *remotefs.PosixFS, path string) error {
+			return fsys.ChownTree(path, "root:root")
+		}},
+		{"ChownTreeInt", func(fsys *remotefs.PosixFS, path string) error {
+			return fsys.ChownTreeInt(path, 0, 0)
+		}},
+	}
+
+	for _, depth := range []int{0, 12, 24} {
+		dir := "/tmp/" + strings.Repeat("deployments/", depth)
+		missing := dir + "missing.conf"
+		for _, op := range ops {
+			t.Run(fmt.Sprintf("%s/pathlen=%d", op.name, len(missing)), func(t *testing.T) {
+				mr := rigtest.NewMockRunner()
+				mr.AddCommand(rigtest.Contains(missing), func(a *rigtest.A) error {
+					// The coreutils diagnostic, reason last.
+					fmt.Fprintf(a.Stderr, "cannot access '%s': No such file or directory\n", missing)
+					return errors.New("exit status 1")
+				})
+
+				err := op.call(remotefs.NewPosixFS(mr), missing)
+				require.Error(t, err)
+				require.ErrorIs(t, err, fs.ErrNotExist,
+					"a missing file must be recognised at any path length")
+			})
+		}
+	}
+}
+
+func TestPosixNotExistThroughSudo(t *testing.T) {
+	// The production path: a sudo-decorated runner chains a second Executor in
+	// front of the first, so the command's stderr must still reach the error
+	// value the classification reads.
+	longPath := "/tmp/" + strings.Repeat("deployments/", 24) + "missing.conf"
+
+	mr := rigtest.NewMockRunner()
+	mr.AddCommand(rigtest.Contains(longPath), func(a *rigtest.A) error {
+		fmt.Fprintf(a.Stderr, "cannot access '%s': No such file or directory\n", longPath)
+		return errors.New("exit status 1")
+	})
+	sudoRunner := cmd.NewExecutor(mr, sudo.Sudo)
+
+	// A control run first: at this path length the shortened message cannot carry
+	// the reason, so classifying correctly is only possible from the full stderr.
+	require.NotContains(t, sudoRunner.Exec(sh.Command("chmod", "0644", longPath)).Error(),
+		"No such file or directory", "the fixture must not be classifiable from the message")
+
+	err := remotefs.NewPosixFS(sudoRunner).Chmod(longPath, 0o644)
+	require.ErrorIs(t, err, fs.ErrNotExist, "the full stderr must survive a chained runner")
+	require.NoError(t, mr.Received(rigtest.HasPrefix("sudo")))
 }


### PR DESCRIPTION
…essage

isNotExist matched "No such file or directory" in err.Error(), and the executor shortened a command's stderr to 100 characters before building that error. Coreutils print the path first and the reason last, so a long enough path pushed the reason out of the message and the classification silently flipped: the same missing file was fs.ErrNotExist at a short path and an opaque command failure at a long one. All six operations that classify through the helper -- Sha256, Chmod, Chown, ChownInt, ChownTree and ChownTreeInt -- depended on the path length.

The executor now builds a *cmd.ProcessError, which keeps the command's stderr in full and shortens it only when rendering its message, so log output is unchanged. cmd.StderrOf reaches the full text, and isNotExist reads that instead of the message, falling back to the message for errors that do not come from a command and carry no stderr of their own.

Remaining limitations, unchanged by this: absence is still inferred from a diagnostic rather than reported in a structured form, so it stays sensitive to command wording and to locale -- LC_ALL=C is set on the stat command but not on chmod, chown or sha256sum. And an exit status of 1 covers a missing path and a permission failure alike, so this does not separate ErrNotExist from ErrPermission. Both need the commands to report why they failed.

Fixes #429