### PR TITLE
fix(ssh): honour StrictHostKeyChecking=yes 

### DIFF
--- a/docs/MIGRATING-from-v0.x.md
+++ b/docs/MIGRATING-from-v0.x.md
@@ -753,13 +753,74 @@ same code works on both Linux and Windows targets.
 v2's host key behaviour follows OpenSSH conventions and is controlled by the same
 fields in `~/.ssh/config`:
 
-- **`StrictHostKeyChecking no`** disables host key verification (permissive mode).
-  Rig reads this from the parsed ssh_config and passes it through.
-- **`UserKnownHostsFile`** selects which known_hosts file to use. The first valid
-  entry in the list is used.
+- **`StrictHostKeyChecking`** selects how an unknown or changed host key is
+  treated. All four values are recognised, but only three behave as OpenSSH does:
+  `ask` has no terminal to prompt at, so it is treated as `accept-new`. See
+  [modes and trust sources](#stricthostkeychecking-modes-and-trust-sources) below.
+- **`UserKnownHostsFile`** selects the known_hosts files. A new key is recorded in
+  the first valid entry, as OpenSSH does it, but every entry counts when a key is
+  being verified — the default list has two.
 - **`HashKnownHosts yes`** causes new entries to be stored as hashed values.
 - The `SSH_KNOWN_HOSTS` environment variable, if set, overrides the config file path.
-  Setting it to an empty string disables host key checking entirely.
+  Setting it to an empty string disables host key checking entirely — except under
+  `StrictHostKeyChecking yes`, which refuses every host instead of honouring the
+  bypass. See [modes and trust sources](#stricthostkeychecking-modes-and-trust-sources).
+
+### `StrictHostKeyChecking` modes and trust sources
+
+What the modes differ in is how a host that is not on file is treated. `ask` is
+the one rig cannot implement the way OpenSSH does — there is no terminal to
+prompt at — so it is mapped onto `accept-new` rather than refused as unsupported:
+
+| Value | Not on file | Recorded key changed |
+|---|---|---|
+| `yes` | refused | refused |
+| `accept-new` | recorded\*, then accepted | refused |
+| `ask` | recorded\*, then accepted | refused |
+| `no` / `off` | recorded\*, then accepted | accepted, warning on stderr |
+| unset | recorded\*, then accepted | refused |
+
+\* Recording needs somewhere to record. A new key is written only when there is a
+writable user file to append to — a `UserKnownHostsFile` entry that is not
+`/dev/null`. With only global files, or with `/dev/null` as the first user entry,
+the key is accepted but **not** stored, so the next connection makes the same
+decision again instead of pinning what it saw the first time. The right-hand
+column then only applies to keys the other trust sources already hold.
+
+**`yes` no longer records keys.** Through v2.1.x every value except `no` took the
+recording path, so `yes` behaved as `accept-new`: rig connected to, and stored the
+key of, a host it had been told to refuse. If you were relying on that, ask for
+`accept-new`, which is the mode that describes it.
+
+Trust is assembled the same way for every mode:
+
+- Every `UserKnownHostsFile` entry and every `GlobalKnownHostsFile` entry is read
+  as **one trust set**, the way OpenSSH reads them, so a key suffices on its own
+  wherever it sits: the second entry of the user list (the default list has two,
+  `~/.ssh/known_hosts` and `~/.ssh/known_hosts2`) or a file an administrator
+  maintains, such as `/etc/ssh/ssh_known_hosts`.
+- A recording mode appends a new key to the **first** user entry, again as
+  OpenSSH does, but it decides whether the host is new at all against the whole
+  set. So a key that any file contradicts is a mismatch, not a new host, and is
+  neither recorded nor accepted.
+- `SSH_KNOWN_HOSTS` **replaces** those files rather than joining them. Setting it
+  to an empty string is rig's switch for skipping verification altogether, and
+  `yes` does not honour it: an explicit request for strict checking outranks the
+  bypass, so every host is refused. Drop `yes` if you want the switch.
+- A path that is only **read** — every file under `yes`, and every one but the
+  append target under a recording mode — contributes nothing when it is missing
+  or is not a regular file, rather than failing the connection.
+- The **append target** is held to more, since a recording mode has to be able to
+  write to it: a missing file is created, and one that cannot be opened for
+  writing — a directory, say — fails the connection instead of being skipped.
+  Under `yes` nothing is written, so a file that does not exist is not created
+  either.
+- `/dev/null` is an empty source wherever it is listed: beside a real file it does
+  not stop that file from being consulted, and as the append target it takes away
+  the record rather than the verification — an unknown host's key is accepted but
+  not stored, while a key the other files contradict is still a mismatch. As the
+  only source it means no verification is possible, which `no` and `accept-new`
+  take as "accept" while `yes` refuses every host.
 
 Host key mismatch errors are automatically wrapped with `ErrNonRetryable`, so the
 v0.x string-match workaround (`strings.Contains(err.Error(), "host key mismatch")`) is
@@ -793,9 +854,12 @@ consumes these fields from the parsed config:
 | `Port` | Port number |
 | `User` | Login user |
 | `IdentityFile` | Private key paths |
-| `StrictHostKeyChecking` | Permissive host key checking when set to `no` |
-| `UserKnownHostsFile` | Known hosts file path |
+| `StrictHostKeyChecking` | How an unknown or changed host key is treated — all four values, `ask` as `accept-new` (see [modes and trust sources](#stricthostkeychecking-modes-and-trust-sources)) |
+| `UserKnownHostsFile` | known_hosts files, every entry read as one trust set; a new key is recorded in the first |
+| `GlobalKnownHostsFile` | System-wide known_hosts files, read alongside the user ones |
 | `HashKnownHosts` | Hash new known-hosts entries |
+| `CheckHostIP` | Also verify the connecting IP address against known_hosts |
+| `HostKeyAlias` | Look the host key up under this name instead of the address |
 
 All other fields (algorithm selection such as `KexAlgorithms`, `Ciphers`, `MACs`,
 `HostKeyAlgorithms`; proxy settings `ProxyJump`, `ProxyCommand`; `Compression`;

--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -541,13 +541,68 @@ func (c *Connection) IsWindows() bool {
 	return c.detectWindows(ctx)
 }
 
-func knownhostsCallback(path string, permissive, hash, checkIP bool) (ssh.HostKeyCallback, error) {
+// hostKeyPolicy is how a known_hosts file is applied, which is what
+// StrictHostKeyChecking selects.
+type hostKeyPolicy int
+
+const (
+	// hostKeyAcceptNew records the key of a host that is not in known_hosts yet
+	// and accepts it, while a host whose recorded key has changed is refused.
+	// OpenSSH's "accept-new".
+	hostKeyAcceptNew hostKeyPolicy = iota
+
+	// hostKeyStrict refuses any host that is not already in known_hosts and
+	// never records a key. OpenSSH's "yes".
+	hostKeyStrict
+
+	// hostKeyPermissive accepts an unknown host and a changed key alike.
+	// OpenSSH's "no" and "off".
+	hostKeyPermissive
+)
+
+// permissive reports whether mismatches are tolerated, which is the one knob
+// the hostkey callbacks take.
+func (p hostKeyPolicy) permissive() bool {
+	return p == hostKeyPermissive
+}
+
+// devNull is the conventional discard-everything path. Pointing a known_hosts
+// option at it is taken as shorthand for not verifying host keys, except under
+// strict checking -- see [hostKeyRejectAll].
+const devNull = "/dev/null"
+
+// hostKeyRejectAll refuses every host key.
+//
+// It stands in for a known_hosts of /dev/null under strict checking. For the
+// recording policies that path works out to accepting everything anyway, since
+// the file reads back empty and so every host is new, and the hostkey package
+// takes the shortcut of not verifying at all. Strict must not degrade the same
+// way: /dev/null is not permission to skip verification, it is a trust source
+// with nothing in it, and nothing verifies against nothing. OpenSSH arrives at
+// the same place, an empty known_hosts file plus StrictHostKeyChecking=yes
+// leaving every host unknown and every connection refused.
+func hostKeyRejectAll(source string) ssh.HostKeyCallback {
+	return func(hostname string, _ net.Addr, _ ssh.PublicKey) error {
+		return fmt.Errorf("%w: unknown host %s: no trusted host keys (%s)",
+			hostkey.ErrHostKeyMismatch, hostname, source)
+	}
+}
+
+// knownhostsCallback builds a validator that records the key of a host it has
+// not seen, so it serves accept-new and the permissive policy; strict is built
+// by [strictHostkeyCallback] instead, which must not write anything.
+//
+// writePath is where a new key is appended, and alsoVerify carries the rest of
+// the trust set. Both are needed: a host is only new when no file knows it, so
+// verifying against the append target alone would record and accept a key that
+// another user file or a system-wide one already contradicts.
+func knownhostsCallback(writePath string, alsoVerify []string, policy hostKeyPolicy, hash, checkIP bool) (ssh.HostKeyCallback, error) {
 	var err error
 	var callback ssh.HostKeyCallback
 	if checkIP {
-		callback, err = hostkey.KnownHostsFileCallbackWithIPCheck(path, permissive, hash)
+		callback, err = hostkey.KnownHostsFilesCallbackWithIPCheck(writePath, alsoVerify, policy.permissive(), hash)
 	} else {
-		callback, err = hostkey.KnownHostsFileCallback(path, permissive, hash)
+		callback, err = hostkey.KnownHostsFilesCallback(writePath, alsoVerify, policy.permissive(), hash)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("%w: create host key validator: %w", protocol.ErrNonRetryable, err)
@@ -555,27 +610,60 @@ func knownhostsCallback(path string, permissive, hash, checkIP bool) (ssh.HostKe
 	return callback, nil
 }
 
-func knownhostsGlobalCallback(path string, permissive, checkIP bool) (ssh.HostKeyCallback, error) {
+// knownhostsGlobalCallback builds a validator for a global known_hosts file.
+// These are never written to whatever the policy is -- they are system files
+// such as /etc/ssh/ssh_known_hosts.
+//
+// This is reached only when there is no user file to record keys in, which
+// UserKnownHostsFile none asks for. accept-new still has to accept a host it
+// has not seen there, so it is wrapped: read-only alone would refuse one, which
+// is the strict behaviour, and reducing the policy to mismatch tolerance would
+// leave accept-new indistinguishable from yes on this path.
+func knownhostsGlobalCallback(paths []string, policy hostKeyPolicy, checkIP bool) (ssh.HostKeyCallback, error) {
 	var err error
 	var callback ssh.HostKeyCallback
 	if checkIP {
-		callback, err = hostkey.KnownHostsReadOnlyFileCallbackWithIPCheck(path, permissive)
+		callback, err = hostkey.KnownHostsReadOnlyFilesCallbackWithIPCheck(paths, policy.permissive())
 	} else {
-		callback, err = hostkey.KnownHostsReadOnlyFileCallback(path, permissive)
+		callback, err = hostkey.KnownHostsReadOnlyFilesCallback(paths, policy.permissive())
 	}
 	if err != nil {
-		return nil, fmt.Errorf("create host key validator for %s: %w", path, err)
+		return nil, fmt.Errorf("create host key validator for %s: %w", strings.Join(paths, ", "), err)
+	}
+	if policy == hostKeyAcceptNew {
+		// Wrapping one aggregate checker rather than each file in turn is what
+		// makes this safe: "not on file" has to mean absent from every global
+		// file, or a conflicting key in a later one would never be reached.
+		callback = hostkey.AcceptUnknownHosts(callback)
 	}
 	return callback, nil
 }
 
-func isPermissive(ctx context.Context, c *Connection) bool {
-	if c.sshConfig.StrictHostKeyChecking.IsFalse() {
-		log.Trace(ctx, "config StrictHostKeyChecking is set to 'no'", log.KeyHost, c)
-		return true
+// hostKeyPolicyFor reads the policy out of StrictHostKeyChecking.
+//
+// "ask" cannot be honoured as OpenSSH does it, since rig has no terminal to ask
+// at, and failing every first connection instead would be a poor trade for a
+// library that provisions hosts. It is treated as "accept-new", which is also
+// what an unset value has always done here: record a new host, refuse a changed
+// key. Callers that want a first connection refused can say so with "yes".
+func hostKeyPolicyFor(ctx context.Context, conn *Connection) hostKeyPolicy {
+	shkc := conn.sshConfig.StrictHostKeyChecking
+	switch {
+	case shkc.IsFalse():
+		log.Trace(ctx, "config StrictHostKeyChecking is 'no', host key mismatches are tolerated", log.KeyHost, conn)
+		return hostKeyPermissive
+	case shkc.IsTrue():
+		log.Trace(ctx, "config StrictHostKeyChecking is 'yes', unknown hosts are refused", log.KeyHost, conn)
+		return hostKeyStrict
+	case shkc.IsAcceptNew():
+		log.Trace(ctx, "config StrictHostKeyChecking is 'accept-new'", log.KeyHost, conn)
+		return hostKeyAcceptNew
+	default:
+		if shkc.IsAsk() {
+			log.Trace(ctx, "config StrictHostKeyChecking is 'ask', treating it as 'accept-new'", log.KeyHost, conn)
+		}
+		return hostKeyAcceptNew
 	}
-
-	return false
 }
 
 func shouldHash(ctx context.Context, c *Connection) bool {
@@ -590,77 +678,216 @@ func (c *Connection) hostkeyCallback(ctx context.Context, checkIP bool) (ssh.Hos
 	knownHostsMU.Lock()
 	defer knownHostsMU.Unlock()
 
-	permissive := isPermissive(ctx, c)
+	policy := hostKeyPolicyFor(ctx, c)
 	hash := shouldHash(ctx, c)
 
 	if checkIP {
 		log.Trace(ctx, "CheckHostIP enabled, IP verification active", log.KeyHost, c)
 	}
 
-	if path, ok := hostkey.KnownHostsPathFromEnv(); ok {
-		if path == "" {
-			return hostkey.InsecureIgnoreHostKeyCallback, nil
+	khPaths, fromEnv, insecure := c.userKnownHostsPaths(ctx)
+	if insecure {
+		// An empty SSH_KNOWN_HOSTS is rig's own switch for skipping host key
+		// verification. It cannot outrank an explicit request for strict
+		// checking: refusing is the only answer that honours both, and a caller
+		// who wants the switch can stop asking for "yes".
+		if policy == hostKeyStrict {
+			return hostKeyRejectAll("SSH_KNOWN_HOSTS is empty"), nil
 		}
-		c.Log().Debug("using known_hosts file from SSH_KNOWN_HOSTS", log.HostAttr(c), log.KeyFile, path)
-		return knownhostsCallback(path, permissive, hash, checkIP)
+		return hostkey.InsecureIgnoreHostKeyCallback, nil
 	}
 
-	var khPath string
+	// The global files join the trust set only when the user path came from the
+	// config: SSH_KNOWN_HOSTS overrides the configured paths rather than adding
+	// to them, and joining the globals to it would quietly widen what an
+	// explicit override is meant to narrow.
+	globalPaths := c.sshConfig.GlobalKnownHostsFile
+	if fromEnv {
+		globalPaths = nil
+	}
+
+	// Strict reads every trust source together and writes to none of them, so
+	// it does not care which file the user's own entries would go in.
+	if policy == hostKeyStrict {
+		return strictHostkeyCallback(ctx, khPaths, globalPaths, checkIP)
+	}
+
+	// A recording policy needs one file to write to, and OpenSSH appends to the
+	// first of the list -- but it still decides "is this host new?" against
+	// every file, so the rest of the set comes along for verification only.
+	if len(khPaths) > 0 {
+		log.Trace(ctx, "recording new host keys in known_hosts file", log.KeyHost, c, log.KeyFile, khPaths[0])
+		alsoVerify, _, _ := usableKnownHostsPaths(ctx, append(slices.Clone(khPaths[1:]), globalPaths...))
+		return knownhostsCallback(khPaths[0], alsoVerify, policy, hash, checkIP)
+	}
+
+	return globalKnownHostsCallback(ctx, globalPaths, policy, checkIP)
+}
+
+// userKnownHostsPaths resolves the user known_hosts files: SSH_KNOWN_HOSTS when
+// that is set, otherwise every UserKnownHostsFile entry that expands. The slice
+// is empty when there is none to use.
+//
+// The order is the config's, which matters because the two readings of this
+// option differ: a policy that records a key writes to the first entry, the way
+// OpenSSH does, while a policy that only verifies reads all of them as one trust
+// set. The default list has two entries (~/.ssh/known_hosts and
+// ~/.ssh/known_hosts2), so ignoring the rest would refuse a host pinned in the
+// second file.
+//
+// fromEnv says the paths came from the environment, which replaces the
+// configured files rather than joining them -- the documented meaning of
+// SSH_KNOWN_HOSTS is that it overrides the config, so a caller pointing rig at
+// one file gets that file and nothing else. insecure reports the other half of
+// that switch: an empty value asks for host key verification to be skipped
+// altogether.
+func (c *Connection) userKnownHostsPaths(ctx context.Context) (paths []string, fromEnv, insecure bool) {
+	if envPath, ok := hostkey.KnownHostsPathFromEnv(); ok {
+		if envPath == "" {
+			return nil, true, true
+		}
+		c.Log().Debug("using known_hosts file from SSH_KNOWN_HOSTS", log.HostAttr(c), log.KeyFile, envPath)
+		return []string{envPath}, true, false
+	}
 
 	// "none" anywhere in the list disables user known_hosts entirely; check
 	// the full list before committing to any path.
-	if !slices.Contains(c.sshConfig.UserKnownHostsFile, sshConfigNone) {
-		for _, f := range c.sshConfig.UserKnownHostsFile {
-			log.Trace(ctx, "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
-			exp, err := homedir.Expand(f)
-			if err == nil {
-				khPath = exp
-				break
-			}
+	if slices.Contains(c.sshConfig.UserKnownHostsFile, sshConfigNone) {
+		return nil, false, false
+	}
+	// Deliberately nil rather than an empty slice, so "nothing configured" and
+	// "none" resolve alike.
+	var expanded []string
+	for _, f := range c.sshConfig.UserKnownHostsFile {
+		log.Trace(ctx, "trying known_hosts file from ssh config", log.KeyHost, c, log.KeyFile, f)
+		if exp, err := homedir.Expand(f); err == nil {
+			expanded = append(expanded, exp)
 		}
 	}
-
-	if khPath != "" {
-		log.Trace(ctx, "using known_hosts file", log.KeyHost, c, log.KeyFile, khPath)
-		return knownhostsCallback(khPath, permissive, hash, checkIP)
-	}
-
-	return globalKnownHostsCallback(ctx, c.sshConfig.GlobalKnownHostsFile, permissive, checkIP)
+	return expanded, false, false
 }
 
-func globalKnownHostsCallback(ctx context.Context, paths []string, permissive, checkIP bool) (ssh.HostKeyCallback, error) {
-	var lastErr error
-	for _, f := range paths {
-		log.Trace(ctx, "trying global known_hosts file", log.KeyFile, f)
-		exp, err := homedir.Expand(f)
+// usableKnownHostsPaths expands paths and keeps the ones that can hold entries:
+// regular files this process can open, in the order given. Anything else
+// contributes nothing rather than failing the connection -- a path that will not
+// expand, one that is absent, a directory, one the process may not read.
+//
+// sawDevNull reports whether the null device was among them, which callers that
+// read it as "verify nothing" need to know; it is never returned as usable,
+// since it can hold no entries. lastErr carries the most recent reason a path
+// was dropped, for callers that have to explain why nothing was left.
+func usableKnownHostsPaths(ctx context.Context, paths []string) (usable []string, sawDevNull bool, lastErr error) {
+	for _, path := range paths {
+		exp, err := homedir.Expand(path)
 		if err != nil {
 			lastErr = err
-			log.Trace(ctx, "skipping global known_hosts file (expand failed)", log.KeyFile, f, log.KeyError, err)
+			log.Trace(ctx, "skipping known_hosts file (expand failed)", log.KeyFile, path, log.KeyError, err)
 			continue
 		}
-		if exp != "/dev/null" {
-			stat, err := os.Stat(exp)
-			if err != nil {
-				if !errors.Is(err, os.ErrNotExist) {
-					lastErr = err
-				}
-				log.Trace(ctx, "skipping global known_hosts file", log.KeyFile, exp, log.KeyError, err)
-				continue
-			}
-			if !stat.Mode().IsRegular() {
-				lastErr = fmt.Errorf("%w: %s", errNotRegularFile, exp)
-				log.Trace(ctx, "skipping non-regular global known_hosts file", log.KeyFile, exp)
-				continue
-			}
+		if exp == devNull {
+			sawDevNull = true
+			continue
 		}
-		cb, err := knownhostsGlobalCallback(exp, permissive, checkIP)
+		// Opened rather than stat'd, because reading it is what the trust set
+		// will do: a file whose mode denies this process passes every stat and
+		// then fails the parse, which takes the whole callback -- and the
+		// connection -- down with it instead of contributing nothing.
+		file, err := os.Open(exp)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				lastErr = err
+			}
+			log.Trace(ctx, "skipping known_hosts file", log.KeyFile, exp, log.KeyError, err)
+			continue
+		}
+		stat, err := file.Stat()
+		if closeErr := file.Close(); closeErr != nil {
+			log.Trace(ctx, "failed to close known_hosts file", log.KeyFile, exp, log.KeyError, closeErr)
+		}
 		if err != nil {
 			lastErr = err
-			log.Trace(ctx, "skipping unusable global known_hosts file", log.KeyFile, exp, log.KeyError, err)
+			log.Trace(ctx, "skipping known_hosts file", log.KeyFile, exp, log.KeyError, err)
 			continue
 		}
-		log.Trace(ctx, "using global known_hosts file", log.KeyFile, exp)
-		return cb, nil
+		if !stat.Mode().IsRegular() {
+			lastErr = fmt.Errorf("%w: %s", errNotRegularFile, exp)
+			log.Trace(ctx, "skipping non-regular known_hosts file", log.KeyFile, exp)
+			continue
+		}
+		usable = append(usable, exp)
+	}
+	return usable, sawDevNull, lastErr
+}
+
+// strictHostkeyCallback builds the validator for StrictHostKeyChecking=yes.
+//
+// Every user file and every global one is read as a single trust set rather than
+// the first usable one winning, because that is how OpenSSH reads them: a key an
+// administrator put in /etc/ssh/ssh_known_hosts counts even when the user's own
+// file has never heard of the host, and so does one in the second entry of a
+// UserKnownHostsFile list. Under the recording policies the
+// distinction is invisible -- an unknown host is simply added to the user file
+// and the connection proceeds -- so it only becomes visible once a policy
+// starts refusing.
+//
+// Nothing is written, which is the whole of what strict means. A file that is
+// missing, or is not a file at all, contributes nothing rather than failing the
+// connection outright, and when that leaves no trust source at all every host
+// is unknown: /dev/null included, which is not permission to skip verification
+// under this policy.
+func strictHostkeyCallback(ctx context.Context, userPaths, globalPaths []string, checkIP bool) (ssh.HostKeyCallback, error) {
+	paths := make([]string, 0, len(userPaths)+len(globalPaths))
+	paths = append(paths, userPaths...)
+	paths = append(paths, globalPaths...)
+
+	usable, _, _ := usableKnownHostsPaths(ctx, paths)
+
+	if len(usable) == 0 {
+		log.Trace(ctx, "no usable known_hosts file, strict checking refuses every host")
+		return hostKeyRejectAll("no known_hosts file to verify against"), nil
+	}
+
+	log.Trace(ctx, "using known_hosts files for strict checking", log.KeyFile, strings.Join(usable, ", "))
+
+	var err error
+	var callback ssh.HostKeyCallback
+	if checkIP {
+		callback, err = hostkey.KnownHostsReadOnlyFilesCallbackWithIPCheck(usable, false)
+	} else {
+		callback, err = hostkey.KnownHostsReadOnlyFilesCallback(usable, false)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: create host key validator: %w", protocol.ErrNonRetryable, err)
+	}
+	return callback, nil
+}
+
+// globalKnownHostsCallback builds a validator from the global known_hosts files.
+//
+// Every usable file goes into one checker rather than the first one winning,
+// the way OpenSSH reads them: a host absent from the first file may be on file
+// in the second, and under accept-new that difference decides whether an
+// unknown host is accepted or a conflicting key is caught.
+func globalKnownHostsCallback(ctx context.Context, paths []string, policy hostKeyPolicy, checkIP bool) (ssh.HostKeyCallback, error) {
+	usable, sawDevNull, lastErr := usableKnownHostsPaths(ctx, paths)
+
+	if len(usable) > 0 {
+		log.Trace(ctx, "using global known_hosts files", log.KeyFile, strings.Join(usable, ", "))
+		cb, err := knownhostsGlobalCallback(usable, policy, checkIP)
+		if err == nil {
+			return cb, nil
+		}
+		lastErr = err
+		log.Trace(ctx, "global known_hosts files unusable", log.KeyError, err)
+	}
+
+	// The null device holds no entries, so it only decides anything once there
+	// is nothing else: listed alongside a real file it is simply an empty
+	// source, and short-circuiting on it would skip the file that does have
+	// something to say. Alone it means the system asks for no verification.
+	if len(usable) == 0 && sawDevNull {
+		log.Trace(ctx, "global known_hosts is only the null device, not verifying host keys")
+		return hostkey.InsecureIgnoreHostKeyCallback, nil
 	}
 
 	if lastErr != nil {

--- a/protocol/ssh/connection_test.go
+++ b/protocol/ssh/connection_test.go
@@ -596,6 +596,401 @@ func Test_isAuthError(t *testing.T) {
 	}
 }
 
+// emptyKnownHosts creates an empty known_hosts file and points
+// SSH_KNOWN_HOSTS at it, returning the path so a test can see whether a
+// connection recorded a host key in it.
+func emptyKnownHosts(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(path, nil, 0o600))
+	t.Setenv("SSH_KNOWN_HOSTS", path)
+	return path
+}
+
+// startRejectingSSHServer starts a server that offers hostSigner's key and
+// rejects every credential, so a connection gets through the handshake -- where
+// host keys are checked -- and no further.
+func startRejectingSSHServer(t *testing.T, hostSigner ssh.Signer) (host string, port int) {
+	t.Helper()
+	cfg := &ssh.ServerConfig{
+		ServerVersion: "SSH-2.0-test-linux",
+		PasswordCallback: func(_ ssh.ConnMetadata, _ []byte) (*ssh.Permissions, error) {
+			return nil, errAuthRejected
+		},
+	}
+	cfg.AddHostKey(hostSigner)
+
+	addr := startSSHServer(t, cfg)
+	h, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	p, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+	return h, p
+}
+
+// TestConnectStrictHostKeyChecking pins how each StrictHostKeyChecking mode
+// treats a host that is not in known_hosts, which is the only place they
+// differ. Every mode but "no" used to take the recording callback, so "yes"
+// silently behaved as "accept-new" and wrote the key of a host it had been told
+// to refuse.
+//
+// The host key is checked during the handshake, before authentication, so a
+// server that rejects every credential still shows whether the key was
+// accepted and recorded.
+func TestConnectStrictHostKeyChecking(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		config     string
+		wantRecord bool
+	}{
+		{"yes refuses an unknown host", "Host *\n  StrictHostKeyChecking yes\n", false},
+		{"accept-new records the new key", "Host *\n  StrictHostKeyChecking accept-new\n", true},
+		{"no records it too", "Host *\n  StrictHostKeyChecking no\n", true},
+		{"ask has no terminal to ask at, so accept-new", "Host *\n  StrictHostKeyChecking ask\n", true},
+		{"unset is accept-new", "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withConfigParser(t, tc.config)
+			t.Setenv("SSH_AUTH_SOCK", "")
+			knownHosts := emptyKnownHosts(t)
+
+			host, port := startRejectingSSHServer(t, newHostSigner(t))
+
+			conn, err := NewConnection(Config{
+				Address:     host,
+				Port:        port,
+				User:        "test",
+				AuthMethods: []ssh.AuthMethod{ssh.Password("wrong")},
+			})
+			require.NoError(t, err)
+			t.Cleanup(conn.Disconnect)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			err = conn.Connect(ctx)
+			require.Error(t, err, "the server rejects every credential, so Connect cannot succeed")
+
+			recorded, readErr := os.ReadFile(knownHosts)
+			require.NoError(t, readErr)
+
+			if tc.wantRecord {
+				require.NotEmpty(t, recorded, "the new host key must be recorded")
+				require.ErrorIs(t, err, protocol.ErrAuthFailed,
+					"the host key was accepted, so the failure must be the credential")
+				return
+			}
+
+			require.Empty(t, recorded, "a refused host key must not be written to known_hosts")
+			require.NotErrorIs(t, err, protocol.ErrAuthFailed,
+				"the connection must fail on the host key, before any credential is offered")
+		})
+	}
+}
+
+// TestConnectStrictHostKeyCheckingDevNull covers the escape hatch that a
+// known_hosts path can be. For the recording policies /dev/null works out to
+// accepting everything anyway -- the file reads back empty, so every host is
+// new -- but strict checking must not degrade the same way just because the
+// trust source happens to be empty.
+//
+// The literal is deliberate rather than os.DevNull: it is the string a user
+// writes in ssh_config or the environment, on any platform. Where the path does
+// not resolve, as on Windows, strict refuses for the plainer reason that there
+// is no trust source at all.
+func TestConnectStrictHostKeyCheckingDevNull(t *testing.T) {
+	withConfigParser(t, "Host *\n  StrictHostKeyChecking yes\n")
+	t.Setenv("SSH_AUTH_SOCK", "")
+	t.Setenv("SSH_KNOWN_HOSTS", "/dev/null")
+
+	host, port := startRejectingSSHServer(t, newHostSigner(t))
+
+	conn, err := NewConnection(Config{
+		Address:     host,
+		Port:        port,
+		User:        "test",
+		AuthMethods: []ssh.AuthMethod{ssh.Password("wrong")},
+	})
+	require.NoError(t, err)
+	t.Cleanup(conn.Disconnect)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = conn.Connect(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, hostkey.ErrHostKeyMismatch,
+		"an empty trust source verifies nothing, so every host is unknown")
+	require.NotErrorIs(t, err, protocol.ErrAuthFailed,
+		"verification must fail before a credential is offered")
+}
+
+// TestConnectStrictHostKeyCheckingEmptyEnv covers rig's own switch for skipping
+// verification, which is the same conflict as /dev/null: an explicit request
+// for strict checking has to win over it, or "yes" is only as strong as the
+// environment it runs in.
+func TestConnectStrictHostKeyCheckingEmptyEnv(t *testing.T) {
+	withConfigParser(t, "Host *\n  StrictHostKeyChecking yes\n")
+	t.Setenv("SSH_AUTH_SOCK", "")
+	t.Setenv("SSH_KNOWN_HOSTS", "")
+
+	host, port := startRejectingSSHServer(t, newHostSigner(t))
+
+	conn, err := NewConnection(Config{
+		Address:     host,
+		Port:        port,
+		User:        "test",
+		AuthMethods: []ssh.AuthMethod{ssh.Password("wrong")},
+	})
+	require.NoError(t, err)
+	t.Cleanup(conn.Disconnect)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = conn.Connect(ctx)
+	require.ErrorIs(t, err, hostkey.ErrHostKeyMismatch)
+	require.NotErrorIs(t, err, protocol.ErrAuthFailed,
+		"verification must fail before a credential is offered")
+}
+
+// TestConnectStrictHostKeyCheckingGlobalFile pins that strict reads the user
+// and global known_hosts files as one trust set. A key an administrator put in
+// a system-wide file has to count even though the user's own file has never
+// heard of the host -- otherwise turning on strict checking would reject every
+// centrally managed host.
+func TestConnectStrictHostKeyCheckingGlobalFile(t *testing.T) {
+	// The environment takes precedence over both configured files, so an
+	// inherited SSH_KNOWN_HOSTS would decide what this exercises: a path would
+	// stand in for the files below, and an empty value would select reject-all.
+	unsetKnownHostsEnv(t)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	hostSigner := newHostSigner(t)
+	cfg := &ssh.ServerConfig{
+		ServerVersion: "SSH-2.0-test-linux",
+		PasswordCallback: func(_ ssh.ConnMetadata, _ []byte) (*ssh.Permissions, error) {
+			return nil, errAuthRejected
+		},
+	}
+	cfg.AddHostKey(hostSigner)
+	addr := startSSHServer(t, cfg)
+
+	dir := t.TempDir()
+	// The user file exists but is empty; only the global one knows the host.
+	userFile := filepath.Join(dir, "known_hosts")
+	require.NoError(t, os.WriteFile(userFile, nil, 0o600))
+	globalFile := filepath.Join(dir, "ssh_known_hosts")
+	require.NoError(t, os.WriteFile(globalFile, []byte(fmt.Sprintf("%s %s\n",
+		knownhosts.Normalize(addr),
+		strings.TrimRight(string(ssh.MarshalAuthorizedKey(hostSigner.PublicKey())), "\n"),
+	)), 0o600))
+
+	withConfigParser(t, fmt.Sprintf("Host *\n  StrictHostKeyChecking yes\n  UserKnownHostsFile %s\n  GlobalKnownHostsFile %s\n",
+		userFile, globalFile))
+
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	conn, err := NewConnection(Config{
+		Address:     host,
+		Port:        port,
+		User:        "test",
+		AuthMethods: []ssh.AuthMethod{ssh.Password("wrong")},
+	})
+	require.NoError(t, err)
+	t.Cleanup(conn.Disconnect)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = conn.Connect(ctx)
+	require.ErrorIs(t, err, protocol.ErrAuthFailed,
+		"the global file's entry must satisfy strict checking, leaving only the credential to fail")
+	require.NotErrorIs(t, err, hostkey.ErrHostKeyMismatch)
+
+	recorded, readErr := os.ReadFile(userFile)
+	require.NoError(t, readErr)
+	require.Empty(t, recorded, "strict checking must not write to the user file either")
+}
+
+// TestConnectStrictHostKeyCheckingSecondUserFile pins that every
+// UserKnownHostsFile entry is a trust source, not just the first. The default
+// list has two entries (~/.ssh/known_hosts and ~/.ssh/known_hosts2), so a host
+// pinned in the second one would otherwise be refused on a stock config.
+//
+// The recording policies keep writing to the first entry, which the subtest
+// below checks, since that is where OpenSSH puts a new key.
+func TestConnectStrictHostKeyCheckingSecondUserFile(t *testing.T) {
+	hostSigner := newHostSigner(t)
+	cfg := &ssh.ServerConfig{
+		ServerVersion: "SSH-2.0-test-linux",
+		PasswordCallback: func(_ ssh.ConnMetadata, _ []byte) (*ssh.Permissions, error) {
+			return nil, errAuthRejected
+		},
+	}
+	cfg.AddHostKey(hostSigner)
+	addr := startSSHServer(t, cfg)
+
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	connect := func(t *testing.T, mode, first, second string) error {
+		t.Helper()
+		unsetKnownHostsEnv(t)
+		t.Setenv("SSH_AUTH_SOCK", "")
+		withConfigParser(t, fmt.Sprintf("Host *\n  StrictHostKeyChecking %s\n  UserKnownHostsFile %s %s\n",
+			mode, first, second))
+
+		conn, cErr := NewConnection(Config{
+			Address:     host,
+			Port:        port,
+			User:        "test",
+			AuthMethods: []ssh.AuthMethod{ssh.Password("wrong")},
+		})
+		require.NoError(t, cErr)
+		t.Cleanup(conn.Disconnect)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return conn.Connect(ctx)
+	}
+
+	pinned := fmt.Sprintf("%s %s\n",
+		knownhosts.Normalize(addr),
+		strings.TrimRight(string(ssh.MarshalAuthorizedKey(hostSigner.PublicKey())), "\n"),
+	)
+
+	t.Run("yes", func(t *testing.T) {
+		dir := t.TempDir()
+		first := filepath.Join(dir, "known_hosts")
+		second := filepath.Join(dir, "known_hosts2")
+		require.NoError(t, os.WriteFile(first, nil, 0o600))
+		require.NoError(t, os.WriteFile(second, []byte(pinned), 0o600))
+
+		err := connect(t, "yes", first, second)
+		require.ErrorIs(t, err, protocol.ErrAuthFailed,
+			"the second file's entry must satisfy strict checking, leaving only the credential to fail")
+		require.NotErrorIs(t, err, hostkey.ErrHostKeyMismatch)
+	})
+
+	t.Run("accept-new", func(t *testing.T) {
+		dir := t.TempDir()
+		first := filepath.Join(dir, "known_hosts")
+		second := filepath.Join(dir, "known_hosts2")
+		require.NoError(t, os.WriteFile(first, nil, 0o600))
+		require.NoError(t, os.WriteFile(second, nil, 0o600))
+
+		require.Error(t, connect(t, "accept-new", first, second))
+
+		recorded, readErr := os.ReadFile(first)
+		require.NoError(t, readErr)
+		require.NotEmpty(t, recorded, "a new key goes in the first entry, as OpenSSH does it")
+		untouched, readErr := os.ReadFile(second)
+		require.NoError(t, readErr)
+		require.Empty(t, untouched, "and nowhere else")
+	})
+}
+
+// TestConnectStrictHostKeyCheckingEnvOverridesGlobal pins the other side of the
+// trust set: SSH_KNOWN_HOSTS overrides the configured files rather than joining
+// them, so a key that only a configured global file vouches for must not be
+// accepted while the environment names a different file. Widening what an
+// explicit override is meant to narrow would be the surprising reading.
+func TestConnectStrictHostKeyCheckingEnvOverridesGlobal(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	hostSigner := newHostSigner(t)
+	cfg := &ssh.ServerConfig{
+		ServerVersion: "SSH-2.0-test-linux",
+		PasswordCallback: func(_ ssh.ConnMetadata, _ []byte) (*ssh.Permissions, error) {
+			return nil, errAuthRejected
+		},
+	}
+	cfg.AddHostKey(hostSigner)
+	addr := startSSHServer(t, cfg)
+
+	dir := t.TempDir()
+	// The global file vouches for the host; the file the environment names does
+	// not, and it is the one that counts.
+	globalFile := filepath.Join(dir, "ssh_known_hosts")
+	require.NoError(t, os.WriteFile(globalFile, []byte(fmt.Sprintf("%s %s\n",
+		knownhosts.Normalize(addr),
+		strings.TrimRight(string(ssh.MarshalAuthorizedKey(hostSigner.PublicKey())), "\n"),
+	)), 0o600))
+	envFile := filepath.Join(dir, "env_known_hosts")
+	require.NoError(t, os.WriteFile(envFile, nil, 0o600))
+
+	withConfigParser(t, fmt.Sprintf("Host *\n  StrictHostKeyChecking yes\n  GlobalKnownHostsFile %s\n", globalFile))
+	t.Setenv("SSH_KNOWN_HOSTS", envFile)
+
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	conn, err := NewConnection(Config{
+		Address:     host,
+		Port:        port,
+		User:        "test",
+		AuthMethods: []ssh.AuthMethod{ssh.Password("wrong")},
+	})
+	require.NoError(t, err)
+	t.Cleanup(conn.Disconnect)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = conn.Connect(ctx)
+	require.ErrorIs(t, err, hostkey.ErrHostKeyMismatch,
+		"the overridden global file must not vouch for the host")
+	require.NotErrorIs(t, err, protocol.ErrAuthFailed,
+		"verification must fail before a credential is offered")
+}
+
+// TestConnectStrictHostKeyCheckingAcceptsKnownHost is the other half: strict
+// refuses what it cannot find, not everything. A pinned host gets through the
+// handshake and fails on the credential instead.
+func TestConnectStrictHostKeyCheckingAcceptsKnownHost(t *testing.T) {
+	withConfigParser(t, "Host *\n  StrictHostKeyChecking yes\n")
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	hostSigner := newHostSigner(t)
+	cfg := &ssh.ServerConfig{
+		ServerVersion: "SSH-2.0-test-linux",
+		PasswordCallback: func(_ ssh.ConnMetadata, _ []byte) (*ssh.Permissions, error) {
+			return nil, errAuthRejected
+		},
+	}
+	cfg.AddHostKey(hostSigner)
+	addr := startSSHServer(t, cfg)
+	pinHostKey(t, addr, hostSigner)
+
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	conn, err := NewConnection(Config{
+		Address:     host,
+		Port:        port,
+		User:        "test",
+		AuthMethods: []ssh.AuthMethod{ssh.Password("wrong")},
+	})
+	require.NoError(t, err)
+	t.Cleanup(conn.Disconnect)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.ErrorIs(t, conn.Connect(ctx), protocol.ErrAuthFailed,
+		"a host key that is already known must pass strict checking, leaving only the credential to fail")
+}
+
 // TestConnectAuthFailure drives Connect against an in-process SSH server that
 // refuses every credential it is offered. The resulting error must be tagged
 // protocol.ErrAuthFailed so callers can fail fast on bad credentials, but must
@@ -846,6 +1241,187 @@ func TestClientConfigRekeyLimit(t *testing.T) {
 	require.Equal(t, uint64(1024*1024), cfg.RekeyThreshold)
 }
 
+// TestUserKnownHostsPaths covers the resolution step on its own. Making
+// StrictHostKeyChecking=yes actually refuse hosts turned three separate
+// masked bugs visible here -- globals ignored, the environment joining instead
+// of overriding, every entry after the first dropped -- because until a policy
+// refused, recording an unknown key hid all of them. A table over the inputs
+// costs less than another end-to-end connect per case.
+func TestUserKnownHostsPaths(t *testing.T) {
+	// Native absolute paths, because homedir.Expand rewrites forward slashes to
+	// backslashes on Windows (homedir/expand_windows.go) and a slash literal
+	// would come back changed there. Nothing reads these paths -- resolution
+	// only expands names -- so they need not exist.
+	var (
+		envFile    = filepath.Join(os.TempDir(), "from-env")
+		firstFile  = filepath.Join(os.TempDir(), "known_hosts")
+		secondFile = filepath.Join(os.TempDir(), "known_hosts2")
+		otherFile  = filepath.Join(os.TempDir(), "also-config")
+	)
+
+	for _, tc := range []struct {
+		name         string
+		env          *string // nil leaves SSH_KNOWN_HOSTS unset
+		configured   []string
+		wantPaths    []string
+		wantFromEnv  bool
+		wantInsecure bool
+	}{
+		{
+			name:        "the environment overrides the config",
+			env:         ptr(envFile),
+			configured:  []string{firstFile, otherFile},
+			wantPaths:   []string{envFile},
+			wantFromEnv: true,
+		},
+		{
+			name:         "an empty environment value is the insecure switch",
+			env:          ptr(""),
+			configured:   []string{firstFile},
+			wantPaths:    nil,
+			wantFromEnv:  true,
+			wantInsecure: true,
+		},
+		{
+			name:       "every configured entry is kept, in order",
+			configured: []string{firstFile, secondFile},
+			wantPaths:  []string{firstFile, secondFile},
+		},
+		{
+			name:       "none anywhere disables the user files",
+			configured: []string{firstFile, "none"},
+			wantPaths:  nil,
+		},
+		{
+			name:       "no configuration resolves to nothing",
+			configured: nil,
+			wantPaths:  nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.env == nil {
+				unsetKnownHostsEnv(t)
+			} else {
+				t.Setenv("SSH_KNOWN_HOSTS", *tc.env)
+			}
+
+			conn := &Connection{sshConfig: &sshconfig.Config{UserKnownHostsFile: tc.configured}}
+			paths, fromEnv, insecure := conn.userKnownHostsPaths(context.Background())
+
+			require.Equal(t, tc.wantPaths, paths)
+			require.Equal(t, tc.wantFromEnv, fromEnv)
+			require.Equal(t, tc.wantInsecure, insecure)
+		})
+	}
+}
+
+// TestStrictHostkeyCallbackTrustSources covers the other half: which files the
+// strict callback ends up trusting. The callback is driven directly, so each
+// layout is one assertion rather than a server handshake.
+func TestStrictHostkeyCallbackTrustSources(t *testing.T) {
+	const addr = "127.0.0.1:2222"
+
+	signer := newHostSigner(t)
+	entry := fmt.Sprintf("%s %s\n",
+		knownhosts.Normalize(addr),
+		strings.TrimRight(string(ssh.MarshalAuthorizedKey(signer.PublicKey())), "\n"),
+	)
+	remote := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 2222}
+
+	// write returns a path to a file holding the given contents.
+	write := func(t *testing.T, name, contents string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), name)
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+		return path
+	}
+
+	for _, tc := range []struct {
+		name  string
+		files func(t *testing.T) (userPaths, globalPaths []string)
+		want  string // "accept" or "reject"
+	}{
+		{
+			name: "the key is in the only user file",
+			files: func(t *testing.T) ([]string, []string) {
+				return []string{write(t, "known_hosts", entry)}, nil
+			},
+			want: "accept",
+		},
+		{
+			name: "the key is in the second user file",
+			files: func(t *testing.T) ([]string, []string) {
+				return []string{write(t, "known_hosts", ""), write(t, "known_hosts2", entry)}, nil
+			},
+			want: "accept",
+		},
+		{
+			name: "the key is in a global file only",
+			files: func(t *testing.T) ([]string, []string) {
+				return []string{write(t, "known_hosts", "")}, []string{write(t, "ssh_known_hosts", entry)}
+			},
+			want: "accept",
+		},
+		{
+			name: "a missing path is skipped, not fatal",
+			files: func(t *testing.T) ([]string, []string) {
+				return []string{filepath.Join(t.TempDir(), "absent"), write(t, "known_hosts2", entry)}, nil
+			},
+			want: "accept",
+		},
+		{
+			// os.DevNull rather than a literal, so this is the null device on
+			// Windows too instead of merely a path that happens not to exist.
+			name: "the null device is skipped, not fatal",
+			files: func(t *testing.T) ([]string, []string) {
+				return []string{os.DevNull, write(t, "known_hosts2", entry)}, nil
+			},
+			want: "accept",
+		},
+		{
+			name: "the key is nowhere",
+			files: func(t *testing.T) ([]string, []string) {
+				return []string{write(t, "known_hosts", "")}, []string{write(t, "ssh_known_hosts", "")}
+			},
+			want: "reject",
+		},
+		{
+			name: "there are no files at all",
+			files: func(_ *testing.T) ([]string, []string) {
+				return nil, nil
+			},
+			want: "reject",
+		},
+		{
+			name: "the null device is the only trust source",
+			files: func(_ *testing.T) ([]string, []string) {
+				return []string{os.DevNull}, nil
+			},
+			want: "reject",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			userPaths, globalPaths := tc.files(t)
+
+			cb, err := strictHostkeyCallback(context.Background(), userPaths, globalPaths, false)
+			require.NoError(t, err, "an unusable path must not fail the build, only contribute nothing")
+
+			err = cb(addr, remote, signer.PublicKey())
+			if tc.want == "accept" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, hostkey.ErrHostKeyMismatch)
+		})
+	}
+}
+
+// ptr returns a pointer to v, for table entries that need to tell "unset" from
+// "set to the empty string".
+func ptr[T any](v T) *T {
+	return &v
+}
+
 // unsetKnownHostsEnv ensures SSH_KNOWN_HOSTS is not set for the duration of the
 // test so the UserKnownHostsFile/GlobalKnownHostsFile resolution path is
 // exercised instead of the environment override.
@@ -879,6 +1455,333 @@ func TestHostkeyCallbackUserNoneFallsBackToGlobalKnownHostsFile(t *testing.T) {
 	cb, err := c.hostkeyCallback(context.Background(), false)
 	require.NoError(t, err)
 	require.NotNil(t, cb)
+}
+
+// TestHostkeyCallbackUserNonePolicies drives the callback that UserKnownHostsFile
+// none produces, where there is no user file to record a key in and only the
+// global files are left to verify against.
+//
+// The policies have to stay distinguishable there. A read-only trust source
+// refuses a host it cannot find, which is what strict wants, so reducing the
+// policy to mismatch tolerance on this path would leave accept-new behaving
+// exactly like yes -- refusing every host absent from a system file it does not
+// control.
+func TestHostkeyCallbackUserNonePolicies(t *testing.T) {
+	const addr = "127.0.0.1:2222"
+
+	signer := newHostSigner(t)
+	remote := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 2222}
+	otherKey := newHostSigner(t).PublicKey()
+	entryFor := func(key ssh.PublicKey) string {
+		return fmt.Sprintf("%s %s\n", knownhosts.Normalize(addr),
+			strings.TrimRight(string(ssh.MarshalAuthorizedKey(key)), "\n"))
+	}
+
+	for _, tc := range []struct {
+		name       string
+		policy     options.StrictHostKeyCheckingOption
+		globalHas  ssh.PublicKey // nil writes an empty global file
+		wantAccept bool
+	}{
+		{
+			name:       "accept-new accepts a host the global file has never seen",
+			policy:     options.StrictHostKeyCheckingOptionAcceptNew,
+			wantAccept: true,
+		},
+		{
+			name:       "accept-new still refuses a changed key",
+			policy:     options.StrictHostKeyCheckingOptionAcceptNew,
+			globalHas:  otherKey,
+			wantAccept: false,
+		},
+		{
+			name:       "accept-new accepts the key the global file vouches for",
+			policy:     options.StrictHostKeyCheckingOptionAcceptNew,
+			globalHas:  signer.PublicKey(),
+			wantAccept: true,
+		},
+		{
+			name:       "yes refuses a host the global file has never seen",
+			policy:     options.StrictHostKeyCheckingOptionYes,
+			wantAccept: false,
+		},
+		{
+			name:       "no accepts anything",
+			policy:     options.StrictHostKeyCheckingOptionNo,
+			globalHas:  otherKey,
+			wantAccept: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			unsetKnownHostsEnv(t)
+
+			contents := ""
+			if tc.globalHas != nil {
+				contents = entryFor(tc.globalHas)
+			}
+			globalKH := filepath.Join(t.TempDir(), "ssh_known_hosts")
+			require.NoError(t, os.WriteFile(globalKH, []byte(contents), 0o600))
+
+			conn := &Connection{
+				sshConfig: &sshconfig.Config{
+					UserKnownHostsFile:    []string{"none"},
+					GlobalKnownHostsFile:  []string{globalKH},
+					StrictHostKeyChecking: tc.policy,
+				},
+			}
+
+			cb, err := conn.hostkeyCallback(context.Background(), false)
+			require.NoError(t, err)
+
+			err = cb(addr, remote, signer.PublicKey())
+			if tc.wantAccept {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestHostkeyCallbackRecordingVerifiesWholeTrustSet covers the default path.
+// accept-new appends a new key to the first user file, but "new" has to mean
+// unknown to every file: verifying against the append target alone would record
+// and accept a key that a later user file, or a system-wide one, already
+// contradicts. The default config has two of each, so this is the stock case.
+func TestHostkeyCallbackRecordingVerifiesWholeTrustSet(t *testing.T) {
+	const addr = "127.0.0.1:2222"
+
+	signer := newHostSigner(t)
+	remote := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 2222}
+	entryFor := func(key ssh.PublicKey) string {
+		return fmt.Sprintf("%s %s\n", knownhosts.Normalize(addr),
+			strings.TrimRight(string(ssh.MarshalAuthorizedKey(key)), "\n"))
+	}
+	conflicting := entryFor(newHostSigner(t).PublicKey())
+
+	for _, tc := range []struct {
+		name          string
+		secondUser    string // contents of the second UserKnownHostsFile entry
+		global        string // contents of the global file
+		wantAccept    bool
+		wantRecording bool
+	}{
+		{
+			name:          "an unknown host is recorded and accepted",
+			wantAccept:    true,
+			wantRecording: true,
+		},
+		{
+			name:       "a key the second user file contradicts is a mismatch",
+			secondUser: conflicting,
+		},
+		{
+			name:   "a key the global file contradicts is a mismatch",
+			global: conflicting,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			unsetKnownHostsEnv(t)
+
+			dir := t.TempDir()
+			first := filepath.Join(dir, "known_hosts")
+			require.NoError(t, os.WriteFile(first, nil, 0o600))
+			second := filepath.Join(dir, "known_hosts2")
+			require.NoError(t, os.WriteFile(second, []byte(tc.secondUser), 0o600))
+			global := filepath.Join(dir, "ssh_known_hosts")
+			require.NoError(t, os.WriteFile(global, []byte(tc.global), 0o600))
+
+			conn := &Connection{
+				sshConfig: &sshconfig.Config{
+					UserKnownHostsFile:    []string{first, second},
+					GlobalKnownHostsFile:  []string{global},
+					StrictHostKeyChecking: options.StrictHostKeyCheckingOptionAcceptNew,
+				},
+			}
+
+			cb, err := conn.hostkeyCallback(context.Background(), false)
+			require.NoError(t, err)
+
+			err = cb(addr, remote, signer.PublicKey())
+			if tc.wantAccept {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err, "a contradicted key must not be treated as a new host")
+			}
+
+			recorded, readErr := os.ReadFile(first)
+			require.NoError(t, readErr)
+			if tc.wantRecording {
+				require.NotEmpty(t, recorded, "a genuinely new key is appended to the first file")
+				return
+			}
+			require.Empty(t, recorded, "a mismatch must not be recorded")
+		})
+	}
+}
+
+// TestHostkeyCallbackGlobalDevNullAlongsideRealFile pins that the null device is
+// an empty trust source rather than a bypass: listed next to a real file it must
+// not stop that file from being consulted.
+func TestHostkeyCallbackGlobalDevNullAlongsideRealFile(t *testing.T) {
+	const addr = "127.0.0.1:2222"
+
+	signer := newHostSigner(t)
+	remote := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 2222}
+	conflicting := fmt.Sprintf("%s %s\n", knownhosts.Normalize(addr),
+		strings.TrimRight(string(ssh.MarshalAuthorizedKey(newHostSigner(t).PublicKey())), "\n"))
+
+	unsetKnownHostsEnv(t)
+
+	global := filepath.Join(t.TempDir(), "ssh_known_hosts")
+	require.NoError(t, os.WriteFile(global, []byte(conflicting), 0o600))
+
+	conn := &Connection{
+		sshConfig: &sshconfig.Config{
+			UserKnownHostsFile:    []string{"none"},
+			GlobalKnownHostsFile:  []string{"/dev/null", global},
+			StrictHostKeyChecking: options.StrictHostKeyCheckingOptionAcceptNew,
+		},
+	}
+
+	cb, err := conn.hostkeyCallback(context.Background(), false)
+	require.NoError(t, err)
+	require.Error(t, cb(addr, remote, signer.PublicKey()),
+		"the real file listed after the null device must still be consulted")
+}
+
+// TestHostkeyCallbackUserDevNullKeepsVerifying is the same rule where the null
+// device lands on the file a recording policy writes to.
+//
+// UserKnownHostsFile=/dev/null is the familiar way to ask for a key not to be
+// remembered, and that is all it asks for: the global files remain the trust
+// set, so a key one of them contradicts is a mismatch and only a host none of
+// them knows is accepted -- and then not stored.
+func TestHostkeyCallbackUserDevNullKeepsVerifying(t *testing.T) {
+	const addr = "127.0.0.1:2222"
+
+	signer := newHostSigner(t)
+	remote := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 2222}
+	entryFor := func(key ssh.PublicKey) string {
+		return fmt.Sprintf("%s %s\n", knownhosts.Normalize(addr),
+			strings.TrimRight(string(ssh.MarshalAuthorizedKey(key)), "\n"))
+	}
+
+	for _, tc := range []struct {
+		name       string
+		global     string
+		wantAccept bool
+	}{
+		{
+			name:       "a conflicting global key is still a mismatch",
+			global:     entryFor(newHostSigner(t).PublicKey()),
+			wantAccept: false,
+		},
+		{
+			name:       "a global file can vouch for the host",
+			global:     entryFor(signer.PublicKey()),
+			wantAccept: true,
+		},
+		{
+			name:       "a host no file knows is accepted",
+			global:     "",
+			wantAccept: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			unsetKnownHostsEnv(t)
+
+			global := filepath.Join(t.TempDir(), "ssh_known_hosts")
+			require.NoError(t, os.WriteFile(global, []byte(tc.global), 0o600))
+
+			conn := &Connection{
+				sshConfig: &sshconfig.Config{
+					UserKnownHostsFile:    []string{"/dev/null"},
+					GlobalKnownHostsFile:  []string{global},
+					StrictHostKeyChecking: options.StrictHostKeyCheckingOptionAcceptNew,
+				},
+			}
+
+			cb, err := conn.hostkeyCallback(context.Background(), false)
+			require.NoError(t, err)
+
+			err = cb(addr, remote, signer.PublicKey())
+			if tc.wantAccept {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err, "a global file must not be bypassed by a /dev/null write target")
+			}
+
+			recorded, readErr := os.ReadFile(global)
+			require.NoError(t, readErr)
+			require.Equal(t, tc.global, string(recorded),
+				"the global file is read-only, and /dev/null is where the record goes")
+		})
+	}
+}
+
+// TestHostkeyCallbackUserNoneAggregatesGlobalFiles pins that all the global
+// files form one trust set, not just the first usable one.
+//
+// It matters most under accept-new: "not on file" has to mean absent from every
+// global file. Wrapping each file in turn instead would let the first file's
+// silence be read as "new host, accept" and never reach a conflicting key in
+// the second -- turning a mismatch that should be refused into a connection.
+func TestHostkeyCallbackUserNoneAggregatesGlobalFiles(t *testing.T) {
+	const addr = "127.0.0.1:2222"
+
+	signer := newHostSigner(t)
+	remote := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 2222}
+	entryFor := func(key ssh.PublicKey) string {
+		return fmt.Sprintf("%s %s\n", knownhosts.Normalize(addr),
+			strings.TrimRight(string(ssh.MarshalAuthorizedKey(key)), "\n"))
+	}
+
+	for _, tc := range []struct {
+		name       string
+		second     ssh.PublicKey // what the second global file vouches for
+		wantAccept bool
+	}{
+		{
+			name:       "a conflicting key in the second file is not bypassed",
+			second:     newHostSigner(t).PublicKey(),
+			wantAccept: false,
+		},
+		{
+			name:       "the second file can vouch for the host",
+			second:     signer.PublicKey(),
+			wantAccept: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			unsetKnownHostsEnv(t)
+
+			dir := t.TempDir()
+			// The first file is empty, so on its own it would say "unknown".
+			first := filepath.Join(dir, "ssh_known_hosts")
+			require.NoError(t, os.WriteFile(first, nil, 0o600))
+			second := filepath.Join(dir, "ssh_known_hosts2")
+			require.NoError(t, os.WriteFile(second, []byte(entryFor(tc.second)), 0o600))
+
+			conn := &Connection{
+				sshConfig: &sshconfig.Config{
+					UserKnownHostsFile:    []string{"none"},
+					GlobalKnownHostsFile:  []string{first, second},
+					StrictHostKeyChecking: options.StrictHostKeyCheckingOptionAcceptNew,
+				},
+			}
+
+			cb, err := conn.hostkeyCallback(context.Background(), false)
+			require.NoError(t, err)
+
+			err = cb(addr, remote, signer.PublicKey())
+			if tc.wantAccept {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err, "the second file's entry must still be consulted")
+		})
+	}
 }
 
 func TestHostkeyCallbackUserNoneAfterValidPathFallsBackToGlobal(t *testing.T) {

--- a/protocol/ssh/hostkey/callbacks.go
+++ b/protocol/ssh/hostkey/callbacks.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -58,23 +59,59 @@ var KnownHostsPathFromEnv = func() (string, bool) {
 
 // KnownHostsFileCallback returns a HostKeyCallback that uses a known hosts file to verify host keys.
 func KnownHostsFileCallback(path string, permissive, hash bool) (ssh.HostKeyCallback, error) {
-	if path == devNull {
-		return InsecureIgnoreHostKeyCallback, nil
+	return KnownHostsFilesCallback(path, nil, permissive, hash)
+}
+
+// KnownHostsFilesCallback verifies a host key against writePath and every file
+// in alsoVerify, and records the key of a host that none of them knows in
+// writePath.
+//
+// That split is OpenSSH's: a new entry is appended to the first file, while
+// every file counts when deciding whether the host is new at all. Verifying
+// against writePath alone would classify a host as new whenever the first file
+// happens not to mention it -- and then record and accept a key that a later
+// user file, or a system-wide one, says belongs to a different host key.
+//
+// Each alsoVerify path must be an existing regular file; writePath is created
+// when it does not exist, since it is where a new key goes. That is a check on
+// what the caller asked for: an alsoVerify file that goes missing later
+// contributes nothing until it comes back, rather than failing every connection
+// after it. writePath is held to more, before and after: it must be readable as
+// well as writable, because a key it already holds is what tells a returning
+// host from a new one, and a write-only file would make every host look new.
+//
+// A writePath of /dev/null keeps no record, so a host that alsoVerify does not
+// know is accepted without being stored -- but alsoVerify is still consulted,
+// and a key it contradicts is still a mismatch. Only when alsoVerify is empty
+// as well does that leave nothing to verify against, which is taken as the
+// usual meaning of the null device: no host key verification.
+func KnownHostsFilesCallback(writePath string, alsoVerify []string, permissive, hash bool) (ssh.HostKeyCallback, error) {
+	if writePath == devNull {
+		return devNullTrustSet(alsoVerify, permissive, false)
+	}
+
+	// Checked here and kept by the db: validating the caller's slice and reading
+	// it again afterwards would let a path that was never checked into the trust
+	// set. writePath is not in this check -- ensureFile is about to create it,
+	// and newHostKeyDB requires it to be readable once it is there.
+	alsoVerify = slices.Clone(alsoVerify)
+	if err := requireRegularFiles(alsoVerify); err != nil {
+		return nil, err
 	}
 
 	mu.Lock()
 	defer mu.Unlock()
 
-	if err := ensureFile(path); err != nil {
+	if err := ensureFile(writePath); err != nil {
 		return nil, err
 	}
 
-	hkc, err := knownhosts.New(path)
+	knownHosts, err := newHostKeyDB([]string{writePath}, alsoVerify)
 	if err != nil {
-		return nil, fmt.Errorf("%w: knownhosts callback: %w", ErrCheckHostKey, err)
+		return nil, err
 	}
 
-	return wrapCallback(hkc, path, permissive, hash), nil
+	return wrapCallback(knownHosts, writePath, permissive, hash), nil
 }
 
 // KnownHostsReadOnlyFileCallback returns a HostKeyCallback that only reads from
@@ -86,84 +123,295 @@ func KnownHostsReadOnlyFileCallback(path string, permissive bool) (ssh.HostKeyCa
 		return InsecureIgnoreHostKeyCallback, nil
 	}
 
-	stat, err := os.Stat(path)
+	hkc, err := readOnlyChecker([]string{path})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrCheckHostKey, err)
-	}
-	if !stat.Mode().IsRegular() {
-		return nil, fmt.Errorf("%w: %s is not a regular file", ErrCheckHostKey, path)
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-
-	hkc, err := knownhosts.New(path)
-	if err != nil {
-		return nil, fmt.Errorf("%w: knownhosts callback: %w", ErrCheckHostKey, err)
+		return nil, err
 	}
 
 	return wrapReadOnlyCallback(hkc, permissive), nil
 }
 
-// KnownHostsFileCallbackWithIPCheck is like KnownHostsFileCallback but also
-// verifies the connecting IP address. It parses the known_hosts file once,
-// sharing the checker between hostname and IP verification.
-func KnownHostsFileCallbackWithIPCheck(path string, permissive, hash bool) (ssh.HostKeyCallback, error) {
-	if path == devNull {
-		return InsecureIgnoreHostKeyCallback, nil
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-
-	if err := ensureFile(path); err != nil {
+// KnownHostsReadOnlyFilesCallback is [KnownHostsReadOnlyFileCallback] over
+// several known_hosts files read as one trust set: a key matching an entry in
+// any of them is accepted, and a host is unknown only when none of them
+// mentions it. That is how OpenSSH reads a user's file together with the
+// system-wide ones, and it is what lets an administrator's entry in
+// /etc/ssh/ssh_known_hosts count even when the user's own file has never heard
+// of the host.
+//
+// Every path must be an existing regular file. /dev/null is not special here:
+// a caller combining trust sources has no use for one that verifies nothing,
+// and it is not a regular file, so it is rejected like any other non-file.
+func KnownHostsReadOnlyFilesCallback(paths []string, permissive bool) (ssh.HostKeyCallback, error) {
+	hkc, err := readOnlyChecker(paths)
+	if err != nil {
 		return nil, err
 	}
 
-	hkc, err := knownhosts.New(path)
-	if err != nil {
-		return nil, fmt.Errorf("%w: knownhosts callback: %w", ErrCheckHostKey, err)
-	}
-
-	return wrapCheckHostIP(wrapCallback(hkc, path, permissive, hash), hkc, permissive), nil
+	return wrapReadOnlyCallback(hkc, permissive), nil
 }
 
-// KnownHostsReadOnlyFileCallbackWithIPCheck is like KnownHostsReadOnlyFileCallback
-// but also verifies the connecting IP address. It parses the known_hosts file once,
-// sharing the checker between hostname and IP verification.
-func KnownHostsReadOnlyFileCallbackWithIPCheck(path string, permissive bool) (ssh.HostKeyCallback, error) {
-	if path == devNull {
-		return InsecureIgnoreHostKeyCallback, nil
-	}
-
-	stat, err := os.Stat(path)
+// KnownHostsReadOnlyFilesCallbackWithIPCheck is [KnownHostsReadOnlyFilesCallback]
+// with the connecting IP address verified as well, against the same files. The
+// IP is checked first; see [WithCheckHostIP] for what that ordering is for.
+func KnownHostsReadOnlyFilesCallbackWithIPCheck(paths []string, permissive bool) (ssh.HostKeyCallback, error) {
+	hkc, err := readOnlyChecker(paths)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrCheckHostKey, err)
-	}
-	if !stat.Mode().IsRegular() {
-		return nil, fmt.Errorf("%w: %s is not a regular file", ErrCheckHostKey, path)
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-
-	hkc, err := knownhosts.New(path)
-	if err != nil {
-		return nil, fmt.Errorf("%w: knownhosts callback: %w", ErrCheckHostKey, err)
+		return nil, err
 	}
 
 	return wrapCheckHostIP(wrapReadOnlyCallback(hkc, permissive), hkc, permissive), nil
 }
 
-// extends a knownhosts callback to not return an error when the key
-// is not found in the known_hosts file but instead adds it to the file as new
-// entry.
-func wrapCallback(hkc ssh.HostKeyCallback, path string, permissive, hash bool) ssh.HostKeyCallback {
-	// TODO this should also support the "accept-new" of StrictHostKeyChecking and possibly some other options.
+// hostKeyDB is a set of known_hosts files parsed into a checker.
+//
+// knownhosts.New reads the files once and answers from that snapshot ever
+// after, which is too little for a callback: the callback outlives the
+// connection it was made for, and keys are appended to those files meanwhile --
+// by this package, by another callback built over the same files for a
+// connection set up alongside this one, or by another process. A decision taken
+// from a stale snapshot finds a host that is on file new all over again, and a
+// recording policy then stores a second, conflicting key for it: the key change
+// accept-new exists to refuse. So refresh rereads the files, and every callback
+// here calls it before every decision rather than caching what it last saw.
+// Trust is not something to answer from a cache whose invalidation could be
+// wrong -- and a parse costs well under a millisecond against a handshake of
+// tens.
+//
+// The files fall in two groups. An optional one that cannot be read when the
+// files are read contributes nothing rather than failing the decision, and
+// counts again once it can be; one trust source among several going away is not
+// reason enough to refuse every connection. A required one is the opposite: it
+// has to be read, and a decision is refused rather than taken without it. The
+// file a key would be recorded in is required, since a key it already holds is
+// the only thing standing between accept-new and recording a second, different
+// key for a host it has seen before.
+type hostKeyDB struct {
+	required []string
+	optional []string
+	check    ssh.HostKeyCallback
+}
+
+// newHostKeyDB parses the files into a checker. The lists are copied: a
+// callback is long-lived and rereads them on every decision, so sharing the
+// caller's slice would let a later change to it move the trust set out from
+// under a verification -- or race with one. Must be called with mu held.
+func newHostKeyDB(required, optional []string) (*hostKeyDB, error) {
+	db := &hostKeyDB{required: slices.Clone(required), optional: slices.Clone(optional), check: nil}
+	if err := db.refresh(); err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// refresh rereads the files, replacing the snapshot the checker answers from.
+// The old snapshot is kept when the files cannot be parsed, so a checker is
+// never left unset. Must be called with mu held.
+func (d *hostKeyDB) refresh() error {
+	paths := make([]string, 0, len(d.required)+len(d.optional))
+	for _, path := range d.required {
+		// Not readable, no decision: a required file that cannot be read is not
+		// an empty one, and treating it as empty would make every host look new.
+		if err := checkReadable(path); err != nil {
+			return err
+		}
+		paths = append(paths, path)
+	}
+	// knownhosts.New fails on a file it cannot open, which would turn one
+	// optional source that went missing or unreadable into a refused
+	// connection. Reading what can be read keeps the other sources answering,
+	// and a path that comes back joins them again on the next read.
+	for _, path := range d.optional {
+		if checkReadable(path) == nil {
+			paths = append(paths, path)
+		}
+	}
+
+	check, err := knownhosts.New(paths...)
+	if err != nil {
+		return fmt.Errorf("%w: knownhosts callback: %w", ErrCheckHostKey, err)
+	}
+	d.check = check
+	return nil
+}
+
+// callback verifies a host key against the files as they are now. Must be
+// called with mu held.
+func (d *hostKeyDB) callback(hostname string, remote net.Addr, key ssh.PublicKey) error {
+	if err := d.refresh(); err != nil {
+		return err
+	}
+	return d.check(hostname, remote, key)
+}
+
+// readOnlyChecker reads paths as a single trust set, requiring each to be an
+// existing regular file. All of them are checked before any is read, so an
+// unusable path is reported rather than silently contributing nothing. That is
+// a check on what the caller asked for, not a promise about later: a file that
+// goes missing afterwards contributes nothing until it comes back.
+func readOnlyChecker(paths []string) (*hostKeyDB, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("%w: no known_hosts files to verify against", ErrCheckHostKey)
+	}
+	// Off the caller's slice first, so the list that is checked is the list that
+	// is kept even if the caller goes on to reuse or change its own.
+	paths = slices.Clone(paths)
+	if err := requireRegularFiles(paths); err != nil {
+		return nil, err
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// All optional: nothing here is written to, so a file that goes away leaves
+	// the rest of the trust set to answer, and a policy that refuses an unknown
+	// host still refuses one when the set is empty.
+	return newHostKeyDB(nil, paths)
+}
+
+// requireRegularFiles reports the first path that is not an existing regular
+// file.
+//
+// A trust source is worth having only if it is read, and [hostKeyDB] reads what
+// is there rather than failing over a file that went missing -- which is right
+// once running, but would quietly turn a path the caller asked to verify
+// against, and mistyped, into no verification at all. So every caller that
+// takes trust sources as an argument checks them here first, before any db is
+// built from them.
+func requireRegularFiles(paths []string) error {
+	for _, path := range paths {
+		if err := checkReadable(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkReadable reports whether path is a regular file that can be read as a
+// known_hosts file.
+//
+// It opens rather than stats, because that is what the reader does: a file
+// whose mode denies it -- 0000, or owned by someone else -- passes every stat
+// and then fails knownhosts.New, which takes the whole trust set down with it.
+// The mode is read from the open file, so the answer is about the file that was
+// opened rather than about whatever the path pointed at a moment earlier.
+func checkReadable(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrCheckHostKey, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrCheckHostKey, err)
+	}
+	if !stat.Mode().IsRegular() {
+		return fmt.Errorf("%w: %s is not a regular file", ErrCheckHostKey, path)
+	}
+	return nil
+}
+
+// devNullTrustSet builds the callback for a write target of /dev/null, where
+// alsoVerify is the whole of the trust set.
+//
+// The null device holds no entries and keeps none, so what it takes away is the
+// record, not the verification: a host that no file in alsoVerify knows is
+// accepted and then forgotten -- which is all that appending to /dev/null
+// amounts to -- while a key one of them contradicts is still a mismatch. Any
+// other reading would let an empty write target overrule a system-wide file.
+//
+// With nothing left to verify against there is no trust set at all, and the
+// null device means what it usually does: no host key verification.
+func devNullTrustSet(alsoVerify []string, permissive, checkIP bool) (ssh.HostKeyCallback, error) {
+	if len(alsoVerify) == 0 {
+		return InsecureIgnoreHostKeyCallback, nil
+	}
+
+	hkc, err := readOnlyChecker(alsoVerify)
+	if err != nil {
+		return nil, err
+	}
+
+	callback := AcceptUnknownHosts(wrapReadOnlyCallback(hkc, permissive))
+	if checkIP {
+		callback = wrapCheckHostIP(callback, hkc, permissive)
+	}
+	return callback, nil
+}
+
+// KnownHostsFileCallbackWithIPCheck is like KnownHostsFileCallback but also
+// verifies the connecting IP address, against the same file. The IP is checked
+// first; see [WithCheckHostIP] for what that ordering is for.
+func KnownHostsFileCallbackWithIPCheck(path string, permissive, hash bool) (ssh.HostKeyCallback, error) {
+	return KnownHostsFilesCallbackWithIPCheck(path, nil, permissive, hash)
+}
+
+// KnownHostsFilesCallbackWithIPCheck is [KnownHostsFilesCallback] with the
+// connecting IP address verified as well, against the same files. The IP is
+// checked first; see [WithCheckHostIP] for what that ordering is for.
+func KnownHostsFilesCallbackWithIPCheck(writePath string, alsoVerify []string, permissive, hash bool) (ssh.HostKeyCallback, error) {
+	if writePath == devNull {
+		return devNullTrustSet(alsoVerify, permissive, true)
+	}
+
+	// Checked here and kept by the db: validating the caller's slice and reading
+	// it again afterwards would let a path that was never checked into the trust
+	// set. writePath is not in this check -- ensureFile is about to create it,
+	// and newHostKeyDB requires it to be readable once it is there.
+	alsoVerify = slices.Clone(alsoVerify)
+	if err := requireRegularFiles(alsoVerify); err != nil {
+		return nil, err
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if err := ensureFile(writePath); err != nil {
+		return nil, err
+	}
+
+	knownHosts, err := newHostKeyDB([]string{writePath}, alsoVerify)
+	if err != nil {
+		return nil, err
+	}
+
+	return wrapCheckHostIP(wrapCallback(knownHosts, writePath, permissive, hash), knownHosts, permissive), nil
+}
+
+// KnownHostsReadOnlyFileCallbackWithIPCheck is like KnownHostsReadOnlyFileCallback
+// but also verifies the connecting IP address, against the same file. The IP is
+// checked first; see [WithCheckHostIP] for what that ordering is for.
+func KnownHostsReadOnlyFileCallbackWithIPCheck(path string, permissive bool) (ssh.HostKeyCallback, error) {
+	if path == devNull {
+		return InsecureIgnoreHostKeyCallback, nil
+	}
+
+	return KnownHostsReadOnlyFilesCallbackWithIPCheck([]string{path}, permissive)
+}
+
+// wrapCallback extends a knownhosts callback to record the key of a host that
+// is not in the known_hosts file yet and accept it, instead of returning an
+// error. A host whose recorded key has changed is still a mismatch.
+//
+// That is OpenSSH's StrictHostKeyChecking=accept-new. The other modes are
+// composed from the pieces here rather than being options on this callback:
+// "yes" is [KnownHostsReadOnlyFileCallback], whose refusal to record a key is
+// the whole of what strict means, and "no" is the permissive flag, which
+// downgrades a mismatch to a warning on stderr. "ask" has no meaning without a
+// terminal to ask at, so a caller with no answer to give picks between
+// accept-new and yes.
+func wrapCallback(knownHosts *hostKeyDB, path string, permissive, hash bool) ssh.HostKeyCallback {
 	return ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 		mu.Lock()
 		defer mu.Unlock()
-		err := hkc(hostname, remote, key)
+
+		// The files as they are now, not as they were when this callback was
+		// built: a key recorded meanwhile -- by this callback on an earlier
+		// connection, by another callback over the same files, or by another
+		// process -- has to count here too, or the host reads as new again and
+		// gets a second, conflicting key recorded for it.
+		err := knownHosts.callback(hostname, remote, key)
 		if err == nil {
 			return nil
 		}
@@ -202,14 +450,14 @@ func wrapCallback(hkc ssh.HostKeyCallback, path string, permissive, hash bool) s
 	})
 }
 
-// wrapReadOnlyCallback wraps a knownhosts callback to reject unknown hosts
+// wrapReadOnlyCallback wraps a knownhosts checker to reject unknown hosts
 // without writing to the file. When permissive is true, unknown hosts are
 // accepted silently instead of rejected.
-func wrapReadOnlyCallback(hkc ssh.HostKeyCallback, permissive bool) ssh.HostKeyCallback {
+func wrapReadOnlyCallback(knownHosts *hostKeyDB, permissive bool) ssh.HostKeyCallback {
 	return ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 		mu.Lock()
 		defer mu.Unlock()
-		err := hkc(hostname, remote, key)
+		err := knownHosts.callback(hostname, remote, key)
 		if err == nil {
 			return nil
 		}
@@ -240,31 +488,63 @@ func wrapReadOnlyCallback(hkc ssh.HostKeyCallback, permissive bool) ssh.HostKeyC
 	})
 }
 
-// WithCheckHostIP wraps cb to also verify the connecting IP address in
+// AcceptUnknownHosts wraps cb so that a host it has never seen is accepted
+// rather than refused, while a host whose recorded key has changed remains a
+// mismatch. Any other error is passed through untouched.
+//
+// This is StrictHostKeyChecking=accept-new applied to a trust source that
+// cannot be written to, such as a system-wide known_hosts file: the key is
+// accepted but not recorded, so the next connection reaches the same decision
+// again rather than pinning what it saw the first time. Where a writable user
+// file exists, [KnownHostsFileCallback] is the better fit, since it records the
+// key and so can detect a later change.
+func AcceptUnknownHosts(cb ssh.HostKeyCallback) ssh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		err := cb(hostname, remote, key)
+		var keyErr *knownhosts.KeyError
+		if errors.As(err, &keyErr) && len(keyErr.Want) == 0 {
+			// An empty Want is knownhosts' way of saying the host is not on
+			// file at all, as opposed to being on file under another key.
+			return nil
+		}
+		return err
+	}
+}
+
+// WithCheckHostIP wraps callback to also verify the connecting IP address in
 // known_hosts. When the remote address is a TCP connection the actual connected
 // IP is checked directly; otherwise all DNS-resolved addresses are checked.
 // If the IP is found in known_hosts with a different key (potential DNS
 // spoofing), ErrHostKeyMismatch is returned. DNS resolution failures are
 // non-fatal. Skipped when hostname is already an IP address. Unlike OpenSSH,
 // this implementation never writes IP addresses to known_hosts.
-func WithCheckHostIP(cb ssh.HostKeyCallback, path string, permissive bool) (ssh.HostKeyCallback, error) {
+//
+// The IP is checked before callback runs, so a recording callback cannot store
+// a key the file already contradicts under the connecting IP. The two checks
+// read the files separately, each seeing them as they are when it runs, rather
+// than sharing one read: they are not one atomic look at known_hosts, and an
+// entry written between them belongs to whichever check follows it. That is the
+// same race as an entry written just before the callback, and it is decided the
+// same way -- by the next connection, which reads the file again.
+func WithCheckHostIP(callback ssh.HostKeyCallback, path string, permissive bool) (ssh.HostKeyCallback, error) {
 	if path == devNull {
-		return cb, nil
+		return callback, nil
 	}
-	mu.Lock()
-	rawChecker, err := knownhosts.New(path)
-	mu.Unlock()
+	// Through readOnlyChecker, so a path that cannot be read is reported here
+	// rather than quietly becoming an empty trust set -- a caller that asked for
+	// the IP to be checked would otherwise get a callback that checks nothing.
+	knownHosts, err := readOnlyChecker([]string{path})
 	if err != nil {
-		return nil, fmt.Errorf("%w: check-host-ip: %w", ErrCheckHostKey, err)
+		return nil, fmt.Errorf("check-host-ip: %w", err)
 	}
-	return wrapCheckHostIP(cb, rawChecker, permissive), nil
+	return wrapCheckHostIP(callback, knownHosts, permissive), nil
 }
 
-// checkResolvedIP checks a single resolved IP address against rawChecker.
+// checkResolvedIP checks a single resolved IP address against knownHosts.
 // Returns an error for a known key mismatch (potential DNS spoofing) and, in
 // strict mode, also for unexpected checker errors (IO, address parsing).
 // Must be called with mu held.
-func checkResolvedIP(rawChecker ssh.HostKeyCallback, addr, port string, remote net.Addr, key ssh.PublicKey, permissive bool) error {
+func checkResolvedIP(knownHosts *hostKeyDB, addr, port string, remote net.Addr, key ssh.PublicKey, permissive bool) error {
 	effectivePort := port
 	ipAddr := &net.TCPAddr{IP: net.ParseIP(addr)}
 	if tcp, ok := remote.(*net.TCPAddr); ok {
@@ -274,7 +554,10 @@ func checkResolvedIP(rawChecker ssh.HostKeyCallback, addr, port string, remote n
 		ipAddr.Port = p
 	}
 	ipHost := net.JoinHostPort(addr, effectivePort)
-	ipErr := rawChecker(ipHost, ipAddr, key)
+	// Through the db, so the IP side of the check reads the files as they are
+	// now as well -- an entry added for the IP since this callback was built
+	// contradicts a spoofed key only if it is actually read.
+	ipErr := knownHosts.callback(ipHost, ipAddr, key)
 	if ipErr == nil {
 		return nil
 	}
@@ -297,7 +580,7 @@ func checkResolvedIP(rawChecker ssh.HostKeyCallback, addr, port string, remote n
 	return fmt.Errorf("%w: resolved IP %s: %w", ErrHostKeyMismatch, addr, ipErr)
 }
 
-func wrapCheckHostIP(callback, rawChecker ssh.HostKeyCallback, permissive bool) ssh.HostKeyCallback {
+func wrapCheckHostIP(callback ssh.HostKeyCallback, knownHosts *hostKeyDB, permissive bool) ssh.HostKeyCallback {
 	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 		host, port, err := net.SplitHostPort(hostname)
 		if err != nil {
@@ -311,7 +594,7 @@ func wrapCheckHostIP(callback, rawChecker ssh.HostKeyCallback, permissive bool) 
 		// Perform the IP check before invoking callback so that a spoofed key is
 		// never written to known_hosts when a mismatch is detected.
 		if net.ParseIP(host) == nil && port != "" {
-			if ipErr := checkHostIP(rawChecker, host, port, remote, key, permissive); ipErr != nil {
+			if ipErr := checkHostIP(knownHosts, host, port, remote, key, permissive); ipErr != nil {
 				return ipErr
 			}
 		}
@@ -324,12 +607,12 @@ func wrapCheckHostIP(callback, rawChecker ssh.HostKeyCallback, permissive bool) 
 // remote is a TCP connection the actual connected IP is checked directly;
 // otherwise all DNS-resolved addresses are checked. DNS resolution failures
 // are non-fatal.
-func checkHostIP(rawChecker ssh.HostKeyCallback, host, port string, remote net.Addr, key ssh.PublicKey, permissive bool) error {
+func checkHostIP(knownHosts *hostKeyDB, host, port string, remote net.Addr, key ssh.PublicKey, permissive bool) error {
 	// When the connected address is known, check only that IP to avoid
 	// false positives from multi-homed hostnames (round-robin/CDN).
 	if tcp, ok := remote.(*net.TCPAddr); ok && tcp.IP != nil {
 		mu.Lock()
-		err := checkResolvedIP(rawChecker, tcp.IP.String(), port, remote, key, permissive)
+		err := checkResolvedIP(knownHosts, tcp.IP.String(), port, remote, key, permissive)
 		mu.Unlock()
 		return err
 	}
@@ -346,7 +629,7 @@ func checkHostIP(rawChecker ssh.HostKeyCallback, host, port string, remote net.A
 	var loopErr error
 	mu.Lock()
 	for _, addr := range addrs {
-		if loopErr = checkResolvedIP(rawChecker, addr, port, remote, key, permissive); loopErr != nil {
+		if loopErr = checkResolvedIP(knownHosts, addr, port, remote, key, permissive); loopErr != nil {
 			break
 		}
 	}

--- a/protocol/ssh/hostkey/callbacks_test.go
+++ b/protocol/ssh/hostkey/callbacks_test.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/k0sproject/rig/v2/protocol/ssh/hostkey"
@@ -118,6 +120,25 @@ func stubLookupHost(t *testing.T, fn func(string) ([]string, error)) {
 		*hostkey.LookupHostFunc = prev
 		hostkey.LookupHostMu.Unlock()
 	})
+}
+
+// denyRead puts mode on path -- one that leaves this process unable to read the
+// file -- and restores it when the test ends.
+//
+// Where a mode cannot deny a read the test is skipped rather than asserting
+// something the platform will not do: Windows honours only the read-only
+// attribute and lets every read through whatever the bits say, and root ignores
+// them as well.
+func denyRead(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits do not deny reads on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root reads a file whatever its mode says")
+	}
+	require.NoError(t, os.Chmod(path, mode))
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
 }
 
 // writeKnownHostsFile writes the given lines to a temp known_hosts file and
@@ -290,14 +311,14 @@ func TestWithAliasRejectsInvalidAliases(t *testing.T) {
 	require.NoError(t, err)
 
 	invalid := []string{
-		"",                  // empty — produces malformed host pattern
-		"my alias",          // space
-		"tab\there",         // tab
-		"newline\nhere",     // newline
-		"cr\rhere",          // carriage return
-		"host1,host2",       // comma — would inject multiple patterns
-		"example.com:2222",  // alias already contains a port
-		"[::1]:22",          // bracketed IPv6 with port
+		"",                 // empty — produces malformed host pattern
+		"my alias",         // space
+		"tab\there",        // tab
+		"newline\nhere",    // newline
+		"cr\rhere",         // carriage return
+		"host1,host2",      // comma — would inject multiple patterns
+		"example.com:2222", // alias already contains a port
+		"[::1]:22",         // bracketed IPv6 with port
 	}
 	for _, alias := range invalid {
 		wrapped := hostkey.WithAlias(base, alias)
@@ -382,4 +403,441 @@ func TestWithCheckHostIPPermissiveDowngradesToWarning(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, wrapped("example.com:22", addr, legit.PublicKey()), "permissive mode must not return error on IP mismatch")
+}
+
+// A writePath of /dev/null keeps no record of a new key, but the files beside
+// it are still the trust set: a key one of them contradicts has to stay a
+// mismatch, or an empty write target would overrule a system-wide file.
+func TestKnownHostsFilesCallbackDevNullConsultsAlsoVerify(t *testing.T) {
+	trusted := newTestSigner(t)
+	presented := newTestSigner(t)
+
+	global := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, trusted.PublicKey()),
+	)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	cb, err := hostkey.KnownHostsFilesCallback("/dev/null", []string{global}, false, false)
+	require.NoError(t, err)
+	require.ErrorIs(t, cb("192.0.2.1:22", addr, presented.PublicKey()), hostkey.ErrHostKeyMismatch,
+		"a key the read-only trust set contradicts must be refused even when nothing can be recorded")
+
+	require.NoError(t, cb("192.0.2.1:22", addr, trusted.PublicKey()),
+		"the key the trust set holds must still be accepted")
+}
+
+func TestKnownHostsFilesCallbackDevNullAcceptsUnknownHostWithoutRecording(t *testing.T) {
+	trusted := newTestSigner(t)
+	unknown := newTestSigner(t)
+
+	global := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, trusted.PublicKey()),
+	)
+	before, err := os.ReadFile(global)
+	require.NoError(t, err)
+
+	addr, err := net.ResolveTCPAddr("tcp", "198.51.100.7:22")
+	require.NoError(t, err)
+
+	cb, err := hostkey.KnownHostsFilesCallback("/dev/null", []string{global}, false, false)
+	require.NoError(t, err)
+	require.NoError(t, cb("198.51.100.7:22", addr, unknown.PublicKey()),
+		"a host no file knows is accept-new, and /dev/null is where the record goes")
+
+	after, err := os.ReadFile(global)
+	require.NoError(t, err)
+	require.Equal(t, string(before), string(after),
+		"a read-only trust source must never be appended to")
+}
+
+func TestKnownHostsFilesCallbackDevNullWithNoOtherSourceVerifiesNothing(t *testing.T) {
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	cb, err := hostkey.KnownHostsFilesCallback("/dev/null", nil, false, false)
+	require.NoError(t, err)
+	require.NoError(t, cb("192.0.2.1:22", addr, newTestSigner(t).PublicKey()),
+		"with no trust set left, /dev/null keeps its usual meaning of not verifying host keys")
+}
+
+func TestKnownHostsFilesCallbackDevNullPermissiveToleratesMismatch(t *testing.T) {
+	trusted := newTestSigner(t)
+	presented := newTestSigner(t)
+
+	global := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, trusted.PublicKey()),
+	)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	cb, err := hostkey.KnownHostsFilesCallback("/dev/null", []string{global}, true, false)
+	require.NoError(t, err)
+	require.NoError(t, cb("192.0.2.1:22", addr, presented.PublicKey()),
+		"permissive downgrades a mismatch to a warning on this path too")
+}
+
+func TestKnownHostsFilesCallbackWithIPCheckDevNullConsultsAlsoVerify(t *testing.T) {
+	legit := newTestSigner(t)
+	spoof := newTestSigner(t)
+
+	global := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("example.com:22")}, legit.PublicKey()),
+		knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, spoof.PublicKey()),
+	)
+	stubLookupHost(t, func(_ string) ([]string, error) {
+		return []string{"192.0.2.1"}, nil
+	})
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	cb, err := hostkey.KnownHostsFilesCallbackWithIPCheck("/dev/null", []string{global}, false, false)
+	require.NoError(t, err)
+
+	cbErr := cb("example.com:22", addr, legit.PublicKey())
+	require.ErrorIs(t, cbErr, hostkey.ErrHostKeyMismatch,
+		"the IP check has to run against the read-only trust set as well")
+	require.Contains(t, cbErr.Error(), "192.0.2.1")
+}
+
+// A callback outlives the connection it was built for, and knownhosts.New reads
+// the files only once. Recording a key therefore has to reach the checker too,
+// or a second connection through the same callback would still find the host
+// unknown and accept whatever key it was offered -- the very change accept-new
+// exists to refuse.
+func TestKnownHostsFileCallbackReuseRefusesChangedKey(t *testing.T) {
+	for _, hash := range []bool{false, true} {
+		t.Run(fmt.Sprintf("hash=%v", hash), func(t *testing.T) {
+			khFile := filepath.Join(t.TempDir(), "known_hosts")
+			cb, err := hostkey.KnownHostsFileCallback(khFile, false, hash)
+			require.NoError(t, err)
+
+			addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+			require.NoError(t, err)
+
+			first := newTestSigner(t)
+			require.NoError(t, cb("192.0.2.1:22", addr, first.PublicKey()),
+				"an unknown host is recorded and accepted")
+
+			recorded, err := os.ReadFile(khFile)
+			require.NoError(t, err)
+			require.Equal(t, 1, strings.Count(string(recorded), "\n"), "exactly one entry is recorded")
+
+			second := newTestSigner(t)
+			cbErr := cb("192.0.2.1:22", addr, second.PublicKey())
+			require.ErrorIs(t, cbErr, hostkey.ErrHostKeyMismatch,
+				"the key recorded a moment ago must be honoured by the same callback")
+
+			after, err := os.ReadFile(khFile)
+			require.NoError(t, err)
+			require.Equal(t, string(recorded), string(after), "a refused key must not be recorded")
+		})
+	}
+}
+
+// Two connections can build their callbacks before either handshakes, leaving
+// each with its own snapshot of the same file. A key one of them records has to
+// count for the other, or both would find the host new and record a key of its
+// own for it.
+func TestKnownHostsFileCallbackSeesKeyRecordedByAnotherCallback(t *testing.T) {
+	khFile := filepath.Join(t.TempDir(), "known_hosts")
+	first, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+	second, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	recorded := newTestSigner(t)
+	require.NoError(t, first("192.0.2.1:22", addr, recorded.PublicKey()))
+
+	changed := newTestSigner(t)
+	require.ErrorIs(t, second("192.0.2.1:22", addr, changed.PublicKey()), hostkey.ErrHostKeyMismatch,
+		"a key recorded by one callback must be honoured by the other")
+	require.NoError(t, second("192.0.2.1:22", addr, recorded.PublicKey()),
+		"and the recorded key itself is simply known")
+
+	contents, err := os.ReadFile(khFile)
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(string(contents), "\n"), "the second callback must not record a key of its own")
+}
+
+// The same reasoning covers a file another process appended to: what the
+// callback verifies against is the file as it is now, not as it was when the
+// connection was set up.
+func TestKnownHostsFileCallbackSeesExternallyRecordedKey(t *testing.T) {
+	khFile := filepath.Join(t.TempDir(), "known_hosts")
+	cb, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+
+	recorded := newTestSigner(t)
+	line := knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, recorded.PublicKey())
+	require.NoError(t, os.WriteFile(khFile, []byte(line+"\n"), 0o600))
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	require.NoError(t, cb("192.0.2.1:22", addr, recorded.PublicKey()))
+
+	contents, err := os.ReadFile(khFile)
+	require.NoError(t, err)
+	require.Equal(t, line+"\n", string(contents), "an entry already on file must be recognised, not recorded again")
+
+	require.ErrorIs(t, cb("192.0.2.1:22", addr, newTestSigner(t).PublicKey()), hostkey.ErrHostKeyMismatch)
+}
+
+// A key replaced by one of the same algorithm produces a line of exactly the
+// same length, and a copy that preserves timestamps puts the modification time
+// back. Neither size nor mtime is therefore evidence that the trust set is
+// unchanged, so the files are read rather than cached.
+func TestKnownHostsFileCallbackSeesSameSizeSameMtimeRewrite(t *testing.T) {
+	khFile := filepath.Join(t.TempDir(), "known_hosts")
+
+	before := newTestSigner(t)
+	oldLine := knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, before.PublicKey()) + "\n"
+	require.NoError(t, os.WriteFile(khFile, []byte(oldLine), 0o600))
+
+	stat, err := os.Stat(khFile)
+	require.NoError(t, err)
+	mtime := stat.ModTime()
+
+	cb, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+	require.NoError(t, cb("192.0.2.1:22", addr, before.PublicKey()))
+
+	after := newTestSigner(t)
+	newLine := knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, after.PublicKey()) + "\n"
+	require.Len(t, newLine, len(oldLine), "same algorithm, same line length — the rewrite has to be invisible to a size check")
+	require.NoError(t, os.WriteFile(khFile, []byte(newLine), 0o600))
+	require.NoError(t, os.Chtimes(khFile, mtime, mtime), "and invisible to an mtime check too")
+
+	require.ErrorIs(t, cb("192.0.2.1:22", addr, before.PublicKey()), hostkey.ErrHostKeyMismatch,
+		"the replaced key must be refused")
+	require.NoError(t, cb("192.0.2.1:22", addr, after.PublicKey()), "and the key now on file accepted")
+}
+
+// The IP check runs before the hostname check, so it needs the files as they are
+// now just as much: an entry for the IP added after the callback was built is
+// what catches a spoofed key.
+func TestCheckHostIPSeesEntryAddedAfterConstruction(t *testing.T) {
+	legit := newTestSigner(t)
+	spoof := newTestSigner(t)
+
+	khFile := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("example.com:22")}, legit.PublicKey()),
+	)
+	stubLookupHost(t, func(_ string) ([]string, error) {
+		return []string{"192.0.2.1"}, nil
+	})
+
+	cb, err := hostkey.KnownHostsFileCallbackWithIPCheck(khFile, false, false)
+	require.NoError(t, err)
+
+	contents, err := os.ReadFile(khFile)
+	require.NoError(t, err)
+	spoofed := knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, spoof.PublicKey())
+	require.NoError(t, os.WriteFile(khFile, append(contents, []byte(spoofed+"\n")...), 0o600))
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	cbErr := cb("example.com:22", addr, legit.PublicKey())
+	require.ErrorIs(t, cbErr, hostkey.ErrHostKeyMismatch, "an IP entry added since must still be consulted")
+	require.Contains(t, cbErr.Error(), "192.0.2.1")
+}
+
+// A trust file that goes missing takes its entries with it, but must not take
+// the connection: the other sources still answer, and the file counts again as
+// soon as it is back.
+func TestKnownHostsFilesCallbackToleratesVanishedVerifyPath(t *testing.T) {
+	recorded := newTestSigner(t)
+	global := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, recorded.PublicKey()),
+	)
+	khFile := filepath.Join(t.TempDir(), "known_hosts")
+
+	cb, err := hostkey.KnownHostsFilesCallback(khFile, []string{global}, false, false)
+	require.NoError(t, err)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+	require.ErrorIs(t, cb("192.0.2.1:22", addr, newTestSigner(t).PublicKey()), hostkey.ErrHostKeyMismatch,
+		"the global file contradicts this key")
+
+	require.NoError(t, os.Remove(global))
+	require.NoError(t, cb("192.0.2.1:22", addr, recorded.PublicKey()),
+		"with the file gone the host is simply unknown, and accept-new records it")
+}
+
+// A file that stats fine but cannot be opened is the case a stat-based filter
+// misses: knownhosts.New fails on it, and one unreadable file must not take the
+// rest of the trust set down with it.
+func TestKnownHostsFilesCallbackToleratesUnreadableVerifyPath(t *testing.T) {
+	recorded := newTestSigner(t)
+	global := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, recorded.PublicKey()),
+	)
+	unreadable := writeKnownHostsFile(t)
+	khFile := filepath.Join(t.TempDir(), "known_hosts")
+
+	cb, err := hostkey.KnownHostsFilesCallback(khFile, []string{global, unreadable}, false, false)
+	require.NoError(t, err)
+
+	denyRead(t, unreadable, 0o000)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+	require.ErrorIs(t, cb("192.0.2.1:22", addr, newTestSigner(t).PublicKey()), hostkey.ErrHostKeyMismatch,
+		"the readable file still contradicts this key")
+	require.NoError(t, cb("192.0.2.1:22", addr, recorded.PublicKey()),
+		"and still vouches for the recorded one")
+}
+
+// The file a key is recorded in is not an optional source: the keys it holds
+// are what tell a host that has been seen before from a new one. Treating an
+// unreadable one as empty would make every host look new, and accept-new would
+// append and accept a key the file already contradicts.
+func TestKnownHostsFileCallbackRefusesUnreadableWriteTarget(t *testing.T) {
+	recorded := newTestSigner(t)
+	khFile := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, recorded.PublicKey()),
+	)
+
+	cb, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+
+	// Appendable but no longer readable, the shape a write-only known_hosts has.
+	denyRead(t, khFile, 0o200)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	err = cb("192.0.2.1:22", addr, newTestSigner(t).PublicKey())
+	require.Error(t, err, "a key must not be accepted against a trust source that could not be read")
+	require.ErrorIs(t, err, hostkey.ErrCheckHostKey)
+
+	require.NoError(t, os.Chmod(khFile, 0o600))
+	contents, err := os.ReadFile(khFile)
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(string(contents), "\n"), "and nothing must have been appended")
+}
+
+// A write target that is already unreadable is refused when the callback is
+// built, rather than after it has accepted something.
+func TestKnownHostsFileCallbackRejectsUnreadableWriteTargetUpFront(t *testing.T) {
+	khFile := writeKnownHostsFile(t)
+	denyRead(t, khFile, 0o200)
+
+	_, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.ErrorIs(t, err, hostkey.ErrCheckHostKey)
+}
+
+// An unreadable file named as the trust source at construction is a different
+// matter: there is nothing left to verify against, so it is reported.
+func TestKnownHostsCallbacksRejectUnreadableTrustSource(t *testing.T) {
+	unreadable := writeKnownHostsFile(t)
+	denyRead(t, unreadable, 0o000)
+
+	_, err := hostkey.KnownHostsReadOnlyFileCallback(unreadable, false)
+	require.ErrorIs(t, err, hostkey.ErrCheckHostKey)
+
+	_, err = hostkey.KnownHostsFilesCallback(filepath.Join(t.TempDir(), "known_hosts"), []string{unreadable}, false, false)
+	require.ErrorIs(t, err, hostkey.ErrCheckHostKey)
+}
+
+// WithCheckHostIP takes the trust source for the IP check as its own argument,
+// so an unusable one has to be an error: silently checking nothing would leave
+// the caller believing the IP was verified.
+func TestWithCheckHostIPRejectsUnusablePath(t *testing.T) {
+	base, err := hostkey.KnownHostsReadOnlyFileCallback(writeKnownHostsFile(t), false)
+	require.NoError(t, err)
+
+	_, err = hostkey.WithCheckHostIP(base, filepath.Join(t.TempDir(), "known_hosts"), false)
+	require.ErrorIs(t, err, hostkey.ErrCheckHostKey, "a missing path must be reported")
+
+	_, err = hostkey.WithCheckHostIP(base, t.TempDir(), false)
+	require.ErrorIs(t, err, hostkey.ErrCheckHostKey, "and so must a directory")
+}
+
+// The trust set is what the constructor was given and checked. A caller that
+// reuses its slice afterwards -- the same backing array for the next
+// connection, say -- must not be able to move the sources out from under a
+// callback that was already built.
+func TestKnownHostsCallbacksKeepTheirOwnTrustSet(t *testing.T) {
+	recorded := newTestSigner(t)
+	real := writeKnownHostsFile(t,
+		knownhosts.Line([]string{knownhosts.Normalize("192.0.2.1:22")}, recorded.PublicKey()),
+	)
+	empty := writeKnownHostsFile(t)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	paths := []string{real}
+	readOnly, err := hostkey.KnownHostsReadOnlyFilesCallback(paths, false)
+	require.NoError(t, err)
+
+	khFile := filepath.Join(t.TempDir(), "known_hosts")
+	recording, err := hostkey.KnownHostsFilesCallback(khFile, paths, false, false)
+	require.NoError(t, err)
+
+	paths[0] = empty // the caller reuses its slice for something else
+
+	require.NoError(t, readOnly("192.0.2.1:22", addr, recorded.PublicKey()),
+		"the read-only callback still verifies against the file it was built with")
+	require.ErrorIs(t, recording("192.0.2.1:22", addr, newTestSigner(t).PublicKey()), hostkey.ErrHostKeyMismatch,
+		"and the recording one still sees the key that file holds, rather than an empty trust set")
+}
+
+// A trust source the caller named but that cannot be read is a mistake worth
+// reporting rather than a source to quietly do without -- on the recording
+// paths just as on the /dev/null one.
+func TestKnownHostsFilesCallbackRejectsUnusableVerifyPath(t *testing.T) {
+	khFile := filepath.Join(t.TempDir(), "known_hosts")
+	missing := filepath.Join(t.TempDir(), "ssh_known_hosts")
+
+	_, err := hostkey.KnownHostsFilesCallback(khFile, []string{missing}, false, false)
+	require.ErrorIs(t, err, hostkey.ErrCheckHostKey, "a verify path that does not exist must be reported")
+	require.NoFileExists(t, khFile, "and the append target must not be created on the way to that error")
+
+	_, err = hostkey.KnownHostsFilesCallbackWithIPCheck(khFile, []string{missing}, false, false)
+	require.ErrorIs(t, err, hostkey.ErrCheckHostKey, "the IP-checking variant takes the same argument, and must hold it to the same rule")
+
+	_, err = hostkey.KnownHostsFilesCallback(khFile, []string{t.TempDir()}, false, false)
+	require.ErrorIs(t, err, hostkey.ErrCheckHostKey, "a directory holds no entries either")
+}
+
+// The same key offered twice is known the second time, so there is nothing left
+// to record: a duplicate line would be harmless but would grow the file on every
+// connection.
+func TestKnownHostsFileCallbackReuseRecordsOnce(t *testing.T) {
+	khFile := filepath.Join(t.TempDir(), "known_hosts")
+	cb, err := hostkey.KnownHostsFileCallback(khFile, false, false)
+	require.NoError(t, err)
+
+	addr, err := net.ResolveTCPAddr("tcp", "192.0.2.1:22")
+	require.NoError(t, err)
+
+	signer := newTestSigner(t)
+	require.NoError(t, cb("192.0.2.1:22", addr, signer.PublicKey()))
+	require.NoError(t, cb("192.0.2.1:22", addr, signer.PublicKey()))
+
+	contents, err := os.ReadFile(khFile)
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(string(contents), "\n"), "the key is recorded once, not once per connection")
+}
+
+func TestKnownHostsFilesCallbackDevNullRejectsUnusableAlsoVerify(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "ssh_known_hosts")
+
+	_, err := hostkey.KnownHostsFilesCallback("/dev/null", []string{missing}, false, false)
+	require.ErrorIs(t, err, hostkey.ErrCheckHostKey,
+		"a trust source that cannot be read must be reported, not silently contribute nothing")
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -133,41 +133,83 @@ rig_test_ssh_config_strict() {
   color_echo "- Testing StrictHostkeyChecking=yes in ssh config"
   make create-host
   port="$(ssh_port node0)"
-  echo "Host testhost" > .ssh/config
-  echo "  User root" >> .ssh/config
-  echo "  HostName 127.0.0.1" >> .ssh/config
-  echo "  Port ${port}" >> .ssh/config
-  echo "  IdentityFile $(pwd)/.ssh/id_ed25519" >> .ssh/config
-  echo "  UserKnownHostsFile $(pwd)/.ssh/known" >> .ssh/config
-  echo "  StrictHostKeyChecking yes" >> .ssh/config
-  cat .ssh/config
-  set +e
-  HOME=$(pwd) go test -v ./ -args -ssh-configpath .ssh/config -host testhost -connect
-  exit_code=$?
-  set -e
-  if [ $exit_code -ne 0 ]; then
-    echo "  * Failed first checkpoint"
+
+  write_strict_config() {
+    echo "Host testhost" > .ssh/config
+    echo "  User root" >> .ssh/config
+    echo "  HostName 127.0.0.1" >> .ssh/config
+    echo "  Port ${port}" >> .ssh/config
+    echo "  IdentityFile $(pwd)/.ssh/id_ed25519" >> .ssh/config
+    echo "  UserKnownHostsFile $(pwd)/.ssh/known" >> .ssh/config
+    echo "  StrictHostKeyChecking $1" >> .ssh/config
+    cat .ssh/config
+  }
+
+  connect() {
+    set +e
+    HOME=$(pwd) go test -v ./ -args -ssh-configpath .ssh/config -host testhost -connect
+    exit_code=$?
+    set -e
+  }
+
+  rm -f .ssh/known
+
+  # "yes" must refuse a host it has never seen, and must not record its key.
+  # This is where it differs from "accept-new": OpenSSH only adds a key under
+  # the latter, and rig used to add one under both.
+  write_strict_config yes
+  connect
+  if [ $exit_code -eq 0 ]; then
+    echo "  * Failed first checkpoint: yes connected to an unknown host"
+    RET=1
+    return
+  fi
+  if [ -s .ssh/known ]; then
+    echo "  * Failed first checkpoint: yes recorded a host key it should have refused"
+    cat .ssh/known
     RET=1
     return
   fi
   echo "  * Passed first checkpoint"
-  cat .ssh/known
-  # modify the known hosts file to make it mismatch
-  echo "[127.0.0.1]:$port ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBgejI9UJnRY/i4HNM/os57oFcRjE77gEbVfUkuGr5NRh3N7XxUnnBKdzrAiQNPttUjKmUm92BN7nCUxbwsoSPw=" > .ssh/known
-  echo "[127.0.0.1]:$port ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBGZKwBdFeIPlDWe7otNy4E2Im8+GnQtsukJ5dIuzDGb" >> .ssh/known
-  cat .ssh/known
-  set +e
-  HOME=$(pwd) go test -v ./ -args -ssh-configpath .ssh/config -host testhost -connect
-  exit_code=$?
-  set -e
 
-  if [ $exit_code -eq 0 ]; then
-    echo "  * Failed second checkpoint"
-    # success is a failure
+  # "accept-new" records the key and connects, which is also how the file gets
+  # populated for the checkpoints below.
+  write_strict_config accept-new
+  connect
+  if [ $exit_code -ne 0 ]; then
+    echo "  * Failed second checkpoint: accept-new refused a new host"
     RET=1
     return
   fi
+  if [ ! -s .ssh/known ]; then
+    echo "  * Failed second checkpoint: accept-new did not record the host key"
+    RET=1
+    return
+  fi
+  cat .ssh/known
   echo "  * Passed second checkpoint"
+
+  # With the key on file, "yes" has something to verify against and connects.
+  write_strict_config yes
+  connect
+  if [ $exit_code -ne 0 ]; then
+    echo "  * Failed third checkpoint: yes refused a host that is on file"
+    RET=1
+    return
+  fi
+  echo "  * Passed third checkpoint"
+
+  # A key that changed under it must still be refused.
+  echo "[127.0.0.1]:$port ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBgejI9UJnRY/i4HNM/os57oFcRjE77gEbVfUkuGr5NRh3N7XxUnnBKdzrAiQNPttUjKmUm92BN7nCUxbwsoSPw=" > .ssh/known
+  echo "[127.0.0.1]:$port ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBGZKwBdFeIPlDWe7otNy4E2Im8+GnQtsukJ5dIuzDGb" >> .ssh/known
+  cat .ssh/known
+  connect
+  if [ $exit_code -eq 0 ]; then
+    echo "  * Failed fourth checkpoint: a changed host key was accepted"
+    RET=1
+    return
+  fi
+  echo "  * Passed fourth checkpoint"
 }
 
 rig_test_ssh_config_no_strict() {


### PR DESCRIPTION

Fixes #453

hostkey/callbacks.go carried a TODO about supporting accept-new. The callback it sat on already implemented accept-new -- record the key of a host that is not in known_hosts, refuse one whose key changed -- but it was the only writable callback, and every mode except "no" was routed to it. So "yes" behaved as "accept-new": rig recorded, and connected to, the key of a host it had been told to refuse. That is the mode that exists to make a first connection fail, and the one k0sctl#813 leans on when openssh and k0sctl disagree about known_hosts.

The mode is now carried as far as the callback choice rather than being flattened into a permissive bool on the way. hostKeyPolicy has the three behaviours the four config values map onto, and picking a callback per policy needs no new hostkey API: refusing to record a key is the whole of what strict means, and that is what KnownHostsReadOnlyFileCallback already does. So "yes" takes the read-only callback against the user's own known_hosts file, "accept-new" keeps the recording one, and "no" keeps tolerating mismatches.

"ask" cannot be honoured the way OpenSSH does, since there is no terminal to ask at, and refusing every first connection instead would be a poor trade for a library that provisions hosts. It stays accept-new, which is also what an unset value has always done, and a caller that wants the refusal has "yes" to ask for it. That reading is now written down instead of implied.

One consequence to know about: under "yes" a known_hosts file that does not exist is now an error rather than a file rig creates, since there would be nothing in it to verify against.

