### PR TITLE
feat(remotefs): add HTTPHead to query URL metadata from the remote host

### DIFF
--- a/remotefs/http.go
+++ b/remotefs/http.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // ErrHTTPStatusNotSupported is returned by HTTPStatusInsecure when the FS
@@ -60,4 +63,138 @@ func HTTPStatusInsecure(ctx context.Context, fs FS, url string) (int, error) {
 		return 0, ErrHTTPStatusNotSupported
 	}
 	return p.httpStatusInsecure(ctx, url)
+}
+
+// ErrHTTPHeadNotSupported is returned by [HTTPHead] when the FS implementation
+// or the remote host cannot perform HTTP HEAD requests. Callers can detect this
+// with errors.Is.
+var ErrHTTPHeadNotSupported = errors.New("http head not supported by this filesystem type")
+
+// errHTTPHeadNoStatus is returned when the output of the remote tool contained
+// no recognizable HTTP status line.
+var errHTTPHeadNoStatus = errors.New("could not determine http status from head response")
+
+// URLInfo describes what an HTTP HEAD request reported about a URL. It carries
+// the values that are useful for deciding whether a previously downloaded file
+// is still current.
+type URLInfo struct {
+	// StatusCode is the status of the final response, after any redirects.
+	StatusCode int
+
+	// ContentLength is the Content-Length of the final response, or -1 when the
+	// server did not report one, which happens under chunked transfer encoding.
+	ContentLength int64
+
+	// ETag is the entity tag exactly as the server sent it, including the quotes
+	// and any weak validator prefix, or empty when the server sent none. It is
+	// opaque: compare it for equality with a previously recorded value, never
+	// try to derive a content hash from it.
+	ETag string
+
+	// LastModified is the parsed Last-Modified header, or the zero time when the
+	// server sent none or it could not be parsed.
+	LastModified time.Time
+
+	// AcceptRanges reports whether the server advertised support for range
+	// requests.
+	AcceptRanges bool
+}
+
+// httpHeadProvider is implemented by FS types that can perform HTTP HEAD
+// requests on the remote host.
+type httpHeadProvider interface {
+	httpHead(ctx context.Context, url string) (*URLInfo, error)
+}
+
+// [HTTPHead] reaches the implementations through a type assertion, so a drifting
+// signature would silently turn into ErrHTTPHeadNotSupported rather than a
+// compile error. These keep that honest.
+var (
+	_ httpHeadProvider = (*PosixFS)(nil)
+	_ httpHeadProvider = (*WinFS)(nil)
+)
+
+// HTTPHead performs an HTTP HEAD request for url from the remote host and
+// reports what the server said about it. Unlike [HTTPStatusInsecure], TLS
+// certificates are verified.
+//
+// The request is made from the remote host rather than from the machine running
+// rig, so the result reflects what that host can actually reach. This matters
+// when the two do not share a view of the network, as with an internal mirror.
+//
+// A non-2xx StatusCode is returned without an error; inspecting it is left to
+// the caller. Servers that reject HEAD typically answer 405, which is reported
+// the same way.
+func HTTPHead(ctx context.Context, fs FS, url string) (*URLInfo, error) {
+	if err := validateHTTPURL(url); err != nil {
+		return nil, fmt.Errorf("HTTPHead: %w", err)
+	}
+	p, ok := fs.(httpHeadProvider)
+	if !ok {
+		return nil, ErrHTTPHeadNotSupported
+	}
+	return p.httpHead(ctx, url)
+}
+
+// applyHeader records a single response header into info, ignoring any header
+// that is not one of the ones URLInfo carries.
+func applyHeader(info *URLInfo, key, value string) {
+	switch strings.ToLower(key) {
+	case "content-length":
+		if n, err := strconv.ParseInt(value, 10, 64); err == nil && n >= 0 {
+			info.ContentLength = n
+		}
+	case "etag":
+		info.ETag = value
+	case "last-modified":
+		if t, err := http.ParseTime(value); err == nil {
+			info.LastModified = t
+		}
+	case "accept-ranges":
+		info.AcceptRanges = value != "" && !strings.EqualFold(value, "none")
+	}
+}
+
+// parseHeadResponse builds a URLInfo from raw HTTP response headers.
+//
+// Following redirects makes the tools emit one header block per response, and
+// the earlier blocks carry values that must not leak into the result -- a 302
+// commonly has its own Content-Length of 0. Every status line therefore starts
+// a fresh URLInfo, leaving the last response as the one that is returned.
+//
+// The input is accepted in the shapes curl and wget produce: CRLF line endings,
+// leading whitespace, and header names in any case.
+func parseHeadResponse(raw string) (*URLInfo, error) {
+	var info *URLInfo
+	for line := range strings.SplitSeq(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "HTTP/") {
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			code, err := strconv.Atoi(fields[1])
+			if err != nil {
+				continue
+			}
+			info = &URLInfo{StatusCode: code, ContentLength: -1}
+			continue
+		}
+		if info == nil {
+			// A header before any status line has no response to belong to.
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		applyHeader(info, strings.TrimSpace(key), strings.TrimSpace(value))
+	}
+	if info == nil {
+		return nil, errHTTPHeadNoStatus
+	}
+	return info, nil
 }

--- a/remotefs/http_test.go
+++ b/remotefs/http_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/k0sproject/rig/v2/remotefs"
 	"github.com/k0sproject/rig/v2/rigtest"
@@ -112,6 +113,216 @@ func TestWindowsHTTPStatusInsecure(t *testing.T) {
 		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
 		f := remotefs.NewWindowsFS(mr)
 		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		require.Error(t, err)
+	})
+}
+
+// curlHeadOutput is the shape curl -sS -L -I produces for a redirecting URL,
+// captured from a real GitHub release asset. The 302 block carries its own
+// content-length of 0, which must not leak into the reported result.
+const curlHeadOutput = "HTTP/2 302 \r\n" +
+	"content-type: text/html; charset=utf-8\r\n" +
+	"location: https://release-assets.githubusercontent.com/xyz\r\n" +
+	"content-length: 0\r\n" +
+	"\r\n" +
+	"HTTP/2 200 \r\n" +
+	"last-modified: Mon, 30 Sep 2024 11:42:01 GMT\r\n" +
+	"etag: \"0x8DCE144E5F2F047\"\r\n" +
+	"accept-ranges: bytes\r\n" +
+	"content-length: 260830864\r\n" +
+	"\r\n"
+
+// wgetHeadOutput is the shape wget --spider --server-response writes to stderr
+// for the same URL: two-space indent, mixed-case header names.
+const wgetHeadOutput = "  HTTP/1.1 302 Found\n" +
+	"  Content-Length: 0\n" +
+	"  Location: https://release-assets.githubusercontent.com/xyz\n" +
+	"\n" +
+	"  HTTP/1.1 200 OK\n" +
+	"  Content-Length: 260830864\n" +
+	"  Last-Modified: Mon, 30 Sep 2024 11:42:01 GMT\n" +
+	"  ETag: \"0x8DCE144E5F2F047\"\n" +
+	"  Accept-Ranges: bytes\n"
+
+func requireReleaseAsset(t *testing.T, info *remotefs.URLInfo) {
+	t.Helper()
+	require.Equal(t, 200, info.StatusCode)
+	require.Equal(t, int64(260830864), info.ContentLength, "the redirect's content-length must not leak")
+	require.Equal(t, `"0x8DCE144E5F2F047"`, info.ETag)
+	require.True(t, info.AcceptRanges)
+	require.Equal(t, time.Date(2024, 9, 30, 11, 42, 1, 0, time.UTC), info.LastModified.UTC())
+}
+
+func TestHTTPHeadURLValidation(t *testing.T) {
+	mr := rigtest.NewMockRunner()
+	f := remotefs.NewPosixFS(mr)
+
+	for _, rawURL := range []string{
+		"file:///etc/passwd",
+		"ftp://example.com",
+		"http:///path",
+		"/relative/path",
+		"http://user:pass@example.com",
+		"http://example.com\x00",
+	} {
+		_, err := remotefs.HTTPHead(context.Background(), f, rawURL)
+		require.Error(t, err, "expected error for %q", rawURL)
+	}
+
+	// The loop above only asserts that an error came back. Pin the
+	// security-relevant branch so it cannot start failing for some unrelated
+	// reason while the credentials check silently goes away.
+	_, err := remotefs.HTTPHead(context.Background(), f, "http://user:pass@example.com")
+	require.ErrorContains(t, err, "credentials")
+}
+
+func TestPosixHTTPHead(t *testing.T) {
+	t.Run("curl", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.HasPrefix("curl"), curlHeadOutput)
+		f := remotefs.NewPosixFS(mr)
+
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		require.NoError(t, err)
+		requireReleaseAsset(t, info)
+		require.NotContains(t, mr.LastCommand(), " -k", "HTTPHead must verify TLS certificates")
+	})
+
+	t.Run("wget fallback", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Equal("command -v curl"), errors.New("not found"))
+		mr.AddCommandOutput(rigtest.Equal("command -v wget"), "/usr/bin/wget")
+		mr.AddCommand(rigtest.HasPrefix("wget"), func(a *rigtest.A) error {
+			_, err := fmt.Fprint(a.Stderr, wgetHeadOutput)
+			return err
+		})
+		f := remotefs.NewPosixFS(mr)
+
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		require.NoError(t, err)
+		requireReleaseAsset(t, info)
+	})
+
+	t.Run("wget reports headers even when it exits non-zero", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Equal("command -v curl"), errors.New("not found"))
+		mr.AddCommandOutput(rigtest.Equal("command -v wget"), "/usr/bin/wget")
+		mr.AddCommand(rigtest.HasPrefix("wget"), func(a *rigtest.A) error {
+			if _, err := fmt.Fprint(a.Stderr, "  HTTP/1.1 404 Not Found\n"); err != nil {
+				return err
+			}
+			return errors.New("exit status 8")
+		})
+		f := remotefs.NewPosixFS(mr)
+
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		require.NoError(t, err)
+		require.Equal(t, 404, info.StatusCode)
+	})
+
+	t.Run("non-2xx is not an error", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "HTTP/2 405 \r\n\r\n")
+		f := remotefs.NewPosixFS(mr)
+
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		require.NoError(t, err)
+		require.Equal(t, 405, info.StatusCode)
+	})
+
+	t.Run("missing content-length reports -1", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "HTTP/2 200 \r\ntransfer-encoding: chunked\r\n\r\n")
+		f := remotefs.NewPosixFS(mr)
+
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		require.NoError(t, err)
+		require.Equal(t, int64(-1), info.ContentLength)
+		require.Empty(t, info.ETag)
+		require.True(t, info.LastModified.IsZero())
+		require.False(t, info.AcceptRanges)
+	})
+
+	t.Run("accept-ranges none", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "HTTP/2 200 \r\naccept-ranges: none\r\n\r\n")
+		f := remotefs.NewPosixFS(mr)
+
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		require.NoError(t, err)
+		require.False(t, info.AcceptRanges)
+	})
+
+	t.Run("unparseable output", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "something went sideways")
+		f := remotefs.NewPosixFS(mr)
+
+		_, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		require.Error(t, err)
+	})
+
+	t.Run("curl error", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("curl"), errors.New("exit status 6"))
+		f := remotefs.NewPosixFS(mr)
+
+		_, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		require.Error(t, err)
+	})
+
+	t.Run("no tools", func(t *testing.T) {
+		notFound := errors.New("not found")
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.Equal("command -v curl"), notFound)
+		mr.AddCommandFailure(rigtest.Equal("command -v wget"), notFound)
+		f := remotefs.NewPosixFS(mr)
+
+		_, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		require.ErrorIs(t, err, remotefs.ErrHTTPHeadNotSupported)
+	})
+}
+
+func TestWindowsHTTPHead(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"),
+			"HTTP/1.1 200\r\n"+
+				"Content-Length: 260830864\r\n"+
+				"Last-Modified: Mon, 30 Sep 2024 11:42:01 GMT\r\n"+
+				"ETag: \"0x8DCE144E5F2F047\"\r\n"+
+				"Accept-Ranges: bytes\r\n")
+		f := remotefs.NewWindowsFS(mr)
+
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		require.NoError(t, err)
+		requireReleaseAsset(t, info)
+	})
+
+	t.Run("non-2xx is not an error", func(t *testing.T) {
+		// Invoke-WebRequest reports non-2xx by throwing, and the script digs the
+		// response back out of the exception. Windows must agree with the posix
+		// paths that a status is a result, not a failure.
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"),
+			"HTTP/1.1 404\r\nContent-Length: 9\r\n")
+		f := remotefs.NewWindowsFS(mr)
+
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		require.NoError(t, err)
+		require.Equal(t, 404, info.StatusCode)
+		require.Equal(t, int64(9), info.ContentLength)
+	})
+
+	t.Run("transport failure is an error", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.Windows = true
+		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit status 1"))
+		f := remotefs.NewWindowsFS(mr)
+
+		_, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
 		require.Error(t, err)
 	})
 }

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -579,6 +579,40 @@ func (s *PosixFS) httpStatusInsecure(ctx context.Context, rawURL string) (int, e
 	return 0, fmt.Errorf("%w: neither curl nor wget found", ErrHTTPStatusNotSupported)
 }
 
+// httpHead performs an HTTP HEAD request for rawURL and reports what the server
+// said. It prefers curl and falls back to wget. TLS certificates are verified.
+func (s *PosixFS) httpHead(ctx context.Context, rawURL string) (*URLInfo, error) {
+	if _, err := s.LookPath("curl"); err == nil {
+		out, err := s.ExecOutputContext(ctx, sh.Command("curl", "-sS", "-L", "-I", "--connect-timeout", "20", "--", rawURL), cmd.Sensitive())
+		if err != nil {
+			return nil, fmt.Errorf("http-head %s: %w", rawURL, err)
+		}
+		info, err := parseHeadResponse(out)
+		if err != nil {
+			return nil, fmt.Errorf("http-head %s: %w", rawURL, err)
+		}
+		return info, nil
+	}
+	if _, err := s.LookPath("wget"); err == nil {
+		// wget writes the server response to stderr, and --spider makes it a
+		// HEAD request. It exits non-zero for non-2xx statuses, but the headers
+		// are still worth reporting, so the exit status is only consulted when
+		// nothing could be parsed.
+		var errBuf strings.Builder
+		execErr := s.ExecContext(ctx, sh.Command("wget", "--spider", "--server-response", "-q", "--", rawURL),
+			cmd.Sensitive(), cmd.Stderr(&errBuf))
+		info, err := parseHeadResponse(errBuf.String())
+		if err != nil {
+			if execErr != nil {
+				return nil, fmt.Errorf("http-head %s: %w", rawURL, execErr)
+			}
+			return nil, fmt.Errorf("http-head %s: %w", rawURL, err)
+		}
+		return info, nil
+	}
+	return nil, fmt.Errorf("%w: neither curl nor wget found", ErrHTTPHeadNotSupported)
+}
+
 // FileContains reports whether the file at path contains the given substring.
 // Returns a not-exist error if the file does not exist.
 func (s *PosixFS) FileContains(name, substr string) (bool, error) {

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -505,6 +505,70 @@ try {
 	return nil
 }
 
+// httpHead performs an HTTP HEAD request for rawURL and reports what the server
+// said. TLS certificates are verified and redirects are followed, matching the
+// curl and wget paths.
+//
+// The status line is synthesized so the output parses with the same reader as
+// the curl and wget responses.
+//
+// Getting a non-2xx status back without an error takes some care, because
+// Invoke-WebRequest reports those by throwing:
+//
+//   - PowerShell 7+ has -SkipHttpErrorCheck, so nothing is thrown and the
+//     normal path handles every status.
+//   - PowerShell 5.1 throws a WebException carrying an HttpWebResponse, whose
+//     Headers collection is keyed like the success-path dictionary.
+//   - PowerShell 6.x has neither, and its HttpResponseMessage exposes headers
+//     as key/value pairs instead of by key. That version is end of life, so it
+//     falls back to enumerating pairs and may omit Content-Length, which lives
+//     on the content headers there. The status is still reported.
+//
+// Windows PowerShell 5.1, the version shipped with Windows Server 2019 and
+// still the built-in on current Windows, is the baseline: it needs
+// UseBasicParsing (there may be no IE engine to fall back on), and both its
+// success-path dictionary and the WebHeaderCollection hanging off a
+// WebException expose headers by key, so the keyed branch covers it. Absent
+// properties read as null in PowerShell rather than throwing, which is what
+// makes the null check a safe way to tell the shapes apart.
+//
+// Header values are a string in 5.1 and a list in 6+, so they are joined.
+func (s *WinFS) httpHead(ctx context.Context, rawURL string) (*URLInfo, error) {
+	script := fmt.Sprintf(`$ProgressPreference='SilentlyContinue'
+$ErrorActionPreference='Stop'
+$v=$PSVersionTable.PSVersion.Major
+$params=@{Uri=%s;Method='HEAD'}
+if($v -lt 6){$params['UseBasicParsing']=$true}
+if($v -ge 7){$params['SkipHttpErrorCheck']=$true}
+function Emit($code,$headers){
+  "HTTP/1.1 " + [int]$code
+  if($headers -eq $null){return}
+  if($headers.Keys -ne $null){
+    foreach($k in $headers.Keys){"{0}: {1}" -f $k,($headers[$k] -join ',')}
+  }else{
+    foreach($p in $headers.GetEnumerator()){"{0}: {1}" -f $p.Key,($p.Value -join ',')}
+  }
+}
+try{
+  $r=Invoke-WebRequest @params
+  Emit $r.StatusCode $r.Headers
+}catch{
+  $resp=$_.Exception.Response
+  if($resp -eq $null){Write-Error $_.Exception.Message;exit 1}
+  Emit $resp.StatusCode $resp.Headers
+}`, ps.SingleQuote(rawURL))
+
+	out, err := s.ExecOutputContext(ctx, script, cmd.PS(), cmd.Sensitive())
+	if err != nil {
+		return nil, fmt.Errorf("http-head %s: %w", rawURL, err)
+	}
+	info, err := parseHeadResponse(out)
+	if err != nil {
+		return nil, fmt.Errorf("http-head %s: %w", rawURL, err)
+	}
+	return info, nil
+}
+
 // httpStatusInsecure checks whether url is reachable and returns the HTTP status
 // code. On PowerShell 6+, TLS certificate verification is skipped. On PowerShell
 // 5.x, TLS certificate verification is not skipped and requests will fail for


### PR DESCRIPTION
Deciding whether a file already on a host is the current content of a URL needs the server's own view of that URL. Add HTTPHead, which runs an HTTP HEAD from the remote host and reports status, Content-Length, ETag, Last-Modified and Accept-Ranges.

The request deliberately runs on the host rather than on the machine running rig, so the answer reflects what the host can actually reach -- which differs whenever the two do not share a view of the network, as with an internal mirror.

Follows the HTTPStatusInsecure shape: an unexported provider method reached through a type assertion from a package-level helper, so no exported interface changes and no implementation is forced to grow a method. Unlike HTTPStatusInsecure, TLS certificates are verified. A non-2xx status is returned without an error, since servers that reject HEAD answer 405 and the caller is better placed to decide what that means.

Redirects make curl and wget emit one header block per response, and the earlier ones carry values that must not leak -- a 302 commonly has its own Content-Length of 0. Every status line therefore restarts the accumulated result. The parser is shared by the curl, wget and PowerShell paths, which is why the PowerShell script synthesizes a status line; it was checked against real curl and wget output for a GitHub release asset.

Refs k0sproject/k0sctl#1131