### PR TITLE
feat(ssh): add ignoreSSHConfig to skip the ssh client config files

### DIFF
--- a/docs/ssh-config-precedence.md
+++ b/docs/ssh-config-precedence.md
@@ -1,7 +1,7 @@
 # SSH Configuration Precedence
 
 When the pure-Go SSH protocol establishes a connection it builds its effective
-configuration from three sources, in decreasing priority order:
+configuration from four sources, in decreasing priority order:
 
 1. **Native fields** (`address`, `user`, `keyPath`, …)
    Strongly-typed fields on `ssh.Config`. Once set to a non-empty/non-zero
@@ -11,8 +11,18 @@ configuration from three sources, in decreasing priority order:
    A map of raw ssh_config directives, e.g. `{"Ciphers": "aes128-ctr"}`.
    Applied after native fields; fills gaps they leave.
 
-3. **`~/.ssh/config`** (read by `sshconfig.ConfigParser` when enabled)
-   Applied last, filling whatever the two sources above did not set.
+3. **`~/.ssh/config`** and the system-wide `ssh_config` (read by
+   `ssh.ConfigParser` in `protocol/ssh` when enabled)
+   Fills whatever the two sources above did not set. Can be skipped entirely
+   — see [Skipping the ssh config files](#skipping-the-ssh-config-files).
+
+4. **OpenSSH built-in defaults**
+   The compiled-in defaults OpenSSH itself would use (`IdentityFile`,
+   `UserKnownHostsFile`, `StrictHostKeyChecking`, `Port`, cipher lists, …).
+   Applied last of all, and kept by `ignoreSSHConfig` and when the config
+   files turn out to be unparseable. They come from the same parser as layer
+   3, so the one way to lose them is assigning nil to `ssh.ConfigParser` in
+   Go, which turns the whole ssh config layer off.
 
 ## Example
 
@@ -41,8 +51,48 @@ means `~/.ssh/config` can still supply a per-host port when the rig
 configuration leaves `port` at `22` or omits it entirely. Set `port` to any
 other value to have it take precedence over `~/.ssh/config`.
 
+## Skipping the ssh config files
+
+This applies to the pure-Go `ssh:` protocol only. For `openssh:` see
+[OpenSSH protocol](#openssh-protocol) below.
+
+Set `ignoreSSHConfig` (Go: `ssh.Config.IgnoreSSHConfig`, or the
+`ssh.WithoutSSHConfig()` option) to stop rig from reading `~/.ssh/config` and
+the system-wide `ssh_config` for a host. This mirrors `ssh -F none`.
+
+```yaml
+ssh:
+  address: 192.0.2.1
+  user: deploy
+  ignoreSSHConfig: true
+```
+
+Only layer 3 above is dropped. Native fields, `options` and OpenSSH's built-in
+defaults still apply, so the connection keeps working defaults for identity
+files, `known_hosts`, host key checking and algorithm lists.
+
+Use it when a config file on the machine running rig cannot be parsed, or
+contains directives that should not influence rig — for example an unrelated
+`Include` file dropped in by corporate IT or a VPN helper. Without the opt-out
+a parse failure anywhere in the evaluated configuration aborts every
+connection, even for hosts the offending stanza does not match.
+
+The setting is inherited by bastion connections, including a bastion derived
+from `ProxyJump`.
+
 ## OpenSSH protocol
 
 The OpenSSH (`protocol/openssh`) variant passes options directly to the
 `ssh` binary as `-o Key=Value` flags, so the precedence rules are those of
 OpenSSH itself. The `options` YAML key is the same (`openssh.Config.Options`).
+
+Because rig never parses the config files for this protocol, `ignoreSSHConfig`
+does not exist on `openssh.Config`. OpenSSH's own switch covers it: `configPath`
+(`openssh.Config.ConfigPath`) becomes `ssh -F <path>`, so `none` reads no
+configuration files at all.
+
+```yaml
+openssh:
+  address: 192.0.2.1
+  configPath: none
+```

--- a/protocol/ssh/config.go
+++ b/protocol/ssh/config.go
@@ -36,6 +36,18 @@ type Config struct {
 	// YAML key: options.
 	SSHConfigOptions sshconfig.OptionArguments `yaml:"options,omitempty" json:"options,omitempty" jsonschema:"description=Additional SSH options as ssh_config key-value pairs"`
 
+	// IgnoreSSHConfig disables reading the OpenSSH client configuration files
+	// (~/.ssh/config and the system-wide ssh_config) when setting up this
+	// connection, mirroring "ssh -F none". OpenSSH's built-in defaults and any
+	// SSHConfigOptions given above are still applied, so only file-derived
+	// settings are dropped.
+	//
+	// Use this to opt out when a config file cannot be parsed or contains
+	// directives that should not influence rig. The setting is inherited by the
+	// bastion connection.
+	// YAML key: ignoreSSHConfig.
+	IgnoreSSHConfig bool `yaml:"ignoreSSHConfig,omitempty" json:"ignoreSSHConfig,omitempty" jsonschema:"description=Do not read ~/.ssh/config or the system ssh_config for this host"`
+
 	// AuthMethods can be used to pass in a list of crypto/ssh.AuthMethod objects
 	// for example to use a private key from memory:
 	//   ssh.PublicKeys(privateKey)
@@ -69,6 +81,11 @@ func (c *Config) SetDefaults() {
 		}
 	}
 	if c.Bastion != nil {
+		// Opting out of the ssh config files applies to the whole chain; a
+		// bastion is dialed through the same local configuration.
+		if c.IgnoreSSHConfig {
+			c.Bastion.IgnoreSSHConfig = true
+		}
 		c.Bastion.SetDefaults()
 	}
 }

--- a/protocol/ssh/config_test.go
+++ b/protocol/ssh/config_test.go
@@ -1,0 +1,48 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigSetDefaultsCascadesIgnoreSSHConfig(t *testing.T) {
+	t.Run("cascades to bastion", func(t *testing.T) {
+		cfg := Config{
+			Address:         "192.0.2.10",
+			IgnoreSSHConfig: true,
+			Bastion:         &Config{Address: "192.0.2.20"},
+		}
+		cfg.SetDefaults()
+		require.True(t, cfg.Bastion.IgnoreSSHConfig, "bastion must inherit IgnoreSSHConfig")
+	})
+
+	t.Run("cascades through a bastion chain", func(t *testing.T) {
+		cfg := Config{
+			Address:         "192.0.2.10",
+			IgnoreSSHConfig: true,
+			Bastion: &Config{
+				Address: "192.0.2.20",
+				Bastion: &Config{Address: "192.0.2.30"},
+			},
+		}
+		cfg.SetDefaults()
+		require.True(t, cfg.Bastion.IgnoreSSHConfig)
+		require.True(t, cfg.Bastion.Bastion.IgnoreSSHConfig)
+	})
+
+	t.Run("does not turn the bastion setting off", func(t *testing.T) {
+		cfg := Config{
+			Address: "192.0.2.10",
+			Bastion: &Config{Address: "192.0.2.20", IgnoreSSHConfig: true},
+		}
+		cfg.SetDefaults()
+		require.False(t, cfg.IgnoreSSHConfig, "parent must be left alone")
+		require.True(t, cfg.Bastion.IgnoreSSHConfig, "bastion setting must be preserved")
+	})
+
+	t.Run("nil bastion is fine", func(t *testing.T) {
+		cfg := Config{Address: "192.0.2.10", IgnoreSSHConfig: true}
+		require.NotPanics(t, func() { cfg.SetDefaults() })
+	})
+}

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -122,11 +122,83 @@ func (c *Connection) wireProxyJumpBastion(options *Options) error {
 	bastionCfg.AuthMethods = c.AuthMethods
 	bastionCfg.KeyPath = c.KeyPath
 	bastionCfg.PasswordCallback = c.PasswordCallback
+	bastionCfg.IgnoreSSHConfig = c.IgnoreSSHConfig
 	options.InjectLoggerTo(bastionCfg, log.KeyProtocol, "ssh-bastion")
 	c.Bastion = bastionCfg
 	c.bastionFromProxyJump = true
 	c.Log().Debug("using ProxyJump as bastion", "jump", jump)
 	return nil
+}
+
+// applyClientConfig applies the OpenSSH client configuration onto c.sshConfig.
+// When IgnoreSSHConfig is set, ~/.ssh/config and the system-wide ssh_config are
+// skipped and only OpenSSH's built-in defaults are applied, mirroring
+// "ssh -F none".
+func (c *Connection) applyClientConfig() error {
+	parser := ConfigParser
+	if c.IgnoreSSHConfig {
+		// Built by need rather than in init() so a failure surfaces as an
+		// error here instead of silently dropping the built-in defaults that
+		// this option promises to keep.
+		defaults, err := defaultsOnlyConfigParser()
+		if err != nil {
+			return err
+		}
+		parser = defaults
+	}
+	if parser == nil {
+		return nil
+	}
+	c.logConfigSource(parser)
+	if err := parser.Apply(c.sshConfig, c.Address); err != nil {
+		return err //nolint:wrapcheck // Apply already prefixes "failed to apply ssh config"; wrapping repeated the sentence
+	}
+	return nil
+}
+
+// propagatePort carries an explicitly chosen port into the ssh config. Port 22
+// is treated as "not explicitly set" so the ssh config files can still supply a
+// per-host port, which is what the log line distinguishes -- and there is
+// nothing to defer to once those files are skipped.
+func (c *Connection) propagatePort() {
+	if c.Port != 0 && c.Port != 22 {
+		c.sshConfig.Port = c.Port
+		c.Log().Debug("propagating explicit port to ssh config", "port", c.Port)
+		return
+	}
+	if c.IgnoreSSHConfig {
+		c.Log().Debug("port is default (22) — ssh config files ignored, keeping it", "port", c.Port)
+		return
+	}
+	c.Log().Debug("port is default (22) — deferring to the ssh config files", "port", c.Port)
+}
+
+// isDefaultsOnlyParser reports whether parser is the shared defaults-only
+// fallback rather than one built from the ssh config files.
+func isDefaultsOnlyParser(parser *sshconfig.Parser) bool {
+	defaults, err := defaultsOnlyConfigParser()
+	return err == nil && parser == defaults
+}
+
+// logConfigSource reports which ssh configuration is about to be applied, given
+// the parser that will apply it. The files are not always part of it: the
+// opt-out skips them, and a parse failure at startup leaves ConfigParser
+// holding the defaults-only fallback instead.
+//
+// That last case warns rather than logging at debug, because settings that the
+// user wrote are being ignored and nothing else reports it. It is keyed on the
+// parser actually in use and not on errConfigParse alone, so that replacing
+// ConfigParser after startup stops the warning along with the fallback it
+// described.
+func (c *Connection) logConfigSource(parser *sshconfig.Parser) {
+	switch {
+	case c.IgnoreSSHConfig:
+		c.Log().Debug("ignoring ssh config files, applying built-in defaults only")
+	case errConfigParse != nil && isDefaultsOnlyParser(parser):
+		c.Log().Warn("ssh config files could not be parsed, applying built-in defaults only", "error", errConfigParse)
+	default:
+		c.Log().Debug("applying ssh config files and built-in defaults")
+	}
 }
 
 // configureKeepalive applies the ServerAliveInterval from ssh config if no explicit keepalive option was provided.
@@ -138,10 +210,19 @@ func (c *Connection) configureKeepalive(options *Options) {
 	}
 }
 
-// NewConnection creates a new SSH connection. Error is currently always nil.
+// NewConnection creates a new SSH connection.
+//
+// It returns an error when the configuration cannot be resolved: an unrecognized
+// or invalid key in SSHConfigOptions, an ssh config that fails to apply, or a
+// ProxyJump that cannot be parsed. Nothing is dialed here, so a connection it
+// returns has not yet contacted the host.
 func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 	options := NewOptions(opts...)
 	options.InjectLoggerTo(cfg, log.KeyProtocol, "ssh-config")
+	if options.IgnoreSSHConfig {
+		cfg.IgnoreSSHConfig = true
+	}
+	// SetDefaults cascades IgnoreSSHConfig to an explicitly configured bastion.
 	cfg.SetDefaults()
 
 	c := &Connection{Config: cfg, options: options} //nolint:varnamelen
@@ -152,12 +233,7 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 	}
 	c.Log().Debug("building ssh config", "user", c.User, "host", c.Address)
 
-	if c.Port != 0 && c.Port != 22 {
-		c.sshConfig.Port = c.Port
-		c.Log().Debug("propagating explicit port to ssh config", "port", c.Port)
-	} else {
-		c.Log().Debug("port is default (22) — deferring to ssh config / ~/.ssh/config", "port", c.Port)
-	}
+	c.propagatePort()
 
 	if c.KeyPath != nil {
 		c.sshConfig.IdentityFile = []string{*c.KeyPath}
@@ -176,11 +252,8 @@ func NewConnection(cfg Config, opts ...Option) (*Connection, error) {
 		}
 	}
 
-	if ConfigParser != nil {
-		c.Log().Debug("applying ~/.ssh/config")
-		if err := ConfigParser.Apply(c.sshConfig, c.Address); err != nil {
-			return nil, fmt.Errorf("failed to apply ssh config: %w", err)
-		}
+	if err := c.applyClientConfig(); err != nil {
+		return nil, err
 	}
 
 	if c.sshConfig.Port != 0 {
@@ -227,13 +300,35 @@ var (
 	ErrChecksumMismatch = errors.New("checksum mismatch")
 )
 
+// configParserOrDefaults picks what [ConfigParser] is initialized to from the
+// outcome of parsing the ssh config files.
+//
+// A syntax error anywhere in ~/.ssh/config or the system-wide ssh_config fails
+// the whole parse, and leaving ConfigParser nil for that would cost every
+// connection OpenSSH's built-in defaults as well -- no IdentityFile, no
+// UserKnownHostsFile, no StrictHostKeyChecking -- silently, because nothing
+// reports it. Falling back to the defaults-only parser keeps those, losing only
+// the file-derived settings that could not be read anyway.
+//
+// Assigning nil to ConfigParser by hand still means "apply nothing at all", and
+// remains the way to opt out of the defaults too.
+func configParserOrDefaults(parser *sshconfig.Parser, err error) *sshconfig.Parser {
+	if err == nil {
+		return parser
+	}
+	defaults, defaultsErr := defaultsOnlyConfigParser()
+	if defaultsErr != nil {
+		return nil
+	}
+	return defaults
+}
+
 // TODO make the parser initialization more elegant.
 func init() {
 	globalOnce.Do(func() {
 		parser, err := sshconfig.NewParser(nil)
-		if err == nil {
-			ConfigParser = parser
-		}
+		errConfigParse = err
+		ConfigParser = configParserOrDefaults(parser, err)
 	})
 }
 
@@ -316,7 +411,32 @@ func (c *Connection) IsConnected() bool {
 }
 
 // ConfigParser is an instance of rig/v2/sshconfig.Parser - it is exported here for weird design decisions made in rig v0.x and will be removed in rig v2 final.
+//
+// Setting it to nil disables the ssh config layer completely, including
+// OpenSSH's built-in defaults. To drop only the config files while keeping
+// those defaults, use Config.IgnoreSSHConfig or [WithoutSSHConfig] instead.
 var ConfigParser *sshconfig.Parser
+
+// errConfigParse records why the ssh config files could not be read, in which
+// case [ConfigParser] holds the defaults-only fallback instead of them. It is a
+// recorded cause rather than a sentinel; nothing matches on it with errors.Is.
+var errConfigParse error
+
+// defaultsOnlyConfigParser returns the parser used in place of [ConfigParser]
+// when Config.IgnoreSSHConfig is set. Passing a reader makes the parser use it
+// instead of the config files, so an empty one means ~/.ssh/config and the
+// system-wide ssh_config are never read while OpenSSH's built-in defaults
+// (IdentityFile, UserKnownHostsFile, StrictHostKeyChecking, Port, ...) are
+// still applied. This mirrors "ssh -F none". Sharing one parser is safe because
+// Apply takes the parser's mutex and rewinds its iterator on entry, not because
+// the parser is free of state.
+var defaultsOnlyConfigParser = sync.OnceValues(func() (*sshconfig.Parser, error) {
+	parser, err := sshconfig.NewParser(strings.NewReader(""))
+	if err != nil {
+		return nil, fmt.Errorf("create defaults-only ssh config parser: %w", err)
+	}
+	return parser, nil
+})
 
 // String returns the connection's printable name.
 func (c *Connection) String() string {

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -1365,3 +1365,313 @@ func TestLoadKeySignersIncludesCertSigner(t *testing.T) {
 	_, isCert = signers[1].PublicKey().(*ssh.Certificate)
 	require.False(t, isCert, "second signer must be the plain signer")
 }
+
+// TestIgnoreSSHConfig covers the opt-out from ~/.ssh/config and the
+// system-wide ssh_config. See https://github.com/k0sproject/rig/issues/444.
+func TestIgnoreSSHConfig(t *testing.T) {
+	// A directive that the parser rejects, in a stanza that has nothing to do
+	// with the host being connected to. This is the shape reported in #444:
+	// an unrelated include file makes every connection fail.
+	const brokenConfig = "Match bogus \"x\"\n  Port 2222\n"
+
+	// A parseable config that changes a value rig reads, used to verify that
+	// file-derived settings really are dropped.
+	const portConfig = "Host *\n  Port 2222\n"
+
+	t.Run("broken config fails without the opt-out", func(t *testing.T) {
+		withConfigParser(t, brokenConfig)
+		_, err := NewConnection(Config{Address: "192.0.2.10", User: "test"})
+		require.ErrorContains(t, err, "invalid Match condition")
+	})
+
+	t.Run("the parse failure is reported without stuttering", func(t *testing.T) {
+		// sshconfig.Parser.Apply already prefixes its errors with "failed to
+		// apply ssh config"; wrapping it again here is what produced the
+		// doubled sentence quoted in the bug report.
+		withConfigParser(t, brokenConfig)
+		_, err := NewConnection(Config{Address: "192.0.2.10", User: "test"})
+		require.Error(t, err)
+		require.Equal(t, 1, strings.Count(err.Error(), "failed to apply ssh config"),
+			"the phrase should appear exactly once, got: %s", err)
+	})
+
+	t.Run("broken config is bypassed with the opt-out", func(t *testing.T) {
+		withConfigParser(t, brokenConfig)
+		conn, err := NewConnection(Config{Address: "192.0.2.10", User: "test", IgnoreSSHConfig: true})
+		require.NoError(t, err)
+		require.NotNil(t, conn.sshConfig)
+	})
+
+	t.Run("broken config is bypassed with WithoutSSHConfig", func(t *testing.T) {
+		withConfigParser(t, brokenConfig)
+		conn, err := NewConnection(Config{Address: "192.0.2.10", User: "test"}, WithoutSSHConfig())
+		require.NoError(t, err)
+		require.True(t, conn.IgnoreSSHConfig)
+	})
+
+	t.Run("file derived settings are dropped", func(t *testing.T) {
+		withConfigParser(t, portConfig)
+
+		conn, err := NewConnection(Config{Address: "192.0.2.10", User: "test"})
+		require.NoError(t, err)
+		require.Equal(t, 2222, conn.Port, "sanity: the config file should set the port")
+
+		ignored, err := NewConnection(Config{Address: "192.0.2.10", User: "test", IgnoreSSHConfig: true})
+		require.NoError(t, err)
+		require.Equal(t, 22, ignored.Port, "port must fall back to the built-in default")
+	})
+
+	t.Run("built-in defaults are still applied", func(t *testing.T) {
+		withConfigParser(t, brokenConfig)
+		conn, err := NewConnection(Config{Address: "192.0.2.10", User: "test", IgnoreSSHConfig: true})
+		require.NoError(t, err)
+
+		// These all come from OpenSSH's compiled-in defaults rather than from a
+		// config file, so ignoring the files must not drop them.
+		require.Equal(t, 22, conn.sshConfig.Port)
+		require.NotEmpty(t, conn.sshConfig.IdentityFile, "default identity files must survive")
+		require.NotEmpty(t, conn.sshConfig.UserKnownHostsFile, "default known_hosts must survive")
+		require.NotEmpty(t, conn.sshConfig.StrictHostKeyChecking, "default StrictHostKeyChecking must survive")
+		require.NotEmpty(t, conn.sshConfig.Ciphers, "default ciphers must survive")
+
+		// Defaults are token-expanded by the parser's finalize step.
+		for _, f := range conn.sshConfig.IdentityFile {
+			require.NotContains(t, f, "~", "identity file paths must be expanded")
+		}
+	})
+
+	t.Run("defaults-only parser is always available", func(t *testing.T) {
+		parser, err := defaultsOnlyConfigParser()
+		require.NoError(t, err)
+		require.NotNil(t, parser, "the opt-out must never fall through to applying nothing")
+	})
+
+	t.Run("defaults are applied even when ConfigParser is nil", func(t *testing.T) {
+		// A nil ConfigParser means "apply nothing" for the normal path, but the
+		// opt-out promises to keep the built-in defaults, so it must not share
+		// that fate.
+		prev := ConfigParser
+		ConfigParser = nil
+		t.Cleanup(func() { ConfigParser = prev })
+
+		conn, err := NewConnection(Config{Address: "192.0.2.10", User: "test", IgnoreSSHConfig: true})
+		require.NoError(t, err)
+		require.Equal(t, 22, conn.sshConfig.Port)
+		require.NotEmpty(t, conn.sshConfig.IdentityFile)
+		require.NotEmpty(t, conn.sshConfig.UserKnownHostsFile)
+	})
+
+	t.Run("explicit options still apply", func(t *testing.T) {
+		withConfigParser(t, brokenConfig)
+		conn, err := NewConnection(Config{
+			Address:          "192.0.2.10",
+			User:             "test",
+			IgnoreSSHConfig:  true,
+			SSHConfigOptions: sshconfig.OptionArguments{"ConnectTimeout": "42s"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 42*time.Second, conn.sshConfig.ConnectTimeout)
+	})
+
+	t.Run("bastion inherits the opt-out", func(t *testing.T) {
+		withConfigParser(t, brokenConfig)
+		conn, err := NewConnection(Config{
+			Address:         "192.0.2.10",
+			User:            "test",
+			IgnoreSSHConfig: true,
+			Bastion:         &Config{Address: "192.0.2.20", User: "test"},
+		})
+		require.NoError(t, err)
+		require.True(t, conn.Bastion.IgnoreSSHConfig)
+
+		// The bastion builds its own Connection, which would otherwise trip on
+		// the same broken config.
+		bastionConn, err := conn.Bastion.Connection()
+		require.NoError(t, err)
+		require.NotNil(t, bastionConn)
+	})
+
+	t.Run("proxyjump bastion inherits the opt-out", func(t *testing.T) {
+		withConfigParser(t, brokenConfig)
+		conn, err := NewConnection(Config{
+			Address:          "192.0.2.10",
+			User:             "test",
+			IgnoreSSHConfig:  true,
+			SSHConfigOptions: sshconfig.OptionArguments{"ProxyJump": "jump.example.com"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, conn.Bastion, "ProxyJump from options must still wire a bastion")
+		require.True(t, conn.Bastion.IgnoreSSHConfig)
+	})
+}
+
+// TestConfigParserOrDefaults covers what ConfigParser is initialized to when
+// the ssh config files cannot be parsed at all. A syntax error there must not
+// also cost the connection OpenSSH's built-in defaults.
+func TestConfigParserOrDefaults(t *testing.T) {
+	t.Run("a parsed config is used as-is", func(t *testing.T) {
+		parser, err := sshconfig.NewParser(strings.NewReader("Host *\n  Port 2222\n"))
+		require.NoError(t, err)
+		require.Same(t, parser, configParserOrDefaults(parser, nil))
+	})
+
+	t.Run("an unparseable config falls back to the built-in defaults", func(t *testing.T) {
+		// This is what a stray line in ~/.ssh/config does: NewParser fails
+		// outright, so there is no parser to apply.
+		_, err := sshconfig.NewParser(strings.NewReader("garbageline\n"))
+		require.Error(t, err, "sanity: a line with no separator must fail to parse")
+
+		parser := configParserOrDefaults(nil, err)
+		require.NotNil(t, parser, "the built-in defaults must survive an unparseable config file")
+
+		cfg := &sshconfig.Config{}
+		require.NoError(t, parser.Apply(cfg, "192.0.2.10"))
+		require.Equal(t, 22, cfg.Port)
+		require.NotEmpty(t, cfg.IdentityFile, "default identity files must survive")
+		require.NotEmpty(t, cfg.UserKnownHostsFile, "default known_hosts must survive")
+	})
+
+	t.Run("the fallback does not read the config files", func(t *testing.T) {
+		parser := configParserOrDefaults(nil, errors.New("broken"))
+		require.NotNil(t, parser)
+
+		cfg := &sshconfig.Config{}
+		require.NoError(t, parser.Apply(cfg, "192.0.2.10"))
+		// 2222 could only come from a config file; the fallback must not read one.
+		require.Equal(t, 22, cfg.Port)
+	})
+}
+
+// capturingLogger records the messages written to it so a test can assert on
+// which one was chosen.
+type capturingLogger struct {
+	debug []string
+	warn  []string
+}
+
+func (l *capturingLogger) Debug(msg string, _ ...any) { l.debug = append(l.debug, msg) }
+func (l *capturingLogger) Info(msg string, _ ...any)  { _ = msg }
+func (l *capturingLogger) Warn(msg string, _ ...any)  { l.warn = append(l.warn, msg) }
+func (l *capturingLogger) Error(msg string, _ ...any) { _ = msg }
+
+// TestLogConfigSource pins what the connection says it is applying. The files
+// are not always part of it, and a log that claims otherwise is misleading in
+// exactly the situation someone reads it to debug.
+//
+// The parser is passed in rather than read from the global, so each case is a
+// state the process can really be in: the warning belongs to the defaults-only
+// fallback being applied, not merely to a parse error having been recorded at
+// startup.
+func TestLogConfigSource(t *testing.T) {
+	setParseErr := func(t *testing.T, err error) {
+		t.Helper()
+		prev := errConfigParse
+		errConfigParse = err
+		t.Cleanup(func() { errConfigParse = prev })
+	}
+	newConn := func(ignore bool) (*Connection, *capturingLogger) {
+		logger := &capturingLogger{}
+		conn := &Connection{}
+		conn.IgnoreSSHConfig = ignore
+		conn.SetLogger(logger)
+		return conn, logger
+	}
+	fileParser := func(t *testing.T) *sshconfig.Parser {
+		t.Helper()
+		parser, err := sshconfig.NewParser(strings.NewReader("Host *\n  Port 2222\n"))
+		require.NoError(t, err)
+		return parser
+	}
+	fallbackParser := func(t *testing.T) *sshconfig.Parser {
+		t.Helper()
+		parser, err := defaultsOnlyConfigParser()
+		require.NoError(t, err)
+		return parser
+	}
+
+	t.Run("normal path names the files and the defaults", func(t *testing.T) {
+		setParseErr(t, nil)
+		conn, logger := newConn(false)
+
+		conn.logConfigSource(fileParser(t))
+		require.Equal(t, []string{"applying ssh config files and built-in defaults"}, logger.debug)
+		require.Empty(t, logger.warn)
+	})
+
+	t.Run("opt-out says the files are skipped", func(t *testing.T) {
+		setParseErr(t, nil)
+		conn, logger := newConn(true)
+
+		conn.logConfigSource(fallbackParser(t))
+		require.Equal(t, []string{"ignoring ssh config files, applying built-in defaults only"}, logger.debug)
+		require.Empty(t, logger.warn)
+	})
+
+	t.Run("the fallback in use warns instead of claiming the files were read", func(t *testing.T) {
+		setParseErr(t, errors.New("syntax error: missing separator"))
+		conn, logger := newConn(false)
+
+		conn.logConfigSource(fallbackParser(t))
+		require.Empty(t, logger.debug, "this must not be reported as a normal application of the files")
+		require.Equal(t, []string{"ssh config files could not be parsed, applying built-in defaults only"}, logger.warn,
+			"the user wrote settings that are being ignored, so it should be visible")
+	})
+
+	t.Run("a replaced parser stops the warning", func(t *testing.T) {
+		// errConfigParse is set once at startup and never cleared, so keying the
+		// warning on it alone would keep blaming a fallback that is no longer
+		// the parser being applied. Overriding ConfigParser is a supported thing
+		// to do, and the tests here do it themselves.
+		setParseErr(t, errors.New("syntax error: missing separator"))
+		conn, logger := newConn(false)
+
+		conn.logConfigSource(fileParser(t))
+		require.Empty(t, logger.warn, "the fallback is not what is being applied any more")
+		require.Equal(t, []string{"applying ssh config files and built-in defaults"}, logger.debug)
+	})
+
+	t.Run("the opt-out takes precedence over a parse failure", func(t *testing.T) {
+		setParseErr(t, errors.New("syntax error: missing separator"))
+		conn, logger := newConn(true)
+
+		conn.logConfigSource(fallbackParser(t))
+		require.Empty(t, logger.warn, "the files were not going to be read anyway")
+	})
+}
+
+// TestPropagatePort pins the port handling and what it claims in the log. Port
+// 22 is deliberately treated as unset so the ssh config files can still supply
+// one, which makes the log line wrong once those files are skipped.
+func TestPropagatePort(t *testing.T) {
+	newConn := func(port int, ignore bool) (*Connection, *capturingLogger) {
+		logger := &capturingLogger{}
+		conn := &Connection{sshConfig: &sshconfig.Config{}}
+		conn.Port = port
+		conn.IgnoreSSHConfig = ignore
+		conn.SetLogger(logger)
+		return conn, logger
+	}
+
+	t.Run("an explicit port is propagated", func(t *testing.T) {
+		conn, logger := newConn(2222, false)
+		conn.propagatePort()
+		require.Equal(t, 2222, conn.sshConfig.Port)
+		require.Equal(t, []string{"propagating explicit port to ssh config"}, logger.debug)
+	})
+
+	t.Run("port 22 defers to the config files", func(t *testing.T) {
+		conn, logger := newConn(22, false)
+		conn.propagatePort()
+		require.Zero(t, conn.sshConfig.Port, "22 must stay unset so the config files can supply a port")
+		require.Equal(t, []string{"port is default (22) — deferring to the ssh config files"}, logger.debug)
+	})
+
+	t.Run("port 22 with the opt-out does not claim to defer to anything", func(t *testing.T) {
+		conn, logger := newConn(22, true)
+		conn.propagatePort()
+		require.Zero(t, conn.sshConfig.Port)
+		require.Equal(t, []string{"port is default (22) — ssh config files ignored, keeping it"}, logger.debug)
+		require.NotContains(t, logger.debug[0], "deferring",
+			"there are no config files to defer to when they are skipped")
+	})
+}

--- a/protocol/ssh/options.go
+++ b/protocol/ssh/options.go
@@ -10,6 +10,7 @@ import (
 type Options struct {
 	log.LoggerInjectable
 	KeepAliveInterval *time.Duration
+	IgnoreSSHConfig   bool
 }
 
 // Option is a function that sets some option on the Options struct.
@@ -35,5 +36,15 @@ func WithLogger(l log.Logger) Option {
 func WithKeepAlive(d time.Duration) Option {
 	return func(o *Options) {
 		o.KeepAliveInterval = &d
+	}
+}
+
+// WithoutSSHConfig disables reading the OpenSSH client configuration files
+// (~/.ssh/config and the system-wide ssh_config), mirroring "ssh -F none".
+// OpenSSH's built-in defaults still apply. This is the functional-option
+// equivalent of setting Config.IgnoreSSHConfig.
+func WithoutSSHConfig() Option {
+	return func(o *Options) {
+		o.IgnoreSSHConfig = true
 	}
 }

--- a/schemas/ssh.json
+++ b/schemas/ssh.json
@@ -49,6 +49,10 @@
         "options": {
           "$ref": "#/$defs/OptionArguments",
           "description": "Additional SSH options as ssh_config key-value pairs"
+        },
+        "ignoreSSHConfig": {
+          "type": "boolean",
+          "description": "Do not read ~/.ssh/config or the system ssh_config for this host"
         }
       },
       "additionalProperties": false,

--- a/schemas/ssh.yaml
+++ b/schemas/ssh.yaml
@@ -35,6 +35,9 @@ $defs:
       options:
         $ref: '#/$defs/OptionArguments'
         description: Additional SSH options as ssh_config key-value pairs
+      ignoreSSHConfig:
+        type: boolean
+        description: Do not read ~/.ssh/config or the system ssh_config for this host
     additionalProperties: false
     type: object
     required:

--- a/schemas/winrm.json
+++ b/schemas/winrm.json
@@ -49,6 +49,10 @@
         "options": {
           "$ref": "#/$defs/OptionArguments",
           "description": "Additional SSH options as ssh_config key-value pairs"
+        },
+        "ignoreSSHConfig": {
+          "type": "boolean",
+          "description": "Do not read ~/.ssh/config or the system ssh_config for this host"
         }
       },
       "additionalProperties": false,

--- a/schemas/winrm.yaml
+++ b/schemas/winrm.yaml
@@ -35,6 +35,9 @@ $defs:
       options:
         $ref: '#/$defs/OptionArguments'
         description: Additional SSH options as ssh_config key-value pairs
+      ignoreSSHConfig:
+        type: boolean
+        description: Do not read ~/.ssh/config or the system ssh_config for this host
     additionalProperties: false
     type: object
     required:


### PR DESCRIPTION
A parse failure anywhere in the evaluated OpenSSH client configuration aborts every connection, even for hosts the offending stanza does not match. 

Add ssh.Config.IgnoreSSHConfig (YAML: ignoreSSHConfig) and the equivalent ssh.WithoutSSHConfig() option to skip ~/.ssh/config and the system-wide ssh_config, mirroring "ssh -F none".

OpenSSH's built-in defaults (IdentityFile, UserKnownHostsFile, StrictHostKeyChecking, Port, algorithm lists) are supplied by the parser's __default__ branch and its token expansion, not by the config files. Instead, apply a parser built from an empty reader so the files are never read while the defaults still are.

The setting is inherited by bastion connections, including one derived from ProxyJump, since a bastion is dialed through the same local config.

The OpenSSH protocol remains unchanged.

Refs #444