### PR TITLE
fix(ssh): use session.WindowChange

### DIFF
--- a/protocol/ssh/connection.go
+++ b/protocol/ssh/connection.go
@@ -1391,19 +1391,25 @@ func setupInteractivePTY(session *ssh.Session, inF *os.File) (func(), error) {
 // prepareSessionInput wires stdin to the session. If stdin is a terminal
 // *os.File a PTY is requested and a raw-mode restore function is returned;
 // otherwise the reader is used as-is and the restore is a no-op.
-func prepareSessionInput(session *ssh.Session, stdin io.Reader) (input io.Reader, restore func(), err error) {
+//
+// tty is that terminal when a PTY was requested and nil otherwise, so a caller
+// can tell whether the remote end has a line discipline to interpret control
+// characters and resizes -- and measure the right terminal, which need not be
+// os.Stdin.
+func prepareSessionInput(session *ssh.Session, stdin io.Reader) (input io.Reader, tty *os.File, restore func(), err error) {
 	restore = func() {}
 	inF, ok := stdin.(*os.File)
 	if !ok {
-		return stdin, restore, nil
+		return stdin, nil, restore, nil
 	}
 	if term.IsTerminal(int(inF.Fd())) {
 		restore, err = setupInteractivePTY(session, inF)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
+		tty = inF
 	}
-	return inF, restore, nil
+	return inF, tty, restore, nil
 }
 
 // defaultInteractiveStreams replaces nil streams with the process's standard
@@ -1453,7 +1459,7 @@ func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.R
 	session.Stdout = stdout
 	session.Stderr = stderr
 
-	input, restoreTerm, err := prepareSessionInput(session, stdin)
+	input, tty, restoreTerm, err := prepareSessionInput(session, stdin)
 	if err != nil {
 		return err
 	}
@@ -1467,7 +1473,7 @@ func (c *Connection) ExecInteractive(ctx context.Context, cmd string, stdin io.R
 		_, _ = io.Copy(stdinpipe, input)
 	}()
 
-	cancel := captureSignals(stdinpipe, session)
+	cancel := captureSignals(ctx, stdinpipe, session, tty)
 	defer cancel()
 
 	if cmd == "" {

--- a/protocol/ssh/signals.go
+++ b/protocol/ssh/signals.go
@@ -3,22 +3,41 @@
 package ssh
 
 import (
-	"encoding/binary"
-	"fmt"
+	"context"
 	"io"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/k0sproject/rig/v2/log"
 	ssh "golang.org/x/crypto/ssh"
 	"golang.org/x/term"
 )
 
-// TODO use session.WindowChange() instead of sending the request manually.
-// TODO use session.Signal() instead of writing control characters to the stdin.
+// captureSignals relays local interrupt, suspend and window-resize signals to a
+// remote session and returns a function that stops relaying.
+//
+// tty is the local terminal the session's pty was created from, or nil when the
+// session has no pty, in which case nothing is relayed and the returned stop
+// function has nothing to undo.
+//
+// Interrupt and suspend are sent as the control characters a terminal would
+// send rather than through [ssh.Session.Signal]. The "signal" channel request
+// that Signal makes (RFC 4254 section 6.9) is optional for a server to act on,
+// and OpenSSH's sshd does not deliver it to the session's process, so relaying
+// through it would quietly do nothing. A \x03 or \x1a written to the session
+// instead reaches the remote pty's line discipline, which raises SIGINT or
+// SIGTSTP in the foreground process group exactly as a local terminal does.
+//
+// That mechanism is also why the relay needs a pty: without one there is no
+// line discipline to read the bytes as anything but data, so injecting them
+// would corrupt the stdin the caller is piping, and a resize would describe a
+// terminal the remote end does not have.
+func captureSignals(ctx context.Context, stdin io.Writer, session *ssh.Session, tty *os.File) func() {
+	if tty == nil {
+		return func() {}
+	}
 
-// captureSignals intercepts interrupt / resize signals and sends them over to the writer.
-func captureSignals(stdin io.Writer, session *ssh.Session) func() {
 	stopCh := make(chan struct{})
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTSTP, syscall.SIGWINCH)
@@ -27,14 +46,11 @@ func captureSignals(stdin io.Writer, session *ssh.Session) func() {
 		for sig := range sigCh {
 			switch sig {
 			case os.Interrupt:
-				fmt.Fprintf(stdin, "\x03")
+				writeControlChar(ctx, stdin, "\x03", "interrupt")
 			case syscall.SIGTSTP:
-				fmt.Fprintf(stdin, "\x1a")
+				writeControlChar(ctx, stdin, "\x1a", "suspend")
 			case syscall.SIGWINCH:
-				_, err := session.SendRequest("window-change", false, termSizeWNCH())
-				if err != nil {
-					println("failed to relay window-change event: " + err.Error())
-				}
+				relayWindowChange(ctx, session, tty)
 			}
 		}
 	}()
@@ -48,17 +64,28 @@ func captureSignals(stdin io.Writer, session *ssh.Session) func() {
 	return func() { close(stopCh) }
 }
 
-func termSizeWNCH() []byte {
-	size := make([]byte, 16)
-	fd := int(os.Stdin.Fd())
-	rows, cols, err := term.GetSize(fd)
-	if err != nil {
-		binary.BigEndian.PutUint32(size, 40)
-		binary.BigEndian.PutUint32(size[4:], 80)
-	} else {
-		binary.BigEndian.PutUint32(size, uint32(cols))     //nolint:gosec // G115: term.GetSize returns safe values
-		binary.BigEndian.PutUint32(size[4:], uint32(rows)) //nolint:gosec // G115: term.GetSize returns safe values
+// writeControlChar sends one control character to the remote pty, tracing a
+// failure rather than failing the session: the command is still running, and
+// there is nobody to return an error to from a signal handler.
+func writeControlChar(ctx context.Context, stdin io.Writer, char, name string) {
+	if _, err := io.WriteString(stdin, char); err != nil {
+		log.Trace(ctx, "failed to relay "+name+" to the remote session", log.KeyError, err)
 	}
+}
 
-	return size
+// relayWindowChange tells the remote pty the terminal's new size.
+//
+// The size is read from the same terminal the pty was created from, which is
+// not necessarily os.Stdin. A size that cannot be read is not reported at all,
+// since there is nothing true to send: any made-up geometry would be worse than
+// leaving the remote end with the last one it was told.
+func relayWindowChange(ctx context.Context, session *ssh.Session, tty *os.File) {
+	cols, rows, err := term.GetSize(int(tty.Fd()))
+	if err != nil {
+		log.Trace(ctx, "not relaying window-change, cannot read the local terminal size", log.KeyError, err)
+		return
+	}
+	if err := session.WindowChange(rows, cols); err != nil {
+		log.Trace(ctx, "failed to relay window-change event", log.KeyError, err)
+	}
 }

--- a/protocol/ssh/signals_test.go
+++ b/protocol/ssh/signals_test.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// errWriter fails every write, standing in for a session whose stdin pipe has
+// already gone away.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("pipe closed") }
+
+func TestWriteControlChar(t *testing.T) {
+	t.Run("sends the character the terminal would send", func(t *testing.T) {
+		var buf bytes.Buffer
+		writeControlChar(context.Background(), &buf, "\x03", "interrupt")
+		require.Equal(t, "\x03", buf.String(),
+			"the remote pty's line discipline is what turns this into SIGINT, so the byte must go through unchanged")
+	})
+
+	t.Run("a write failure is not fatal", func(t *testing.T) {
+		// There is nobody to return an error to from a signal handler, and the
+		// command is still running, so a failed relay must not take anything down.
+		require.NotPanics(t, func() {
+			writeControlChar(context.Background(), errWriter{}, "\x1a", "suspend")
+		})
+	})
+}
+
+func TestRelayWindowChange(t *testing.T) {
+	t.Run("an unreadable size is not reported at all", func(t *testing.T) {
+		// A nil session panics the moment anything is sent on it, which is the
+		// assertion: a size that cannot be read must stop the relay before it
+		// reaches the session, rather than inventing a geometry to send.
+		f, err := os.Open(os.DevNull)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = f.Close() })
+
+		require.NotPanics(t, func() { relayWindowChange(context.Background(), nil, f) })
+	})
+}
+
+func TestCaptureSignalsWithoutPTY(t *testing.T) {
+	// Without a pty there is no line discipline to read control characters as
+	// anything but data, so nothing may be relayed into the caller's stdin.
+	var buf bytes.Buffer
+	stop := captureSignals(context.Background(), &buf, nil, nil)
+	require.NotNil(t, stop, "the stop function must always be callable")
+	stop()
+	require.Zero(t, buf.Len(), "no pty means nothing is relayed")
+
+	// Calling it with a discarding writer must be just as inert.
+	require.NotPanics(t, func() { captureSignals(context.Background(), io.Discard, nil, nil)() })
+}

--- a/protocol/ssh/signals_windows.go
+++ b/protocol/ssh/signals_windows.go
@@ -1,27 +1,40 @@
 //go:build windows
-// +build windows
 
 package ssh
 
 import (
-	"fmt"
+	"context"
 	"io"
 	"os"
 	"os/signal"
 
+	"github.com/k0sproject/rig/v2/log"
 	ssh "golang.org/x/crypto/ssh"
 )
 
-func captureSignals(stdin io.Writer, session *ssh.Session) func() {
+// captureSignals relays local interrupts to a remote session and returns a
+// function that stops relaying. See the unix build of this file for why the
+// interrupt travels as a control character rather than through
+// [ssh.Session.Signal], and why a pty is required for it to mean anything.
+//
+// Windows has no SIGTSTP or SIGWINCH, so an interrupt is all there is to relay.
+func captureSignals(ctx context.Context, stdin io.Writer, _ *ssh.Session, tty *os.File) func() {
+	if tty == nil {
+		return func() {}
+	}
+
 	stopCh := make(chan struct{})
-	sigCh := make(chan os.Signal)
+	// Buffered, because signal.Notify never blocks on a send: an unbuffered
+	// channel drops any signal arriving while the relay is busy.
+	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
 
 	go func() {
 		for sig := range sigCh {
-			switch sig {
-			case os.Interrupt:
-				fmt.Fprintf(stdin, "\x03")
+			if sig == os.Interrupt {
+				if _, err := io.WriteString(stdin, "\x03"); err != nil {
+					log.Trace(ctx, "failed to relay interrupt to the remote session", log.KeyError, err)
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #455

signals.go carried two TODOs asking for the library's own APIs. One is right, the other would break interrupt handling, so this takes one and records the reason for keeping the other.

Taken: session.WindowChange() replaces a hand-packed window-change request. x/crypto sends the same request with columns and rows in the same order, so the only difference is that it fills in the pixel dimensions the manual version left at zero, which RFC 4254 treats as advisory. termSizeWNCH and its two gosec suppressions go with it.

Kept: the interrupt and suspend control characters. session.Signal() sends the "signal" channel request of RFC 4254 section 6.9, which a server may ignore -- and OpenSSH's sshd does not deliver it to the session's process, so switching would leave Ctrl-C quietly doing nothing. A \x03 or \x1a written to the session reaches the remote pty's line discipline, which raises SIGINT or SIGTSTP in the foreground process group, which is both how a local terminal does it and why it works.

Writing that down made the missing precondition obvious: that mechanism needs a pty, and captureSignals was called whether or not one had been requested. With a piped stdin there is no line discipline, so a Ctrl-C only injected 0x03 into the caller's data stream and a resize described a terminal the remote end did not have. prepareSessionInput now reports the terminal it made the pty from, and the relay is skipped without one. That also fixes which terminal is measured: the size came from os.Stdin while the pty had been sized from the stdin actually passed in.

Two smaller things in the same handler: an unreadable terminal size now sends nothing instead of a made-up 40x80 -- which had its rows and columns the wrong way round anyway -- and the failure path no longer reaches for the println builtin, which wrote unstructured text to stderr from a library.

The windows build gets the same treatment, plus a buffer on its signal channel: signal.Notify never blocks on a send, so an unbuffered channel drops any interrupt arriving while the relay is busy.

