### PR TITLE
fix(sshconfig): don't panic in Finalize on a non-string map value

### DIFF
--- a/sshconfig/set.go
+++ b/sshconfig/set.go
@@ -973,7 +973,8 @@ func (s *Setter) Set(key string, values ...string) error {
 	return nil
 }
 
-// Reset sets a field to its zero value. This is useful in testing.
+// Reset clears a field. A pointer field is set to a pointer to its zero value,
+// any other field to the zero value itself. This is useful in testing.
 func (s *Setter) Reset(key string) error {
 	info, ok := knownKeys[strings.ToLower(key)]
 	if !ok {
@@ -983,7 +984,6 @@ func (s *Setter) Reset(key string) error {
 	if !ok {
 		return fmt.Errorf("%w: field %q is not found", errFieldNotFound, key)
 	}
-	// Set a pointer to nil and a non-pointer to zero value.
 	if field.Kind() == reflect.Pointer {
 		field.Set(reflect.New(field.Type().Elem()))
 	} else {
@@ -1020,25 +1020,55 @@ func (s *Setter) Finalize() error { //nolint:cyclop
 				field.Set(reflect.ValueOf(newVal))
 			}
 		case reflect.Map:
-			// do nothing unless it's a map[string]string
-			if field.Type().Key().Kind() != reflect.String && field.Type().Elem().Kind() != reflect.String {
+			// Only map[string]string can be expanded. Anything else, such as
+			// ChannelTimeout's map[string]time.Duration, must not reach it. The types are
+			// compared instead of the kinds because expandStringMap indexes the map with a
+			// plain string, which a named string key type would not accept.
+			if field.Type() != reflect.TypeFor[map[string]string]() {
 				continue
 			}
-			if info.key != "LocalForward" && info.key != "RemoteForward" {
-				for _, k := range field.MapKeys() {
-					value := field.MapIndex(k)
-					if value.Len() == 1 && strings.Contains(value.Index(0).String(), "$") {
-						newValue, err := shellescape.Expand(value.Index(0).String(), shellescape.ExpandNoDollarVars(), shellescape.ExpandErrorIfUnset())
-						if err != nil {
-							return fmt.Errorf("%w: failed to expand localforward value %q: %w", errInvalidValue, info.key, err)
-						}
-						field.SetMapIndex(k, reflect.ValueOf([]string{newValue}))
-					}
-				}
-				continue
+			if err := s.expandStringMap(field, info); err != nil {
+				return err
 			}
 		}
 	}
+	return nil
+}
+
+// expandStringMap expands the keys and the values of a map[string]string field according to the
+// expansion rules of the key. Both halves are expanded because a forwarding entry can use a unix
+// socket path on either side and those accept tokens.
+//
+// The result is collected into a new map so that two entries expanding into the same key are
+// reported as an error instead of one of them silently replacing the other.
+func (s *Setter) expandStringMap(field reflect.Value, info keyInfo) error {
+	oldKeys := make([]string, 0, field.Len())
+	for _, k := range field.MapKeys() {
+		oldKeys = append(oldKeys, k.String())
+	}
+	if len(oldKeys) == 0 {
+		return nil
+	}
+	// Sorted so that a collision is always reported against the same entry.
+	slices.Sort(oldKeys)
+
+	expanded := reflect.MakeMapWithSize(field.Type(), len(oldKeys))
+	for _, oldKey := range oldKeys {
+		newKey, err := s.expand(oldKey, info)
+		if err != nil {
+			return fmt.Errorf("%w: failed to expand %q key %q: %w", errInvalidValue, info.key, oldKey, err)
+		}
+		oldValue := field.MapIndex(reflect.ValueOf(oldKey)).String()
+		newValue, err := s.expand(oldValue, info)
+		if err != nil {
+			return fmt.Errorf("%w: failed to expand %q value %q: %w", errInvalidValue, info.key, oldValue, err)
+		}
+		if expanded.MapIndex(reflect.ValueOf(newKey)).IsValid() {
+			return fmt.Errorf("%w: %q key %q expands to %q which is already set", errInvalidValue, info.key, oldKey, newKey)
+		}
+		expanded.SetMapIndex(reflect.ValueOf(newKey), reflect.ValueOf(newValue))
+	}
+	field.Set(expanded)
 	return nil
 }
 

--- a/sshconfig/set_test.go
+++ b/sshconfig/set_test.go
@@ -674,6 +674,14 @@ func TestSetterFieldChannelTimeout(t *testing.T) {
 		require.Equal(t, 1*time.Minute, obj.ChannelTimeout["agent-connection"], "original values should stick")
 		require.Equal(t, 1*time.Minute, obj.ChannelTimeout["direct-tcpip"], "original values should stick")
 	})
+	t.Run("finalize", func(t *testing.T) {
+		require.NoError(t, setter.Reset("ChannelTimeout"))
+		require.NoError(t, setter.Set("ChannelTimeout", "session=30"))
+		require.NotPanics(t, func() {
+			require.NoError(t, setter.Finalize())
+		}, "a map with non-string values must not reach the string expansion")
+		require.Equal(t, 30*time.Second, obj.ChannelTimeout["session"])
+	})
 }
 
 func TestSetterDurationFields(t *testing.T) {
@@ -1518,6 +1526,59 @@ func TestSetterFinalize(t *testing.T) {
 	require.Len(t, obj.IdentityFile, 2)
 	require.NotEqual(t, "~/foo", obj.IdentityFile[0])
 	require.Equal(t, "/tmp/22.txt", obj.IdentityFile[1])
+}
+
+func TestSetterFinalizeStringMaps(t *testing.T) {
+	t.Setenv("RIG_TEST_FINALIZE", "expanded")
+
+	t.Run("forwards expand tokens on both sides", func(t *testing.T) {
+		obj := sshconfig.Config{Port: 22, User: "bob"}
+		setter, err := sshconfig.NewSetter(&obj)
+		require.NoError(t, err)
+
+		require.NoError(t, setter.Set("LocalForward", "/tmp/%r.sock", "/run/%p.sock"))
+		require.NoError(t, setter.Finalize())
+		require.Equal(t, "/run/22.sock", obj.LocalForward["/tmp/bob.sock"])
+	})
+
+	t.Run("colliding keys are an error", func(t *testing.T) {
+		obj := sshconfig.Config{Port: 22}
+		setter, err := sshconfig.NewSetter(&obj)
+		require.NoError(t, err)
+
+		require.NoError(t, setter.Set("LocalForward", "/tmp/%p.sock", "/run/a.sock"))
+		require.NoError(t, setter.Set("LocalForward", "/tmp/22.sock", "/run/b.sock"))
+		require.ErrorContains(t, setter.Finalize(), "already set")
+	})
+
+	t.Run("a named key type is skipped", func(t *testing.T) {
+		type namedString string
+		obj := struct {
+			Port         int
+			LocalForward map[namedString]string
+		}{
+			Port:         22,
+			LocalForward: map[namedString]string{"/tmp/%p.sock": "/run/%p.sock"},
+		}
+		setter, err := sshconfig.NewSetter(&obj)
+		require.NoError(t, err)
+
+		require.NotPanics(t, func() {
+			require.NoError(t, setter.Finalize())
+		}, "a map that is not exactly map[string]string must not reach the string expansion")
+		require.Equal(t, "/run/%p.sock", obj.LocalForward["/tmp/%p.sock"])
+	})
+
+	t.Run("setenv is left alone", func(t *testing.T) {
+		obj := sshconfig.Config{Port: 22}
+		setter, err := sshconfig.NewSetter(&obj)
+		require.NoError(t, err)
+
+		require.NoError(t, setter.Set("SetEnv", "FOO=${RIG_TEST_FINALIZE}", "BAR=%p"))
+		require.NoError(t, setter.Finalize())
+		require.Equal(t, "${RIG_TEST_FINALIZE}", obj.SetEnv["FOO"], "SetEnv does not support expansion")
+		require.Equal(t, "%p", obj.SetEnv["BAR"], "SetEnv does not support expansion")
+	})
 }
 
 // matchExecutor records the commands run by a Match exec criteria and reports


### PR DESCRIPTION
Finalize skipped a map field only when NEITHER its key nor its element was a string. ChannelTimeout is a map[string]time.Duration, so its key being a string was enough to carry it into the branch below, which treats values as []string and calls reflect.Value.Len on them:

    panic: reflect: call of reflect.Value.Len on int64 Value

Any ssh config carrying a ChannelTimeout directive hit this. The condition now skips unless both the key and the element are strings, which is what the branch's comment already described.

Also corrects Reset's doc comment: a pointer field is set to a pointer to the zero value, not to nil, and that non-nil zero is what marks it unset.