### PR TITLE
feat(remotefs): make downloads atomic and add opt-in resume

### DIFF
--- a/remotefs/download.go
+++ b/remotefs/download.go
@@ -1,0 +1,272 @@
+package remotefs
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+)
+
+// ErrDownloadNotSupported is returned by the DownloadURL methods when the FS
+// implementation cannot fetch URLs, so a caller can tell that apart from a
+// transfer that was attempted and failed.
+//
+// [Download] never raises it itself, since every remotefs.FS exposes DownloadURL
+// for it to fall back to, but it does propagate one raised by the FS it was
+// given -- so testing for it with errors.Is stays meaningful there.
+var ErrDownloadNotSupported = errors.New("download not supported by this filesystem type")
+
+// urlFetcher is implemented by FS types that can fetch a URL into a given path.
+// The resume flag asks for an interrupted transfer to that same path to be
+// continued instead of restarted; implementations that cannot resume fall back
+// to a full transfer, which is always correct, just slower.
+//
+// It is the preferred path rather than the only one: it is what carries the
+// context and the resume flag, but [fetcherFor] falls back to the exported
+// DownloadURL so that [Download] works with any FS, not just this package's.
+type urlFetcher interface {
+	fetchURL(ctx context.Context, url, dst string, resume bool) error
+}
+
+// [downloadToTemp] reaches the implementations through a type assertion, so a
+// drifting signature would silently lose the capability rather than fail to
+// compile.
+var (
+	_ urlFetcher = (*PosixFS)(nil)
+	_ urlFetcher = (*WinFS)(nil)
+)
+
+// downloadToTemp fetches into a temporary file alongside dst and moves it onto
+// dst only once fetch reports success, so dst is never observed half-written.
+//
+// The temporary lives in the same directory as dst so the move is a rename
+// within one filesystem rather than a copy across two. It is removed if the
+// fetch fails; a hard crash can still strand one, which is the cost of never
+// leaving a truncated file at the destination.
+//
+// fetch receives the temporary path and may be called more than once with it.
+func downloadToTemp(ctx context.Context, fsys FS, dst string, fetch func(ctx context.Context, tmp string) error) error {
+	tmp, err := fsys.CreateTemp(fsys.Dir(dst), fsys.Base(dst)+".")
+	if err != nil {
+		return fmt.Errorf("download %s: create temporary file: %w", dst, err)
+	}
+
+	if err := fetch(ctx, tmp); err != nil {
+		// The destination is untouched, so the partial file has nothing left to
+		// say. A removal failure must not mask the download failure.
+		if rmErr := fsys.Remove(tmp); rmErr != nil {
+			return fmt.Errorf("%w (leaving %s behind: %w)", err, tmp, rmErr)
+		}
+		return err
+	}
+
+	if err := fsys.Rename(tmp, dst); err != nil {
+		if rmErr := fsys.Remove(tmp); rmErr != nil {
+			return fmt.Errorf("download %s: rename from %s: %w (leaving it behind: %w)", dst, tmp, err, rmErr)
+		}
+		return fmt.Errorf("download %s: rename from %s: %w", dst, tmp, err)
+	}
+	return nil
+}
+
+// fetcherFor returns how Download transfers url for fsys.
+//
+// The unexported provider is preferred, being the only path that honours a
+// context and can resume. Any other FS is still driven through DownloadURL,
+// which is all that remotefs.FS guarantees, so Download is not restricted to
+// this package's own implementations -- it just cannot cancel or resume on one.
+// Atomicity survives either way, since the move needs only exported methods.
+func fetcherFor(fsys FS, url string) func(ctx context.Context, dst string, resume bool) error {
+	if f, ok := fsys.(urlFetcher); ok {
+		return func(ctx context.Context, dst string, resume bool) error {
+			return f.fetchURL(ctx, url, dst, resume)
+		}
+	}
+	return func(_ context.Context, dst string, _ bool) error {
+		return fsys.DownloadURL(url, dst)
+	}
+}
+
+// downloadURL is the shared implementation behind the DownloadURL methods. It
+// keeps their signature and their acceptance of any URL string while routing
+// the transfer through a temporary file.
+//
+// This one cannot take [fetcherFor]'s fallback: it *is* what DownloadURL calls,
+// so reaching for the exported method would recurse. The compile-time
+// assertions above are what keep the guard from ever firing.
+func downloadURL(fsys FS, url, dst string) error {
+	f, ok := fsys.(urlFetcher)
+	if !ok {
+		return fmt.Errorf("download %s: %w", url, ErrDownloadNotSupported)
+	}
+	return downloadToTemp(context.Background(), fsys, dst, func(ctx context.Context, tmp string) error {
+		return f.fetchURL(ctx, url, tmp, false)
+	})
+}
+
+// downloadOptions carries the tunables for [Download].
+type downloadOptions struct {
+	resume bool
+}
+
+// DownloadOption configures [Download].
+type DownloadOption func(*downloadOptions)
+
+// WithResume keeps the partially transferred file when a download fails, and
+// continues it on the next [Download] call for the same url and destination
+// instead of starting over. Retrying is left to the caller; this only makes a
+// retry cheap.
+//
+// The partial is kept beside the destination under a name derived from both the
+// destination and the url, so a later call can only continue a file that its own
+// url and destination produced. Without this option a failed download leaves
+// nothing behind.
+//
+// Resuming assumes the bytes already on disk are a prefix of what the url serves
+// now. That holds for an interrupted transfer of unchanging content, which is
+// what versioned artifact URLs provide. It does not hold if the content behind
+// the url is replaced between attempts: neither curl nor wget can detect that,
+// and the result would be half of each version.
+//
+// To catch that before spending a transfer on it, record the ETag or
+// LastModified that [HTTPHead] reports for the url alongside the download,
+// compare it before retrying, and call [DiscardPartial] when it has changed. A
+// checksum over the finished file catches what no header can say.
+//
+// Windows hosts always restart the transfer: Invoke-WebRequest under Windows
+// PowerShell 5.1 cannot continue one. So does an FS from outside this package,
+// which can only be driven through its exported DownloadURL. The partial is
+// still kept and the result is still correct, so the option is safe to pass in
+// both cases, it just saves nothing.
+func WithResume() DownloadOption {
+	return func(o *downloadOptions) {
+		o.resume = true
+	}
+}
+
+// size returns the size of name, or zero when it cannot be determined.
+func size(fsys FS, name string) int64 {
+	info, err := fsys.Stat(name)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
+// partialPath is where an interrupted download of url to dst is parked.
+//
+// The url is folded into the name so that a partial can only ever be continued
+// by a call carrying the same url and destination. That is what makes resuming
+// across separate calls safe to offer: the alternative, a name derived from the
+// destination alone, would happily continue a partial left by a different url.
+func partialPath(fsys FS, dst, url string) string {
+	sum := sha256.Sum256([]byte(url))
+	return fsys.Join(fsys.Dir(dst), fsys.Base(dst)+".rigpart-"+hex.EncodeToString(sum[:6]))
+}
+
+// resumable reports whether the bytes already at the partial file can be
+// continued, and is deliberately conservative: anything it cannot confirm means
+// starting over, which is always correct and only costs time.
+func resumable(ctx context.Context, fsys FS, url string, have int64) bool {
+	if have <= 0 {
+		return false
+	}
+	info, err := HTTPHead(ctx, fsys, url)
+	if err != nil {
+		// Nothing is known about the url, including whether ranges work.
+		return false
+	}
+	if !info.AcceptRanges {
+		// curl refuses with exit 33 against a server that will not range, and
+		// would leave the transfer stranded rather than fall back.
+		return false
+	}
+	if info.ContentLength >= 0 && have > info.ContentLength {
+		// Longer than the whole resource, so it cannot be a prefix of it. Left
+		// alone, curl would ask for a range past the end, take the 416 as "this
+		// is already complete" and report success on the wrong bytes.
+		return false
+	}
+	return true
+}
+
+// Download fetches url to dst on the remote host.
+//
+// The transfer goes to a file beside dst and is renamed onto it only once it
+// completes, so dst is never observed half-written.
+//
+// Downloads are not retried here. A failed call returns its error and the caller
+// decides whether to try again; see [WithResume] for making that retry continue
+// where the last attempt stopped rather than starting over.
+//
+// An FS from outside this package is transferred through its exported
+// DownloadURL, so it still gets the atomic move and the url validation, but
+// neither cancellation nor resume: both need the richer internal provider that
+// PosixFS and WinFS implement.
+func Download(ctx context.Context, fsys FS, url, dst string, opts ...DownloadOption) error {
+	if err := validateHTTPURL(url); err != nil {
+		return fmt.Errorf("download: %w", err)
+	}
+	var options downloadOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	transfer := fetcherFor(fsys, url)
+
+	if !options.resume {
+		return downloadToTemp(ctx, fsys, dst, func(ctx context.Context, tmp string) error {
+			return transfer(ctx, tmp, false)
+		})
+	}
+
+	part := partialPath(fsys, dst, url)
+	// One stat answers both questions: whether there is anything to continue,
+	// and whether there is anything to clear out. With no partial yet -- every
+	// first attempt -- that is the only extra work this option costs, since
+	// resumable does not reach for a HEAD when there are no bytes to check.
+	have := size(fsys, part)
+	resume := resumable(ctx, fsys, url, have)
+	if !resume && have > 0 {
+		// Whatever is there cannot be built on. Emptying it is preferred over
+		// removing it, as it keeps the path stable for the attempt about to write
+		// it and needs no write permission on the directory. But truncate is a
+		// separate binary that a stripped host may not carry, and its absence
+		// must not turn a workable from-scratch restart into a failure, so a
+		// removal stands in: curl and wget both create the file they are given.
+		if err := fsys.Truncate(part, 0); err != nil {
+			if rmErr := fsys.Remove(part); rmErr != nil {
+				return fmt.Errorf("download %s: discard unusable partial %s: %w (removing it instead: %w)", url, part, err, rmErr)
+			}
+		}
+	}
+	if err := transfer(ctx, part, resume); err != nil {
+		// Deliberately kept: it is what the next call resumes from.
+		return err
+	}
+	if err := fsys.Rename(part, dst); err != nil {
+		return fmt.Errorf("download %s: rename %s to %s: %w", url, part, dst, err)
+	}
+	return nil
+}
+
+// DiscardPartial removes the partially transferred file that a [Download] with
+// [WithResume] leaves behind for this url and destination.
+//
+// Call it when abandoning a download for good. The partial is deliberately kept
+// across failures so that a later attempt can continue it, which means nothing
+// else will ever remove it, and an abandoned one holds its bytes on the
+// destination's filesystem indefinitely. For a large artifact that is the whole
+// download sitting there unreferenced.
+//
+// Having nothing to discard is not an error, so it is safe to call after a
+// download that succeeded or never started one.
+func DiscardPartial(fsys FS, url, dst string) error {
+	part := partialPath(fsys, dst, url)
+	if err := fsys.Remove(part); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("discard partial %s: %w", part, err)
+	}
+	return nil
+}

--- a/remotefs/download_test.go
+++ b/remotefs/download_test.go
@@ -1,0 +1,555 @@
+package remotefs_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/rig/v2/remotefs"
+	"github.com/k0sproject/rig/v2/rigtest"
+	"github.com/stretchr/testify/require"
+)
+
+// Test URLs use the .invalid TLD, which RFC 2606 reserves and guarantees will
+// never resolve. Nothing here reaches the network -- every FS is backed by a
+// rigtest.MockRunner, which records command strings instead of running them --
+// and an unresolvable host means that stays true even if a test is later
+// rewired by mistake.
+
+const (
+	tmpPath = "/var/lib/k0s/images/bundle.tar.AbCdEf"
+	dstPath = "/var/lib/k0s/images/bundle.tar"
+	testURL = "https://test.invalid/bundle.tar"
+)
+
+// mockDownloadRunner wires up a runner where mktemp yields a known path and
+// curl is available, so the interesting part is what the download does with it.
+func mockDownloadRunner() *rigtest.MockRunner {
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandOutput(rigtest.HasPrefix("mktemp"), tmpPath)
+	mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
+	return mr
+}
+
+// commandTouching returns the first recorded command mentioning substr.
+func commandTouching(t *testing.T, mr *rigtest.MockRunner, substr string) string {
+	t.Helper()
+	for _, c := range mr.Commands() {
+		if strings.Contains(c, substr) {
+			return c
+		}
+	}
+	return ""
+}
+
+// psScriptTouching returns the first recorded command whose decoded PowerShell
+// script mentions substr. The commands themselves carry only the base64 payload
+// that powershell.Cmd produces, so the script has to be decoded to be asserted
+// against.
+func psScriptTouching(t *testing.T, mr *rigtest.MockRunner, substr string) string {
+	t.Helper()
+	for _, c := range mr.Commands() {
+		script, ok := decodePSScript(c)
+		if ok && strings.Contains(script, substr) {
+			return script
+		}
+	}
+	return ""
+}
+
+func TestPosixDownloadURLIsAtomic(t *testing.T) {
+	t.Run("fetches into a temporary and renames onto the destination", func(t *testing.T) {
+		mr := mockDownloadRunner()
+		f := remotefs.NewPosixFS(mr)
+
+		require.NoError(t, f.DownloadURL("http://test.invalid/bundle.tar", dstPath))
+
+		curl := commandTouching(t, mr, "curl -sSLf")
+		require.NotEmpty(t, curl, "expected a curl invocation, got %v", mr.Commands())
+		// The temporary name starts with the destination name, so compare the
+		// -o argument rather than looking for the destination anywhere.
+		require.Contains(t, curl, "-o "+tmpPath, "curl must write to the temporary file")
+		require.NotContains(t, curl, "-o "+dstPath+" ", "curl must not write straight to the destination")
+
+		require.Contains(t, mr.LastCommand(), "mv", "the temporary must be renamed into place")
+		require.Contains(t, mr.LastCommand(), dstPath)
+	})
+
+	t.Run("the temporary is created next to the destination", func(t *testing.T) {
+		mr := mockDownloadRunner()
+		f := remotefs.NewPosixFS(mr)
+
+		require.NoError(t, f.DownloadURL("http://test.invalid/bundle.tar", dstPath))
+
+		mktemp := commandTouching(t, mr, "mktemp")
+		require.Contains(t, mktemp, "/var/lib/k0s/images/bundle.tar.",
+			"the temporary must share a directory with the destination so the rename stays within one filesystem")
+	})
+
+	t.Run("a failed fetch removes the temporary and never touches the destination", func(t *testing.T) {
+		mr := mockDownloadRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("curl"), errors.New("exit status 18"))
+		f := remotefs.NewPosixFS(mr)
+
+		err := f.DownloadURL("http://test.invalid/bundle.tar", dstPath)
+		require.Error(t, err)
+
+		require.NotEmpty(t, commandTouching(t, mr, "rm -- "+tmpPath), "the partial file must be cleaned up")
+		for _, c := range mr.Commands() {
+			require.NotContains(t, c, "mv", "nothing may be moved onto the destination after a failed fetch")
+		}
+	})
+
+	t.Run("a failed rename removes the temporary", func(t *testing.T) {
+		mr := mockDownloadRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("mv"), errors.New("exit status 1"))
+		f := remotefs.NewPosixFS(mr)
+
+		err := f.DownloadURL("http://test.invalid/bundle.tar", dstPath)
+		require.Error(t, err)
+		require.NotEmpty(t, commandTouching(t, mr, "rm -- "+tmpPath))
+	})
+
+	t.Run("a cleanup failure does not hide the download failure", func(t *testing.T) {
+		mr := mockDownloadRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("curl"), errors.New("exit status 18"))
+		mr.AddCommandFailure(rigtest.HasPrefix("rm"), errors.New("permission denied"))
+		f := remotefs.NewPosixFS(mr)
+
+		err := f.DownloadURL("http://test.invalid/bundle.tar", dstPath)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "exit status 18", "the original failure must survive")
+		require.ErrorContains(t, err, tmpPath, "the stranded file must be named")
+	})
+
+	t.Run("mktemp failure is reported", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("mktemp"), errors.New("no space left on device"))
+		f := remotefs.NewPosixFS(mr)
+
+		err := f.DownloadURL("http://test.invalid/bundle.tar", dstPath)
+		require.ErrorContains(t, err, "create temporary file")
+	})
+}
+
+func TestWindowsDownloadURLIsAtomic(t *testing.T) {
+	const (
+		winTmp = `C:\k0s\bundle.tar.AbCdEf`
+		winDst = `C:\k0s\bundle.tar`
+	)
+
+	mr := rigtest.NewMockRunner()
+	mr.Windows = true
+	mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), winTmp)
+	f := remotefs.NewWindowsFS(mr)
+
+	require.NoError(t, f.DownloadURL("http://test.invalid/bundle.tar", winDst))
+
+	fetch := psScriptTouching(t, mr, "Invoke-WebRequest")
+	require.NotEmpty(t, fetch, "expected an Invoke-WebRequest invocation, got %v", mr.Commands())
+	// The temporary name starts with the destination name, so compare the
+	// -OutFile argument rather than looking for the destination anywhere.
+	require.Contains(t, fetch, `-OutFile "`+winTmp+`"`, "the transfer must write to the temporary file")
+	require.NotContains(t, fetch, `-OutFile "`+winDst+`"`, "the transfer must not write straight to the destination")
+
+	rename := psScriptTouching(t, mr, "Move-Item")
+	require.NotEmpty(t, rename, "the temporary must be renamed into place, got %v", mr.Commands())
+	require.Contains(t, rename, `-LiteralPath "`+winTmp+`"`)
+	require.Contains(t, rename, `-Destination "`+winDst+`"`)
+}
+
+// headOutput builds a curl -I style response for the download tests.
+func headOutput(length int64, ranges bool) string {
+	out := "HTTP/2 200 \r\n"
+	if length >= 0 {
+		out += fmt.Sprintf("content-length: %d\r\n", length)
+	}
+	if ranges {
+		out += "accept-ranges: bytes\r\n"
+	}
+	return out + "\r\n"
+}
+
+// wgetHeadStderr builds the same response in the shape wget --spider
+// --server-response writes to stderr: two-space indent, mixed case, no CR.
+func wgetHeadStderr(length int64, ranges bool) string {
+	out := "  HTTP/1.1 200 OK\n"
+	if length >= 0 {
+		out += fmt.Sprintf("  Content-Length: %d\n", length)
+	}
+	if ranges {
+		out += "  Accept-Ranges: bytes\n"
+	}
+	return out
+}
+
+// resumeRunner records the resume flag seen on each transfer and reports a
+// fixed size for the partial file.
+type resumeRunner struct {
+	*rigtest.MockRunner
+	resumeSeen []bool
+	// truncateErr and removeErr are what emptying and removing the partial fail
+	// with. They are read when the command runs, so a test can set them after
+	// the runner is built.
+	truncateErr error
+	removeErr   error
+}
+
+func newResumeRunner(t *testing.T, head string, partSize int64, transferErr error) *resumeRunner {
+	t.Helper()
+	rr := &resumeRunner{MockRunner: rigtest.NewMockRunner()}
+	rr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
+	rr.AddCommandOutput(rigtest.HasPrefix("curl -sS -L -I"), head)
+	rr.addPartialProbes(partSize)
+	rr.AddCommand(rigtest.HasPrefix("curl -sSLf"), func(a *rigtest.A) error {
+		rr.resumeSeen = append(rr.resumeSeen, strings.Contains(a.Command, "-C -"))
+		return transferErr
+	})
+	return rr
+}
+
+// newWgetResumeRunner is newResumeRunner for a host without curl, so the wget
+// fallback in PosixFS.fetchURL is what runs. wget reports headers on stderr and
+// makes its HEAD request with --spider, so that is matched ahead of the transfer:
+// the mock takes the first matching handler.
+func newWgetResumeRunner(t *testing.T, head string, partSize int64, transferErr error) *resumeRunner {
+	t.Helper()
+	rr := &resumeRunner{MockRunner: rigtest.NewMockRunner()}
+	rr.AddCommandFailure(rigtest.Equal("command -v curl"), errors.New("exit status 127"))
+	rr.AddCommandOutput(rigtest.Equal("command -v wget"), "/usr/bin/wget")
+	rr.AddCommand(rigtest.HasPrefix("wget --spider"), func(a *rigtest.A) error {
+		_, err := fmt.Fprint(a.Stderr, head)
+		return err
+	})
+	rr.addPartialProbes(partSize)
+	rr.AddCommand(rigtest.HasPrefix("wget"), func(a *rigtest.A) error {
+		rr.resumeSeen = append(rr.resumeSeen, strings.Contains(a.Command, " -c "))
+		return transferErr
+	})
+	return rr
+}
+
+// addPartialProbes wires up what Download asks about the partial file: the stat
+// behind size, the existence check, mktemp for the non-resuming path and
+// truncate for discarding an unusable partial. A negative partSize means there
+// is no partial.
+func (rr *resumeRunner) addPartialProbes(partSize int64) {
+	rr.AddCommand(rigtest.HasPrefix("truncate"), func(_ *rigtest.A) error { return rr.truncateErr })
+	rr.AddCommand(rigtest.HasPrefix("rm"), func(_ *rigtest.A) error { return rr.removeErr })
+	rr.AddCommandOutput(rigtest.HasPrefix("mktemp"), tmpPath)
+	// test -f, used by FileExist.
+	rr.AddCommand(rigtest.HasPrefix("test -f"), func(_ *rigtest.A) error {
+		if partSize < 0 {
+			return errors.New("exit status 1")
+		}
+		return nil
+	})
+	rr.AddCommand(rigtest.HasPrefix("env -i"), func(a *rigtest.A) error {
+		if partSize < 0 {
+			return errors.New("exit status 1")
+		}
+		_, err := fmt.Fprintf(a.Stdout, "0x81a4 %d 2024-09-30 11:42:01.000000000 +0000 //part//\n", partSize)
+		return err
+	})
+}
+
+// partialFor mirrors the naming Download uses, so the tests assert against the
+// same rule rather than a copied literal.
+func partialFor(t *testing.T, dst, url string) string {
+	t.Helper()
+	sum := sha256.Sum256([]byte(url))
+	return dst + ".rigpart-" + hex.EncodeToString(sum[:6])
+}
+
+// foreignFS is an FS implemented outside this package: it provides the exported
+// Downloader and the few methods the atomic move needs, but not the unexported
+// fetch provider that PosixFS and WinFS have. Everything else is inherited from
+// the embedded nil interface and would panic if reached, which keeps the stub
+// honest about what Download actually touches.
+type foreignFS struct {
+	remotefs.FS
+	tmp         string
+	fetchedTo   []string
+	renamedTo   map[string]string
+	downloadErr error
+}
+
+func newForeignFS(tmp string) *foreignFS {
+	return &foreignFS{tmp: tmp, renamedTo: map[string]string{}}
+}
+
+func (f *foreignFS) DownloadURL(_, dst string) error {
+	f.fetchedTo = append(f.fetchedTo, dst)
+	return f.downloadErr
+}
+
+func (f *foreignFS) CreateTemp(_, _ string) (string, error) { return f.tmp, nil }
+func (f *foreignFS) Rename(oldpath, newpath string) error {
+	f.renamedTo[oldpath] = newpath
+	return nil
+}
+func (f *foreignFS) Remove(string) error        { return nil }
+func (f *foreignFS) Dir(p string) string        { return path.Dir(p) }
+func (f *foreignFS) Base(p string) string       { return path.Base(p) }
+func (f *foreignFS) Join(elem ...string) string { return path.Join(elem...) }
+func (f *foreignFS) Stat(string) (fs.FileInfo, error) {
+	// No partial file, which is what makes the resume case a full transfer.
+	return nil, fs.ErrNotExist
+}
+
+// An FS from outside this package cannot implement the unexported fetch
+// provider, but it does implement the exported Downloader that remotefs.FS
+// embeds, so Download drives it through that rather than refusing it.
+func TestDownloadForeignFS(t *testing.T) {
+	t.Run("transfers through the exported DownloadURL, atomically", func(t *testing.T) {
+		f := newForeignFS(tmpPath)
+		require.NoError(t, remotefs.Download(context.Background(), f, testURL, dstPath))
+
+		require.Equal(t, []string{tmpPath}, f.fetchedTo,
+			"the transfer must be handed the temporary, never the destination")
+		require.Equal(t, dstPath, f.renamedTo[tmpPath],
+			"and the temporary must be renamed onto the destination")
+	})
+
+	t.Run("a failed transfer still reports", func(t *testing.T) {
+		f := newForeignFS(tmpPath)
+		f.downloadErr = errors.New("exit status 22")
+
+		err := remotefs.Download(context.Background(), f, testURL, dstPath)
+		require.ErrorContains(t, err, "exit status 22")
+		require.Empty(t, f.renamedTo, "nothing may land on the destination after a failed transfer")
+	})
+
+	t.Run("WithResume is accepted and simply does not resume", func(t *testing.T) {
+		f := newForeignFS(tmpPath)
+		require.NoError(t, remotefs.Download(context.Background(), f, testURL, dstPath, remotefs.WithResume()))
+		require.Len(t, f.fetchedTo, 1, "one full transfer, since DownloadURL cannot be told to continue")
+	})
+
+	t.Run("the url is still validated", func(t *testing.T) {
+		f := newForeignFS(tmpPath)
+		err := remotefs.Download(context.Background(), f, "http://user:pass@test.invalid/a", dstPath)
+		require.ErrorContains(t, err, "credentials")
+		require.Empty(t, f.fetchedTo, "a rejected url must not reach the FS")
+	})
+}
+
+func TestDownloadWithoutResume(t *testing.T) {
+	t.Run("uses a throwaway temporary and removes it on failure", func(t *testing.T) {
+		rr := newResumeRunner(t, headOutput(1000, true), -1, errors.New("exit status 18"))
+		err := remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath)
+		require.Error(t, err)
+		require.Equal(t, []bool{false}, rr.resumeSeen, "a plain download never resumes")
+		require.NotEmpty(t, commandTouching(t, rr.MockRunner, "rm -- "+tmpPath),
+			"without WithResume nothing may be left behind")
+	})
+
+	t.Run("does not consult the server at all", func(t *testing.T) {
+		rr := newResumeRunner(t, headOutput(1000, true), -1, nil)
+		require.NoError(t, remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath))
+		require.Empty(t, commandTouching(t, rr.MockRunner, "curl -sS -L -I"),
+			"a HEAD is only needed to decide whether to resume")
+	})
+}
+
+func TestDownloadWithResume(t *testing.T) {
+	part := partialFor(t, dstPath, testURL)
+
+	t.Run("keeps the partial file when the transfer fails", func(t *testing.T) {
+		rr := newResumeRunner(t, headOutput(1000, true), -1, errors.New("exit status 18"))
+		err := remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume())
+		require.Error(t, err)
+		require.Empty(t, commandTouching(t, rr.MockRunner, "rm -- "),
+			"the partial is what the next call resumes from, so it must survive")
+		require.Contains(t, commandTouching(t, rr.MockRunner, "curl -sSLf"), part,
+			"the transfer must write to the url-keyed partial")
+	})
+
+	t.Run("continues an existing partial", func(t *testing.T) {
+		rr := newResumeRunner(t, headOutput(1000, true), 400, nil)
+		require.NoError(t, remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume()))
+		require.Equal(t, []bool{true}, rr.resumeSeen)
+		require.Contains(t, rr.LastCommand(), "mv", "a completed transfer is renamed onto the destination")
+	})
+
+	t.Run("starts clean when there is no partial", func(t *testing.T) {
+		rr := newResumeRunner(t, headOutput(1000, true), -1, nil)
+		require.NoError(t, remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume()))
+		require.Equal(t, []bool{false}, rr.resumeSeen)
+	})
+
+	t.Run("a first attempt costs one stat and nothing else", func(t *testing.T) {
+		// This is why there is no separate keep-the-partial option: asking for
+		// resume before there is anything to resume behaves exactly like a plain
+		// download, so the same option can be passed on every attempt.
+		rr := newResumeRunner(t, headOutput(1000, true), -1, nil)
+		require.NoError(t, remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume()))
+
+		require.Empty(t, commandTouching(t, rr.MockRunner, "curl -sS -L -I"),
+			"there are no bytes to check, so the server is not consulted")
+		require.Empty(t, commandTouching(t, rr.MockRunner, "truncate"),
+			"there is nothing to clear out")
+		require.Empty(t, commandTouching(t, rr.MockRunner, "test -f"),
+			"the stat already answered whether a partial exists")
+
+		probes := 0
+		for _, c := range rr.Commands() {
+			if strings.HasPrefix(c, "env -i") {
+				probes++
+			}
+		}
+		require.Equal(t, 1, probes, "one stat, not one per question asked about the partial")
+	})
+
+	t.Run("starts clean when the server will not range", func(t *testing.T) {
+		rr := newResumeRunner(t, headOutput(1000, false), 400, nil)
+		require.NoError(t, remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume()))
+		require.Equal(t, []bool{false}, rr.resumeSeen, "curl exits 33 rather than falling back, so do not ask")
+		require.NotEmpty(t, commandTouching(t, rr.MockRunner, "truncate"), "the unusable partial is emptied first")
+	})
+
+	t.Run("discards a partial longer than the resource", func(t *testing.T) {
+		// curl would range past the end, read the 416 as "already complete" and
+		// report success on the wrong bytes.
+		rr := newResumeRunner(t, headOutput(1000, true), 4000, nil)
+		require.NoError(t, remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume()))
+		require.Equal(t, []bool{false}, rr.resumeSeen)
+		require.NotEmpty(t, commandTouching(t, rr.MockRunner, "truncate"))
+	})
+
+	t.Run("starts clean when the url cannot be inspected", func(t *testing.T) {
+		rr := &resumeRunner{MockRunner: rigtest.NewMockRunner()}
+		rr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
+		rr.AddCommandFailure(rigtest.HasPrefix("curl -sS -L -I"), errors.New("exit status 6"))
+		rr.AddCommandOutput(rigtest.HasPrefix("truncate"), "")
+		rr.AddCommand(rigtest.HasPrefix("test -f"), func(a *rigtest.A) error { return nil })
+		rr.AddCommand(rigtest.HasPrefix("env -i"), func(a *rigtest.A) error {
+			_, err := fmt.Fprintf(a.Stdout, "0x81a4 400 2024-09-30 11:42:01.000000000 +0000 //part//\n")
+			return err
+		})
+		rr.AddCommand(rigtest.HasPrefix("curl -sSLf"), func(a *rigtest.A) error {
+			rr.resumeSeen = append(rr.resumeSeen, strings.Contains(a.Command, "-C -"))
+			return nil
+		})
+		require.NoError(t, remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume()))
+		require.Equal(t, []bool{false}, rr.resumeSeen, "an unknown url means no promise that ranges work")
+	})
+
+	t.Run("a different url does not continue this partial", func(t *testing.T) {
+		other := partialFor(t, dstPath, "https://test.invalid/other.tar")
+		require.NotEqual(t, part, other,
+			"the partial name must key on the url, or a leftover from one url would be fed to another")
+	})
+
+	t.Run("removes an unusable partial when truncate is missing", func(t *testing.T) {
+		// truncate is a separate binary, so a stripped host may not have it. That
+		// must not turn a restart that would have worked into a failure.
+		rr := newResumeRunner(t, headOutput(1000, false), 400, nil)
+		rr.truncateErr = errors.New("sh: truncate: not found")
+
+		require.NoError(t, remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume()))
+		require.NotEmpty(t, commandTouching(t, rr.MockRunner, "rm -- "+part),
+			"the partial must be removed once it could not be emptied")
+		require.Equal(t, []bool{false}, rr.resumeSeen, "the restart is still a full transfer")
+		require.Contains(t, rr.LastCommand(), "mv", "and it still lands on the destination")
+	})
+
+	t.Run("reports both failures when the partial cannot be cleared at all", func(t *testing.T) {
+		rr := newResumeRunner(t, headOutput(1000, false), 400, nil)
+		rr.truncateErr = errors.New("sh: truncate: not found")
+		rr.removeErr = errors.New("Permission denied")
+
+		err := remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume())
+		require.ErrorContains(t, err, "discard unusable partial")
+		require.ErrorContains(t, err, "truncate: not found", "the first failure must survive")
+		require.ErrorContains(t, err, "Permission denied", "and so must the one from the fallback")
+	})
+
+	t.Run("rejects urls with credentials", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		err := remotefs.Download(context.Background(), remotefs.NewPosixFS(mr), "http://user:pass@test.invalid/a", dstPath)
+		require.ErrorContains(t, err, "credentials")
+	})
+}
+
+// The wget fallback gets its own resume coverage because its flags are not a
+// rename of curl's: resume is -c, and the destination is named by -qO, which the
+// wget manual says truncates the output file immediately. It does not do that
+// when -c is also given -- wget 1.25 sends Range: bytes=<have>- and appends --
+// but the invocation is exactly the kind that looks safe to "simplify" into
+// something that would silently stop resuming.
+func TestDownloadWithResumeViaWget(t *testing.T) {
+	part := partialFor(t, dstPath, testURL)
+
+	t.Run("continues an existing partial", func(t *testing.T) {
+		rr := newWgetResumeRunner(t, wgetHeadStderr(1000, true), 400, nil)
+		require.NoError(t, remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume()))
+		require.Equal(t, []bool{true}, rr.resumeSeen)
+
+		transfer := commandTouching(t, rr.MockRunner, "-qO")
+		require.NotEmpty(t, transfer, "expected a wget transfer, got %v", rr.Commands())
+		require.Contains(t, transfer, "wget -c -qO "+part, "resume must be asked for, and the partial must be what -qO names")
+		require.Contains(t, rr.LastCommand(), "mv", "a completed transfer is renamed onto the destination")
+	})
+
+	t.Run("starts clean when there is no partial", func(t *testing.T) {
+		rr := newWgetResumeRunner(t, wgetHeadStderr(1000, true), -1, nil)
+		require.NoError(t, remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume()))
+		require.Equal(t, []bool{false}, rr.resumeSeen)
+		require.Contains(t, commandTouching(t, rr.MockRunner, "-qO"), "wget -qO "+part,
+			"with nothing to continue the transfer must not carry -c")
+	})
+
+	t.Run("starts clean when the server will not range", func(t *testing.T) {
+		rr := newWgetResumeRunner(t, wgetHeadStderr(1000, false), 400, nil)
+		require.NoError(t, remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath, remotefs.WithResume()))
+		require.Equal(t, []bool{false}, rr.resumeSeen)
+		require.NotEmpty(t, commandTouching(t, rr.MockRunner, "truncate"), "the unusable partial is emptied first")
+	})
+
+	t.Run("a plain download never resumes and leaves nothing behind", func(t *testing.T) {
+		rr := newWgetResumeRunner(t, wgetHeadStderr(1000, true), -1, errors.New("exit status 8"))
+		err := remotefs.Download(context.Background(), remotefs.NewPosixFS(rr), testURL, dstPath)
+		require.Error(t, err)
+		require.Equal(t, []bool{false}, rr.resumeSeen)
+		require.NotEmpty(t, commandTouching(t, rr.MockRunner, "rm -- "+tmpPath),
+			"without WithResume nothing may be left behind")
+	})
+}
+
+func TestDiscardPartial(t *testing.T) {
+	t.Run("removes the partial for this url and destination", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		require.NoError(t, remotefs.DiscardPartial(remotefs.NewPosixFS(mr), testURL, dstPath))
+		require.Contains(t, mr.LastCommand(), partialFor(t, dstPath, testURL))
+	})
+
+	t.Run("nothing to discard is not an error", func(t *testing.T) {
+		// Remove reports a not-exist error, which is the normal case after a
+		// download that succeeded or never started one.
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("rm"), errors.New("No such file or directory"))
+		require.NoError(t, remotefs.DiscardPartial(remotefs.NewPosixFS(mr), testURL, dstPath))
+	})
+
+	t.Run("a real removal failure is reported", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		mr.AddCommandFailure(rigtest.HasPrefix("rm"), errors.New("Permission denied"))
+		err := remotefs.DiscardPartial(remotefs.NewPosixFS(mr), testURL, dstPath)
+		require.ErrorContains(t, err, "discard partial")
+	})
+
+	t.Run("does not touch the destination", func(t *testing.T) {
+		mr := rigtest.NewMockRunner()
+		require.NoError(t, remotefs.DiscardPartial(remotefs.NewPosixFS(mr), testURL, dstPath))
+		for _, c := range mr.Commands() {
+			require.NotContains(t, c, "rm -- "+dstPath+" ", "only the partial may be removed")
+		}
+	})
+}

--- a/remotefs/http_test.go
+++ b/remotefs/http_test.go
@@ -12,17 +12,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test URLs use the .invalid TLD, which RFC 2606 reserves and guarantees will
+// never resolve. Nothing here reaches the network -- every FS is backed by a
+// rigtest.MockRunner, which records command strings instead of running them --
+// and an unresolvable host means that stays true even if a test is later
+// rewired by mistake.
+
 func TestHTTPStatusInsecureURLValidation(t *testing.T) {
 	mr := rigtest.NewMockRunner()
 	f := remotefs.NewPosixFS(mr)
 
 	for _, rawURL := range []string{
 		"file:///etc/passwd",
-		"ftp://example.com",
+		"ftp://test.invalid",
 		"http:///path",
 		"/relative/path",
-		"http://user:pass@example.com",
-		"http://example.com\x00",
+		"http://user:pass@test.invalid",
+		"http://test.invalid\x00",
 	} {
 		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, rawURL)
 		require.Error(t, err, "expected error for %q", rawURL)
@@ -34,7 +40,7 @@ func TestPosixHTTPStatusInsecure(t *testing.T) {
 		mr := rigtest.NewMockRunner()
 		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "200")
 		f := remotefs.NewPosixFS(mr)
-		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://test.invalid/health")
 		require.NoError(t, err)
 		require.Equal(t, 200, code)
 		require.Contains(t, mr.LastCommand(), "-k")
@@ -43,7 +49,7 @@ func TestPosixHTTPStatusInsecure(t *testing.T) {
 		mr := rigtest.NewMockRunner()
 		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "503")
 		f := remotefs.NewPosixFS(mr)
-		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://test.invalid/health")
 		require.NoError(t, err)
 		require.Equal(t, 503, code)
 	})
@@ -51,7 +57,7 @@ func TestPosixHTTPStatusInsecure(t *testing.T) {
 		mr := rigtest.NewMockRunner()
 		mr.AddCommandFailure(rigtest.HasPrefix("curl"), errors.New("exit status 60"))
 		f := remotefs.NewPosixFS(mr)
-		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://test.invalid/health")
 		require.Error(t, err)
 	})
 }
@@ -68,7 +74,7 @@ func TestPosixHTTPStatusInsecureWget(t *testing.T) {
 			return err
 		})
 		f := remotefs.NewPosixFS(mr)
-		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://test.invalid/health")
 		require.NoError(t, err)
 		require.Equal(t, 200, code)
 	})
@@ -82,7 +88,7 @@ func TestPosixHTTPStatusInsecureWget(t *testing.T) {
 			return err
 		})
 		f := remotefs.NewPosixFS(mr)
-		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://test.invalid/health")
 		require.NoError(t, err)
 		require.Equal(t, 301, code)
 	})
@@ -92,7 +98,7 @@ func TestPosixHTTPStatusInsecureWget(t *testing.T) {
 		mr.AddCommandFailure(rigtest.Equal("command -v curl"), noCurl)
 		mr.AddCommandFailure(rigtest.Equal("command -v wget"), noCurl)
 		f := remotefs.NewPosixFS(mr)
-		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://test.invalid/health")
 		require.ErrorIs(t, err, remotefs.ErrHTTPStatusNotSupported)
 	})
 }
@@ -103,7 +109,7 @@ func TestWindowsHTTPStatusInsecure(t *testing.T) {
 		mr.Windows = true
 		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), "200")
 		f := remotefs.NewWindowsFS(mr)
-		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		code, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://test.invalid/health")
 		require.NoError(t, err)
 		require.Equal(t, 200, code)
 	})
@@ -112,7 +118,7 @@ func TestWindowsHTTPStatusInsecure(t *testing.T) {
 		mr.Windows = true
 		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
 		f := remotefs.NewWindowsFS(mr)
-		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://example.com/health")
+		_, err := remotefs.HTTPStatusInsecure(context.Background(), f, "https://test.invalid/health")
 		require.Error(t, err)
 	})
 }
@@ -159,11 +165,11 @@ func TestHTTPHeadURLValidation(t *testing.T) {
 
 	for _, rawURL := range []string{
 		"file:///etc/passwd",
-		"ftp://example.com",
+		"ftp://test.invalid",
 		"http:///path",
 		"/relative/path",
-		"http://user:pass@example.com",
-		"http://example.com\x00",
+		"http://user:pass@test.invalid",
+		"http://test.invalid\x00",
 	} {
 		_, err := remotefs.HTTPHead(context.Background(), f, rawURL)
 		require.Error(t, err, "expected error for %q", rawURL)
@@ -172,7 +178,7 @@ func TestHTTPHeadURLValidation(t *testing.T) {
 	// The loop above only asserts that an error came back. Pin the
 	// security-relevant branch so it cannot start failing for some unrelated
 	// reason while the credentials check silently goes away.
-	_, err := remotefs.HTTPHead(context.Background(), f, "http://user:pass@example.com")
+	_, err := remotefs.HTTPHead(context.Background(), f, "http://user:pass@test.invalid")
 	require.ErrorContains(t, err, "credentials")
 }
 
@@ -182,7 +188,7 @@ func TestPosixHTTPHead(t *testing.T) {
 		mr.AddCommandOutput(rigtest.HasPrefix("curl"), curlHeadOutput)
 		f := remotefs.NewPosixFS(mr)
 
-		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.NoError(t, err)
 		requireReleaseAsset(t, info)
 		require.NotContains(t, mr.LastCommand(), " -k", "HTTPHead must verify TLS certificates")
@@ -198,7 +204,7 @@ func TestPosixHTTPHead(t *testing.T) {
 		})
 		f := remotefs.NewPosixFS(mr)
 
-		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.NoError(t, err)
 		requireReleaseAsset(t, info)
 	})
@@ -215,7 +221,7 @@ func TestPosixHTTPHead(t *testing.T) {
 		})
 		f := remotefs.NewPosixFS(mr)
 
-		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.NoError(t, err)
 		require.Equal(t, 404, info.StatusCode)
 	})
@@ -225,7 +231,7 @@ func TestPosixHTTPHead(t *testing.T) {
 		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "HTTP/2 405 \r\n\r\n")
 		f := remotefs.NewPosixFS(mr)
 
-		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.NoError(t, err)
 		require.Equal(t, 405, info.StatusCode)
 	})
@@ -235,7 +241,7 @@ func TestPosixHTTPHead(t *testing.T) {
 		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "HTTP/2 200 \r\ntransfer-encoding: chunked\r\n\r\n")
 		f := remotefs.NewPosixFS(mr)
 
-		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.NoError(t, err)
 		require.Equal(t, int64(-1), info.ContentLength)
 		require.Empty(t, info.ETag)
@@ -248,7 +254,7 @@ func TestPosixHTTPHead(t *testing.T) {
 		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "HTTP/2 200 \r\naccept-ranges: none\r\n\r\n")
 		f := remotefs.NewPosixFS(mr)
 
-		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.NoError(t, err)
 		require.False(t, info.AcceptRanges)
 	})
@@ -258,7 +264,7 @@ func TestPosixHTTPHead(t *testing.T) {
 		mr.AddCommandOutput(rigtest.HasPrefix("curl"), "something went sideways")
 		f := remotefs.NewPosixFS(mr)
 
-		_, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		_, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.Error(t, err)
 	})
 
@@ -267,7 +273,7 @@ func TestPosixHTTPHead(t *testing.T) {
 		mr.AddCommandFailure(rigtest.HasPrefix("curl"), errors.New("exit status 6"))
 		f := remotefs.NewPosixFS(mr)
 
-		_, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		_, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.Error(t, err)
 	})
 
@@ -278,7 +284,7 @@ func TestPosixHTTPHead(t *testing.T) {
 		mr.AddCommandFailure(rigtest.Equal("command -v wget"), notFound)
 		f := remotefs.NewPosixFS(mr)
 
-		_, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		_, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.ErrorIs(t, err, remotefs.ErrHTTPHeadNotSupported)
 	})
 }
@@ -295,7 +301,7 @@ func TestWindowsHTTPHead(t *testing.T) {
 				"Accept-Ranges: bytes\r\n")
 		f := remotefs.NewWindowsFS(mr)
 
-		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.NoError(t, err)
 		requireReleaseAsset(t, info)
 	})
@@ -310,7 +316,7 @@ func TestWindowsHTTPHead(t *testing.T) {
 			"HTTP/1.1 404\r\nContent-Length: 9\r\n")
 		f := remotefs.NewWindowsFS(mr)
 
-		info, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		info, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.NoError(t, err)
 		require.Equal(t, 404, info.StatusCode)
 		require.Equal(t, int64(9), info.ContentLength)
@@ -322,7 +328,7 @@ func TestWindowsHTTPHead(t *testing.T) {
 		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit status 1"))
 		f := remotefs.NewWindowsFS(mr)
 
-		_, err := remotefs.HTTPHead(context.Background(), f, "https://example.com/a.tar")
+		_, err := remotefs.HTTPHead(context.Background(), f, "https://test.invalid/a.tar")
 		require.Error(t, err)
 	})
 }

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -29,6 +29,7 @@ var (
 	errGrepFailed              = errors.New("grep failed")
 	errTestFailed              = errors.New("test failed")
 	errStatInitFailed          = errors.New("stat command not found or unsupported stat implementation")
+	errEmptyTempPath           = errors.New("no temporary file path returned") // also returned by WinFS.CreateTemp
 
 	// The modification time is read from %y, which spells the timestamp out, rather
 	// than from the epoch seconds of %.9Y: the uutils (Rust) reimplementation of
@@ -527,17 +528,45 @@ func (s *PosixFS) ChownTreeInt(name string, uid, gid int) error {
 	return nil
 }
 
-// DownloadURL downloads the contents of url to dst. It prefers curl when available
-// and falls back to wget. Returns a descriptive error if neither is available.
+// DownloadURL downloads the contents of url to dst.
+//
+// The transfer goes to a temporary file next to dst and is renamed into place
+// only once it completes, so an interrupted download never leaves a truncated
+// file sitting at dst looking complete.
 func (s *PosixFS) DownloadURL(url, dst string) error {
+	return downloadURL(s, url, dst)
+}
+
+// fetchURL downloads url into dst. It prefers curl when available and falls
+// back to wget. Returns a descriptive error if neither is available.
+//
+// Resuming appends to whatever is already at dst, which is only sound because
+// the callers point it at a partial file they created themselves for this same
+// url. Neither tool can tell whether a local file is a valid prefix of the
+// remote one, so it must never be aimed at a file of unknown origin.
+//
+// wget takes -c alongside -qO even though its manual says -O truncates the
+// output file immediately: with -c it does not, and wget still sends the range
+// request (measured with wget 1.25 against a range-serving host).
+func (s *PosixFS) fetchURL(ctx context.Context, url, dst string, resume bool) error {
 	if _, err := s.LookPath("curl"); err == nil {
-		if err := s.Exec(sh.Command("curl", "-sSLf", "-o", dst, "--", url)); err != nil {
+		args := []string{"-sSLf", "-o", dst}
+		if resume {
+			args = append(args, "-C", "-")
+		}
+		args = append(args, "--", url)
+		if err := s.ExecContext(ctx, sh.Command("curl", args...), cmd.Sensitive()); err != nil {
 			return fmt.Errorf("download %s: %w", url, err)
 		}
 		return nil
 	}
 	if _, err := s.LookPath("wget"); err == nil {
-		if err := s.Exec(sh.Command("wget", "-qO", dst, "--", url)); err != nil {
+		args := []string{}
+		if resume {
+			args = append(args, "-c")
+		}
+		args = append(args, "-qO", dst, "--", url)
+		if err := s.ExecContext(ctx, sh.Command("wget", args...), cmd.Sensitive()); err != nil {
 			return fmt.Errorf("download %s: %w", url, err)
 		}
 		return nil
@@ -1019,6 +1048,13 @@ func (s *PosixFS) CreateTemp(dir, prefix string) (string, error) {
 	out, err := s.ExecOutput(sh.Command("mktemp", "--", s.Join(dir, prefix+"XXXXXX")))
 	if err != nil {
 		return "", fmt.Errorf("create temp %s: %w", dir, err)
+	}
+	// mktemp always prints the path it created, so silence means the command
+	// succeeded without doing the job. An empty string is not a path to anything:
+	// the callers would go on to run curl -o '' and mv -f '' dst, which fail
+	// naming nothing at all, a long way from the cause.
+	if out == "" {
+		return "", fmt.Errorf("create temp %s: %w", dir, errEmptyTempPath)
 	}
 	return out, nil
 }

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -73,30 +73,42 @@ func TestPosixSystemTime(t *testing.T) {
 }
 
 func TestPosixDownloadURL(t *testing.T) {
+	// The download fetches into a temporary and renames it onto the destination,
+	// so mktemp has to name one: without it CreateTemp fails, and before it
+	// failed these tests passed while running curl -o "" and mv -- "".
+	const downloadTmp = "/tmp/file.AbCdEf"
+
 	t.Run("curl", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.HasPrefix("mktemp"), downloadTmp)
 		mr.AddCommandOutput(rigtest.Equal("command -v curl"), "/usr/bin/curl")
 		mr.AddCommandSuccess(rigtest.HasPrefix("curl"))
 		f := remotefs.NewPosixFS(mr)
-		require.NoError(t, f.DownloadURL("http://example.com/file", "/tmp/file"))
+		require.NoError(t, f.DownloadURL("http://test.invalid/file", "/tmp/file"))
+		require.NoError(t, mr.Received(rigtest.Contains("curl -sSLf -o "+downloadTmp)))
+		require.NoError(t, mr.Received(rigtest.Contains("mv -f "+downloadTmp+" /tmp/file")))
 	})
 
 	t.Run("wget fallback", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.HasPrefix("mktemp"), downloadTmp)
 		mr.AddCommandFailure(rigtest.Equal("command -v curl"), errors.New("not found"))
 		mr.AddCommandOutput(rigtest.Equal("command -v wget"), "/usr/bin/wget")
 		mr.AddCommandSuccess(rigtest.HasPrefix("wget"))
 		f := remotefs.NewPosixFS(mr)
-		require.NoError(t, f.DownloadURL("http://example.com/file", "/tmp/file"))
+		require.NoError(t, f.DownloadURL("http://test.invalid/file", "/tmp/file"))
+		require.NoError(t, mr.Received(rigtest.Contains("wget -qO "+downloadTmp)))
 	})
 
 	t.Run("neither available", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
+		mr.AddCommandOutput(rigtest.HasPrefix("mktemp"), downloadTmp)
 		mr.AddCommandFailure(rigtest.Equal("command -v curl"), errors.New("not found"))
 		mr.AddCommandFailure(rigtest.Equal("command -v wget"), errors.New("not found"))
 		f := remotefs.NewPosixFS(mr)
-		err := f.DownloadURL("http://example.com/file", "/tmp/file")
-		require.Error(t, err)
+		err := f.DownloadURL("http://test.invalid/file", "/tmp/file")
+		require.ErrorContains(t, err, "neither curl nor wget",
+			"the failure must be the missing tools, not a missing temporary")
 	})
 }
 

--- a/remotefs/winfs.go
+++ b/remotefs/winfs.go
@@ -249,6 +249,13 @@ func (s *WinFS) CreateTemp(dir, prefix string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("create temp %s: %w", dir, err)
 	}
+	// The script writes the path it created or throws, so silence means neither
+	// happened. An empty string is not a path to anything: the callers would go
+	// on to run Invoke-WebRequest -OutFile "" and Move-Item -LiteralPath "",
+	// which fail naming nothing at all, a long way from the cause.
+	if out == "" {
+		return "", fmt.Errorf("create temp %s: %w", dir, errEmptyTempPath)
+	}
 	return toSlashes(out), nil
 }
 
@@ -491,7 +498,23 @@ func (s *WinFS) ChownTreeInt(name string, _, _ int) error {
 }
 
 // DownloadURL downloads the contents of url to dst using Invoke-WebRequest.
+//
+// The transfer goes to a temporary file next to dst and is renamed into place
+// only once it completes, so an interrupted download never leaves a truncated
+// file sitting at dst looking complete.
 func (s *WinFS) DownloadURL(url, dst string) error {
+	return downloadURL(s, url, dst)
+}
+
+// fetchURL downloads url into dst using Invoke-WebRequest.
+//
+// The resume flag is ignored: -Resume arrived in PowerShell 6.1, which ships
+// separately as pwsh.exe, while [cmd.PS] runs powershell.exe -- Windows
+// PowerShell 5.1 -- so it is never reachable here. Restarting is always
+// correct, as -OutFile rewrites the file from the beginning rather than
+// appending to it. UseBasicParsing is for that same 5.1 baseline, where there
+// may be no IE engine to parse the response with.
+func (s *WinFS) fetchURL(ctx context.Context, url, dst string, _ bool) error {
 	script := fmt.Sprintf(`$ProgressPreference='SilentlyContinue'
 try {
   Invoke-WebRequest -Uri %s -OutFile %s -UseBasicParsing -ErrorAction Stop | Out-Null
@@ -499,7 +522,7 @@ try {
   Write-Error $_.Exception.Message
   exit 1
 }`, ps.SingleQuote(url), ps.DoubleQuotePath(dst))
-	if err := s.Exec(script, cmd.PS()); err != nil {
+	if err := s.ExecContext(ctx, script, cmd.PS(), cmd.Sensitive()); err != nil {
 		return fmt.Errorf("download %s: %w", url, err)
 	}
 	return nil

--- a/remotefs/winfs_test.go
+++ b/remotefs/winfs_test.go
@@ -59,12 +59,22 @@ func TestWindowsSystemTime(t *testing.T) {
 }
 
 func TestWindowsDownloadURL(t *testing.T) {
+	// CreateTemp names the file the transfer writes to, so its output has to be
+	// a path: an empty one used to pass this test while running Invoke-WebRequest
+	// with -OutFile "".
+	const downloadTmp = `C:\tmp\file.AbCdEf`
+
 	t.Run("ok", func(t *testing.T) {
 		mr := rigtest.NewMockRunner()
 		mr.Windows = true
-		mr.AddCommandSuccess(rigtest.HasPrefix("powershell.exe"))
+		mr.AddCommandOutput(rigtest.HasPrefix("powershell.exe"), downloadTmp)
 		f := remotefs.NewWindowsFS(mr)
-		require.NoError(t, f.DownloadURL("http://example.com/file", `C:\tmp\file`))
+		require.NoError(t, f.DownloadURL("http://test.invalid/file", `C:\tmp\file`))
+
+		script, ok := decodePSScript(mr.LastCommand())
+		require.True(t, ok, "expected an encoded script, got %q", mr.LastCommand())
+		require.Contains(t, script, `Move-Item -Force -LiteralPath "`+downloadTmp+`"`,
+			"the temporary must be renamed into place")
 	})
 
 	t.Run("failure", func(t *testing.T) {
@@ -72,7 +82,7 @@ func TestWindowsDownloadURL(t *testing.T) {
 		mr.Windows = true
 		mr.AddCommandFailure(rigtest.HasPrefix("powershell.exe"), errors.New("exit 1"))
 		f := remotefs.NewWindowsFS(mr)
-		err := f.DownloadURL("http://example.com/file", `C:\tmp\file`)
+		err := f.DownloadURL("http://test.invalid/file", `C:\tmp\file`)
 		require.Error(t, err)
 	})
 }

--- a/remotefs/writefileatomic_test.go
+++ b/remotefs/writefileatomic_test.go
@@ -139,6 +139,9 @@ func TestWriteFileAtomic(t *testing.T) {
 // TestWriteFileAtomicPosix verifies WriteFileAtomic works end-to-end via PosixFS.
 func TestWriteFileAtomicPosix(t *testing.T) {
 	mr := rigtest.NewMockRunner()
+	// CreateTemp needs mktemp to name a file; without it the write would target
+	// an empty path.
+	mr.AddCommandOutput(rigtest.HasPrefix("mktemp"), "/srv/k0s.AbCdEf")
 
 	f := remotefs.NewPosixFS(mr)
 	err := remotefs.WriteFileAtomic(f, "/srv/k0s", []byte("binary"), 0o755)


### PR DESCRIPTION
DownloadURL wrote straight to the destination, so an interrupted transfer left a truncated file sitting there looking complete and nothing downstream could tell it apart from a finished one. It now fetches into a temporary alongside the destination and renames onto it only once the transfer succeeds. WriteFile already worked this way; DownloadURL was the outlier. The temporary shares a directory with the destination to keep the move a rename inside one filesystem, and is removed when the fetch or the rename fails, without hiding the original error.

Atomicity is also what makes resuming safe to offer at all: appending is only sound against a partial file rig created itself for that same url, since neither curl nor wget can tell whether a local file is a valid prefix of the remote one. Resume arrives as remotefs.WithResume() on a new package-level remotefs.Download(ctx, fs, url, dst, opts...), mirroring remotefs.Upload. It is a helper rather than options on DownloadURL because Download needs a context, and no variadic can add a leading one to a method already in the released Downloader interface. It also validates the url and rejects credentials in it, which DownloadURL deliberately keeps accepting.

Download does not retry. A failed call returns its error and the caller decides how many attempts, what backoff, whether to give up; rig has no business guessing. That puts provenance on the partial's name, since it now has to survive between separate calls: it is parked at <dst>.rigpart-<hash of url>, so a call can only ever continue a file its own url and destination produced, never a leftover from a different url.

Content replaced behind a stable url between attempts is the one hazard no local check can see. WithResume documents it and points at the ETag and Last-Modified that HTTPHead reports, for detecting it before spending a transfer, and at DiscardPartial for resetting. DiscardPartial is also the retry loop's exit: the partial is deliberately kept across failures, so nothing else ever removes it, and an abandoned one would hold a whole artifact's bytes on the destination indefinitely.

On Windows the transfer always restarts. Invoke-WebRequest gained -Resume in PowerShell 6.1, which ships separately as pwsh.exe, while rig runs its scripts through powershell.exe -- Windows PowerShell 5.1, the built-in on Windows Server 2019 and on current Windows -- so an in-script version probe could only ever take the negative branch. Passing WithResume there is still safe and still correct, just no cheaper: -OutFile rewrites the file from the beginning rather than appending, so a kept partial is replaced by a complete one. Resuming on stock Windows is possible -- curl.exe has shipped in System32 since Windows 10 1803 / Server 2019, and the resume gates here are protocol-agnostic already -- but it is left to a follow-up, ideally with a Windows host to verify against. On POSIX hosts the wget fallback does resume, with -c alongside -qO; its manual says -O truncates the output file immediately, but with -c it does not, and wget still sends the range request.

