### PR TITLE
fix(sshconfig): accept space separated Match criteria and honor exec exit status

### DIFF
--- a/sshconfig/parser.go
+++ b/sshconfig/parser.go
@@ -8,6 +8,9 @@
 //   - Partial Match directive support. Address, LocalAddress, LocalPort and
 //     RDomain are not implemented because they require passing
 //     in a connection, which is not (yet?) implemented.
+//   - Match exec commands are executed directly instead of being run under the
+//     user's shell, so shell constructs like pipes or boolean operators in the
+//     command are not supported.
 //   - Partial token expansion support. Like above, expanding some of the
 //     tokens would require an established connection.
 //   - Include directive support, the parser will follow the Include directives

--- a/sshconfig/set.go
+++ b/sshconfig/set.go
@@ -1348,27 +1348,141 @@ func (s *Setter) matchesHost(conditions ...string) (bool, error) {
 	return match, nil
 }
 
-// matchesMatch checks if the Match directive conditions are met.
-func (s *Setter) matchesMatch(conditions ...string) (bool, error) { //nolint:funlen,cyclop // TODO extract functions
-	log.Trace(context.Background(), "matching Match directive", "conditions", conditions)
-	for i := range conditions {
-		condition := conditions[i]
-		log.Trace(context.Background(), "matching Match directive", "condition", condition)
-		var negate bool
-		if condition[0] == '!' {
-			negate = true
-			condition = condition[1:]
+// Match directive criteria keywords as documented in ssh_config(5).
+const (
+	matchCriteriaAll          = "all"
+	matchCriteriaCanonical    = "canonical"
+	matchCriteriaExec         = "exec"
+	matchCriteriaFinal        = "final"
+	matchCriteriaHost         = "host"
+	matchCriteriaLocalNetwork = "localnetwork"
+	matchCriteriaLocalUser    = "localuser"
+	matchCriteriaOriginalHost = "originalhost"
+	matchCriteriaTagged       = "tagged"
+	matchCriteriaUser         = "user"
+)
+
+var (
+	// arglessMatchCriteria are the Match criteria that must not be given an argument.
+	arglessMatchCriteria = []string{matchCriteriaAll, matchCriteriaCanonical, matchCriteriaFinal}
+
+	// argumentMatchCriteria are the Match criteria that require an argument.
+	argumentMatchCriteria = []string{
+		matchCriteriaExec, matchCriteriaHost, matchCriteriaLocalNetwork,
+		matchCriteriaLocalUser, matchCriteriaOriginalHost, matchCriteriaTagged,
+		matchCriteriaUser,
+	}
+)
+
+// matchCondition is a single criteria of a Match directive together with its
+// argument and negation flag.
+type matchCondition struct {
+	criteria string
+	arg      string
+	negate   bool
+}
+
+// matchCriteriaTakesArgument reports whether one of the Match criteria
+// supported by this package requires an argument. Every supported criteria
+// except "all", "canonical" and "final" does. The criteria that ssh_config(5)
+// documents but this package does not implement are absent from both lists and
+// are rejected as unknown, see the package documentation for the details.
+func matchCriteriaTakesArgument(criteria string) bool {
+	return slices.Contains(argumentMatchCriteria, criteria)
+}
+
+// parseMatchConditions pairs the tokens of a Match directive into criteria and
+// their arguments.
+func parseMatchConditions(tokens []string) ([]matchCondition, error) {
+	conditions := make([]matchCondition, 0, len(tokens))
+	for i := 0; i < len(tokens); i++ {
+		if tokens[i] == "" {
+			continue
 		}
-		switch condition {
-		case "all":
-			// For 'all', return true. Using '!all' is useful maybe only for
-			// commenting out a block, but it's a valid condition which is always false.
-			return !negate, nil
-		case "canonical", "final":
+		condition, consumed, err := parseMatchCondition(tokens[i:])
+		if err != nil {
+			return nil, err
+		}
+		i += consumed - 1
+		conditions = append(conditions, condition)
+	}
+	if len(conditions) == 0 {
+		return nil, fmt.Errorf("%w: Match directive without conditions", ErrSyntax)
+	}
+	// OpenSSH rejects a Match line where anything follows "all", so the criteria
+	// may only appear as the last condition of the directive.
+	for _, condition := range conditions[:len(conditions)-1] {
+		if condition.criteria == matchCriteriaAll {
+			token := matchCriteriaAll
+			if condition.negate {
+				token = "!" + token
+			}
+			return nil, fmt.Errorf("%w: Match criteria %q cannot be combined with the criteria following it", ErrSyntax, token)
+		}
+	}
+	return conditions, nil
+}
+
+// parseMatchCondition parses the Match criteria at the head of tokens and
+// returns it together with the number of tokens it consumed.
+func parseMatchCondition(tokens []string) (matchCondition, int, error) {
+	token := tokens[0]
+	negate := strings.HasPrefix(token, "!")
+	criteria, arg, attached := strings.Cut(strings.TrimPrefix(token, "!"), "=")
+	criteria = strings.ToLower(criteria)
+	// A bare "!" or a "!=argument" leaves nothing to name a criteria, which
+	// would otherwise be reported as an invalid criteria "".
+	if criteria == "" {
+		return matchCondition{}, 0, fmt.Errorf("%w: Match condition %q is missing the criteria name", ErrSyntax, token)
+	}
+
+	if !matchCriteriaTakesArgument(criteria) {
+		if !slices.Contains(arglessMatchCriteria, criteria) {
+			return matchCondition{}, 0, fmt.Errorf("%w: invalid Match condition: %q", ErrSyntax, criteria)
+		}
+		if attached {
+			return matchCondition{}, 0, fmt.Errorf("%w: Match criteria %q does not take an argument", ErrSyntax, criteria)
+		}
+		return matchCondition{criteria: criteria, negate: negate}, 1, nil
+	}
+
+	// OpenSSH accepts the argument of a criteria either attached with an equals
+	// sign or as the token following the criteria, so "Match host=example.com"
+	// and "Match host example.com" are equivalent.
+	consumed := 1
+	if !attached {
+		if len(tokens) < 2 {
+			return matchCondition{}, 0, fmt.Errorf("%w: missing argument for Match criteria %q", ErrSyntax, criteria)
+		}
+		arg, consumed = tokens[1], 2
+	}
+	if arg == "" {
+		return matchCondition{}, 0, fmt.Errorf("%w: missing argument for Match criteria %q", ErrSyntax, criteria)
+	}
+	return matchCondition{criteria: criteria, arg: arg, negate: negate}, consumed, nil
+}
+
+// matchesMatch checks if the Match directive conditions are met.
+func (s *Setter) matchesMatch(tokens ...string) (bool, error) {
+	log.Trace(context.Background(), "matching Match directive", "conditions", tokens)
+	conditions, err := parseMatchConditions(tokens)
+	if err != nil {
+		return false, err
+	}
+	for _, condition := range conditions {
+		log.Trace(context.Background(), "matching Match criteria", "criteria", condition.criteria, "argument", condition.arg, "negate", condition.negate)
+		switch condition.criteria {
+		case matchCriteriaAll:
+			// parseMatchConditions guarantees 'all' is the last condition, so
+			// returning here does not skip any remaining criteria. Using '!all'
+			// is useful maybe only for commenting out a block, but it's a valid
+			// condition which is always false.
+			return !condition.negate, nil
+		case matchCriteriaCanonical, matchCriteriaFinal:
 			// We're going to perform canonical and final during the same pass, so
 			// we can treat them as synonyms.
 			if s.phase == phaseFinal {
-				if negate {
+				if condition.negate {
 					// it's the final round but !final is used, so return false
 					return false, nil
 				}
@@ -1376,7 +1490,7 @@ func (s *Setter) matchesMatch(conditions ...string) (bool, error) { //nolint:fun
 				continue
 			}
 			// Not on the final round
-			if negate {
+			if condition.negate {
 				// !canonical or !final is used, so proceed to check other conditions
 				continue
 			}
@@ -1385,125 +1499,112 @@ func (s *Setter) matchesMatch(conditions ...string) (bool, error) { //nolint:fun
 			return false, nil
 		}
 
-		parts := strings.Split(condition, "=")
-		if len(parts) != 2 {
-			return false, fmt.Errorf("%w: invalid Match condition: %q", ErrSyntax, condition)
-		}
-		condition, quotedArgs := parts[0], parts[1]
-		args, err := shellescape.Unquote(quotedArgs)
+		match, err := s.matchesCriteria(condition)
 		if err != nil {
-			return false, fmt.Errorf("%w: failed to unquote match condition %q: %w", ErrSyntax, args, err)
+			return false, err
 		}
-
-		// Deal with "exec" condition because its parameter is parsed differently.
-		if condition == "exec" { //nolint:nestif // TODO extract function
-			cmdStr, err := s.expand(args, keyInfo{
-				key:    "exec",
-				tokens: tokenset1,
-			})
-			if err != nil {
-				return false, fmt.Errorf("%w: failed to expand %q for Match exec condition: %w", ErrSyntax, args, err)
-			}
-			unq, err := shellescape.Split(cmdStr)
-			if err != nil {
-				return false, fmt.Errorf("%w: failed to process %q: %w", ErrSyntax, args, err)
-			}
-			cmd := unq[0]
-			var args []string
-			if len(unq) > 1 {
-				args = unq[1:]
-			}
-			log.Trace(context.Background(), "executing command from match directive", "condition", condition, "cmd", cmd, "args", args)
-			if runErr := s.executor.Run(cmd, args...); runErr != nil {
-				log.Trace(context.Background(), "command failed", "condition", condition, "cmd", cmd, "args", args, "error", runErr)
-				if negate {
-					return false, nil
-				}
-				continue
-			}
-			log.Trace(context.Background(), "command succeeded", "condition", condition, "cmd", cmd, "args", args)
-			if negate {
-				return false, nil
-			}
-			continue
-		}
-
-		// The rest of the conditions take a comma separated list of arguments.
-		argsSlice := strings.Split(args, ",")
-
-		// Deal with "localnetwork" condition separately.
-		if condition == "localnetwork" { //nolint:nestif
-			match, err := matchLocalNetwork(argsSlice)
-			if err != nil {
-				return false, fmt.Errorf("failed to match local network: %w", err)
-			}
-			if match {
-				if negate {
-					return false, nil
-				}
-				continue
-			}
-			if negate {
-				continue
-			}
-			return false, nil
-		}
-
-		// The rest of the conditions share an equal logic:
-		// The args are patterns and depending on the condition, a different
-		// value is matched against the patterns.
-		//
-		// The patterns are already in the args and the switch statement below
-		// is used to determine the matchTarget.
-		var matchTarget string
-
-		// continue with the condition
-		switch condition {
-		case "user":
-			// consume next arg
-			user, err := s.get("User", reflect.String)
-			if err != nil {
-				return false, fmt.Errorf("%w: user field not found", ErrInvalidObject)
-			}
-			matchTarget = user.String()
-		case "originalhost":
-			matchTarget = s.OriginalHost
-		case "localuser":
-			matchTarget = username()
-		case "host":
-			if hostname, err := s.get("Hostname", reflect.String); err == nil && hostname.Len() > 0 {
-				matchTarget = hostname.String()
-			} else if host, err := s.get("Host", reflect.String); err == nil && host.Len() > 0 {
-				matchTarget = host.String()
-			} else {
-				return false, fmt.Errorf("%w: host or hostname fields not found or empty", ErrInvalidObject)
-			}
-		case "tagged":
-			tag, err := s.get("Tag", reflect.String)
-			if err != nil {
-				return false, fmt.Errorf("%w: tag field not found", ErrInvalidObject)
-			}
-			matchTarget = tag.String()
-		default:
-			return false, fmt.Errorf("%w: unknown match condition: %q", ErrSyntax, condition)
-		}
-
-		match, err := patternMatchAll(matchTarget, argsSlice...)
-		if err != nil {
-			return false, fmt.Errorf("match %q for match condition: %w", condition, err)
-		}
-		if match && !negate {
-			continue
-		}
-		if match && negate {
-			return false, nil
-		}
-		if !match && !negate {
+		if match == condition.negate {
+			// Either the criteria did not match, or it matched a negated one.
 			return false, nil
 		}
 	}
 
 	// If none of the conditions explicitly return false, the match is successful
+	return true, nil
+}
+
+// matchesCriteria evaluates a single argument-taking Match criteria, ignoring
+// the negation which is handled by the caller.
+func (s *Setter) matchesCriteria(condition matchCondition) (bool, error) {
+	switch condition.criteria {
+	case matchCriteriaExec:
+		// The exec argument is a command line, not a pattern list.
+		return s.matchesExec(condition.arg)
+	case matchCriteriaLocalNetwork:
+		match, err := matchLocalNetwork(strings.Split(condition.arg, ","))
+		if err != nil {
+			return false, fmt.Errorf("failed to match local network: %w", err)
+		}
+		return match, nil
+	}
+
+	// The rest of the criteria share an equal logic: the argument is a comma
+	// separated list of patterns and depending on the criteria, a different
+	// value is matched against the patterns.
+	target, err := s.matchTarget(condition.criteria)
+	if err != nil {
+		return false, err
+	}
+	match, err := patternMatchAll(target, strings.Split(condition.arg, ",")...)
+	if err != nil {
+		return false, fmt.Errorf("match %q for match condition: %w", condition.criteria, err)
+	}
+	return match, nil
+}
+
+// matchTarget returns the value that the argument patterns of a pattern based
+// Match criteria are matched against.
+func (s *Setter) matchTarget(criteria string) (string, error) {
+	switch criteria {
+	case matchCriteriaUser:
+		user, err := s.get("User", reflect.String)
+		if err != nil {
+			return "", fmt.Errorf("%w: user field not found", ErrInvalidObject)
+		}
+		return user.String(), nil
+	case matchCriteriaOriginalHost:
+		return s.OriginalHost, nil
+	case matchCriteriaLocalUser:
+		return username(), nil
+	case matchCriteriaHost:
+		return s.matchHostTarget()
+	case matchCriteriaTagged:
+		tag, err := s.get("Tag", reflect.String)
+		if err != nil {
+			return "", fmt.Errorf("%w: tag field not found", ErrInvalidObject)
+		}
+		return tag.String(), nil
+	default:
+		return "", fmt.Errorf("%w: unknown match condition: %q", ErrSyntax, criteria)
+	}
+}
+
+// matchHostTarget returns the Hostname if one has been resolved, falling back
+// to the Host given to the parser.
+func (s *Setter) matchHostTarget() (string, error) {
+	if hostname, err := s.get("Hostname", reflect.String); err == nil && hostname.Len() > 0 {
+		return hostname.String(), nil
+	}
+	if host, err := s.get("Host", reflect.String); err == nil && host.Len() > 0 {
+		return host.String(), nil
+	}
+	return "", fmt.Errorf("%w: host or hostname fields not found or empty", ErrInvalidObject)
+}
+
+// matchesExec runs the command given as the argument of a Match exec criteria
+// and reports whether it exited successfully.
+func (s *Setter) matchesExec(command string) (bool, error) {
+	cmdStr, err := s.expand(command, keyInfo{
+		key:    matchCriteriaExec,
+		tokens: tokenset1,
+	})
+	if err != nil {
+		return false, fmt.Errorf("%w: failed to expand %q for Match exec condition: %w", ErrSyntax, command, err)
+	}
+	parts, err := shellescape.Split(cmdStr)
+	if err != nil {
+		return false, fmt.Errorf("%w: failed to process %q: %w", ErrSyntax, cmdStr, err)
+	}
+	if len(parts) == 0 {
+		return false, fmt.Errorf("%w: empty command for Match exec condition", ErrSyntax)
+	}
+	cmd, args := parts[0], parts[1:]
+	log.Trace(context.Background(), "executing command from match directive", "cmd", cmd, "args", args)
+	if runErr := s.executor.Run(cmd, args...); runErr != nil {
+		log.Trace(context.Background(), "command failed", "cmd", cmd, "args", args, "error", runErr)
+		return false, nil
+	}
+	log.Trace(context.Background(), "command succeeded", "cmd", cmd, "args", args)
 	return true, nil
 }
 

--- a/sshconfig/set_test.go
+++ b/sshconfig/set_test.go
@@ -1,9 +1,11 @@
 package sshconfig_test
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1516,4 +1518,188 @@ func TestSetterFinalize(t *testing.T) {
 	require.Len(t, obj.IdentityFile, 2)
 	require.NotEqual(t, "~/foo", obj.IdentityFile[0])
 	require.Equal(t, "/tmp/22.txt", obj.IdentityFile[1])
+}
+
+// matchExecutor records the commands run by a Match exec criteria and reports
+// the configured exit result for each of them.
+type matchExecutor struct {
+	fail bool
+	// received holds the argv of each command that was run.
+	received [][]string
+}
+
+func (m *matchExecutor) Run(cmd string, args ...string) error {
+	m.received = append(m.received, append([]string{cmd}, args...))
+	if m.fail {
+		return errors.New("command failed")
+	}
+	return nil
+}
+
+// applyMatchConfig parses config and applies it to a Config for host, using the
+// given executor for Match exec criteria.
+func applyMatchConfig(t *testing.T, config, host string, exec *matchExecutor) (*sshconfig.Config, error) {
+	t.Helper()
+	parser, err := sshconfig.NewParser(strings.NewReader(config), sshconfig.WithExecutor(exec))
+	require.NoError(t, err)
+	obj := &sshconfig.Config{}
+	return obj, parser.Apply(obj, host)
+}
+
+// matchConfig builds a config where condition decides whether Port becomes 2222
+// or the 22 of the catch-all block. The leading block seeds the fields that the
+// user and tagged criteria match against.
+func matchConfig(condition string) string {
+	return "Host *\n    User admin\n    Tag work\n\nMatch " + condition + "\n    Port 2222\n\nHost *\n    Port 22\n"
+}
+
+// TestMatchCriteriaArgumentForms verifies that a criteria argument can be given
+// either attached with an equals sign or as a separate token, which is how
+// ssh_config(5) documents it, and that the criteria keyword is case
+// insensitive.
+func TestMatchCriteriaArgumentForms(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// conditions are different spellings of the same condition, all of
+		// which are expected to behave identically.
+		conditions []string
+		wantMatch  bool
+	}{
+		{"host", []string{`host example.com`, `host=example.com`, `HOST example.com`}, true},
+		{"host no match", []string{`host other.example`, `host=other.example`}, false},
+		{"host negated", []string{`!host other.example`, `!host=other.example`}, true},
+		{"host negated no match", []string{`!host example.com`, `!host=example.com`}, false},
+		{"host pattern", []string{`host *.com`, `host="*.com"`}, true},
+		{"host list", []string{`host other.example,example.com`, `host=other.example,example.com`}, true},
+		{"originalhost", []string{`originalhost example.com`, `originalhost=example.com`}, true},
+		{"user", []string{`user admin`, `user=admin`, `User admin`}, true},
+		{"user no match", []string{`user root`, `user=root`}, false},
+		{"tagged", []string{`tagged work`, `tagged=work`}, true},
+		{"tagged no match", []string{`tagged home`, `tagged=home`}, false},
+		{"exec", []string{`exec /bin/true`, `exec=/bin/true`, `EXEC /bin/true`}, true},
+		{"exec quoted", []string{`exec "/bin/true --flag"`, `exec="/bin/true --flag"`}, true},
+		{"exec negated", []string{`!exec /bin/true`, `!exec=/bin/true`}, false},
+		{"all", []string{`all`, `ALL`}, true},
+		{"all negated", []string{`!all`}, false},
+		{"final and host", []string{`final host example.com`, `final host=example.com`}, true},
+		{"host and exec", []string{`host example.com exec /bin/true`, `host=example.com exec=/bin/true`}, true},
+		{"host and exec no match", []string{`host other.example exec /bin/true`, `host=other.example exec=/bin/true`}, false},
+		{"host and trailing all", []string{`host example.com all`, `host=example.com all`}, true},
+		{"host no match and trailing all", []string{`host other.example all`, `host=other.example all`}, false},
+		{"final and trailing all", []string{`final all`}, true},
+		{"host and trailing negated all", []string{`host example.com !all`}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, condition := range tc.conditions {
+				t.Run(condition, func(t *testing.T) {
+					obj, err := applyMatchConfig(t, matchConfig(condition), "example.com", &matchExecutor{})
+					require.NoError(t, err)
+					if tc.wantMatch {
+						require.Equal(t, 2222, obj.Port, "condition %q should have matched", condition)
+					} else {
+						require.Equal(t, 22, obj.Port, "condition %q should not have matched", condition)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestMatchExecExitStatus verifies that the exit status of the Match exec
+// command decides whether the block matches.
+func TestMatchExecExitStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		condition string
+		fail      bool
+		wantMatch bool
+	}{
+		{"exec succeeds", `exec "/bin/check"`, false, true},
+		{"exec fails", `exec "/bin/check"`, true, false},
+		{"negated exec succeeds", `!exec "/bin/check"`, false, false},
+		{"negated exec fails", `!exec "/bin/check"`, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := &matchExecutor{fail: tc.fail}
+			config := "Match " + tc.condition + "\n    Port 2222\n\nHost *\n    Port 22\n"
+			obj, err := applyMatchConfig(t, config, "example.com", exec)
+			require.NoError(t, err)
+			require.Equal(t, [][]string{{"/bin/check"}}, exec.received, "the command should have been run once")
+			if tc.wantMatch {
+				require.Equal(t, 2222, obj.Port)
+			} else {
+				require.Equal(t, 22, obj.Port)
+			}
+		})
+	}
+}
+
+// TestMatchExecCommandParsing verifies that the Match exec argument is treated
+// as a command line instead of being split on equals signs or unquoted twice.
+func TestMatchExecCommandParsing(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		config  string
+		wantCmd []string
+	}{
+		{
+			"equals sign in the command",
+			`Match exec="test x = x"`,
+			[]string{"test", "x", "=", "x"},
+		},
+		{
+			"environment assignment in the command",
+			`Match exec "env FOO=bar /bin/check"`,
+			[]string{"env", "FOO=bar", "/bin/check"},
+		},
+		{
+			"nested quotes are preserved as one argument",
+			`Match exec "grep -q 'foo bar' /etc/hosts"`,
+			[]string{"grep", "-q", "foo bar", "/etc/hosts"},
+		},
+		{
+			"percent h is expanded to the host",
+			`Match exec "/usr/local/bin/on-vpn %h"`,
+			[]string{"/usr/local/bin/on-vpn", "example.com"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := &matchExecutor{}
+			_, err := applyMatchConfig(t, tc.config+"\n    Port 2222\n", "example.com", exec)
+			require.NoError(t, err)
+			require.Equal(t, [][]string{tc.wantCmd}, exec.received)
+		})
+	}
+}
+
+// TestMatchSyntaxErrors verifies that malformed Match directives are reported
+// as syntax errors.
+func TestMatchSyntaxErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config string
+	}{
+		{"missing argument", "Match host\n    Port 2222\n"},
+		{"missing argument for the last criteria", "Match host example.com user\n    Port 2222\n"},
+		{"argument for an argument-less criteria", "Match all=yes\n    Port 2222\n"},
+		{"unimplemented criteria address", "Match address 192.0.2.10\n    Port 2222\n"},
+		{"unimplemented criteria localaddress", "Match localaddress 192.0.2.10\n    Port 2222\n"},
+		{"unimplemented criteria localport", "Match localport 22\n    Port 2222\n"},
+		{"unimplemented criteria rdomain", "Match rdomain vrf0\n    Port 2222\n"},
+		{"unknown criteria", "Match bogus value\n    Port 2222\n"},
+		{"bare negation", "Match !\n    Port 2222\n"},
+		{"bare negation before a criteria", "Match ! host example.com\n    Port 2222\n"},
+		{"leading equals sign", "Match =example.com\n    Port 2222\n"},
+		{"negated argument without a criteria", "Match !=example.com\n    Port 2222\n"},
+		{"all followed by another criteria", "Match all host example.com\n    Port 2222\n"},
+		{"negated all followed by another criteria", "Match !all user admin\n    Port 2222\n"},
+		{"all repeated", "Match all all\n    Port 2222\n"},
+		{"all followed by a non matching criteria", "Match all host other.example\n    Port 2222\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := applyMatchConfig(t, tc.config, "example.com", &matchExecutor{})
+			require.Error(t, err)
+			require.ErrorIs(t, err, sshconfig.ErrSyntax)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #444

ssh_config(5) allows the argument of a Match criteria to be given either attached with an equals sign or as the token following the criteria, so "Match host=example.com" and "Match host example.com" are equivalent. Only the attached form was handled: matchesMatch split every token on "=" and rejected anything without it, so each of the argument taking criteria (exec, host, localnetwork, localuser, originalhost, tagged, user) failed with "invalid Match condition" when written in the documented space separated form. Only the argument-less all, canonical and final worked in both forms.

Since the conditions are evaluated while applying the config to a host, a single such stanza anywhere in the evaluated configuration aborted every connection, even when the stanza was unrelated to the host being connected to and would never have matched it.

Splitting on "=" also required the token to contain exactly one of them, which rejected commands such as Match exec="test x = x".

The exec criteria itself never used the result of the command it ran: the success and the failure branch handled the negation identically, so "exec" always matched and "!exec" never did, whatever the command exited with.

Parse the tokens of the directive into criteria, argument and negation triples before evaluating them, so an argument can be attached or separate, and return the exit status of the command from the exec criteria. The negation of every argument taking criteria is now applied in one place instead of being repeated per criteria.

Two deliberate behavior changes come along:

  - The criteria keyword is matched case insensitively, like OpenSSH does with strcasecmp.
  - The argument is no longer unquoted a second time after splitArgs has already unquoted it. The double unquoting dropped nested quotes from exec command lines, so `exec "grep -q 'foo bar' file"` lost the grouping of its pattern argument. The flip side is that an argument written with escaped quotes, as in `Match host=\"foo\"`, now keeps them.

Running the exec command directly instead of under the user's shell remains a deviation from OpenSSH and is now mentioned in the package documentation.

