### PR TITLE
refactor(remotefs): split multiStat instead of suppressing cyclop

### DIFF
--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -351,47 +351,101 @@ func commandRanAndFailed(err error) bool {
 	return false
 }
 
-func (s *PosixFS) multiStat(names ...string) ([]fs.FileInfo, error) { //nolint:cyclop // TODO refactor
+// statBatchBytes caps how much of a stat command line one batch may fill. The
+// limit is on the arguments alone, so it leaves room for the command itself
+// within a conservative view of the remote ARG_MAX.
+const statBatchBytes = 1024
+
+// statBatch quotes names into one command line, starting at idx and stopping
+// once the batch is full or the names run out. It returns the batch and the
+// index to continue from, which always advances, so a caller looping until the
+// names are exhausted terminates.
+//
+// Empty names are skipped rather than passed to stat, which would read them as
+// a missing operand and fail the whole batch. A batch of nothing but empty
+// names therefore comes back empty.
+func statBatch(names []string, idx int) (string, int) {
+	var batch strings.Builder
+	batch.Grow(statBatchBytes)
+	for batch.Len() < statBatchBytes && idx < len(names) {
+		if names[idx] != "" {
+			if batch.Len() > 0 {
+				batch.WriteRune(' ')
+			}
+			batch.WriteString(shellescape.Quote(names[idx]))
+		}
+		idx++
+	}
+	return batch.String(), idx
+}
+
+// statScanError explains a stat command that failed rather than a path that
+// could not be parsed.
+//
+// A single name gets the os package's treatment: a command that ran and exited
+// non-zero means the path is not there, while anything else -- a transport
+// failure, a stat that is not installed -- says nothing about the path and is
+// reported as it came. Several names cannot pin the failure on one of them, so
+// they are all named instead -- every name the call asked for, not just the
+// batch that failed, since a name that stat never reached is as unanswered as
+// one it did.
+func statScanError(err error, names []string) error {
+	if len(names) != 1 {
+		return fmt.Errorf("stat %s: %w", names, err)
+	}
+	if commandRanAndFailed(err) {
+		return PathError(OpStat, names[0], fs.ErrNotExist)
+	}
+	return PathErrorf(OpStat, names[0], "stat: %w", err)
+}
+
+// appendStatLines parses every line the scanner yields onto res and returns it,
+// so a failure part way through still carries what was read before it.
+func (s *PosixFS) appendStatLines(scanner *bufio.Scanner, res []fs.FileInfo) ([]fs.FileInfo, error) {
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		info, err := s.parseStat(line)
+		if err != nil {
+			return res, err
+		}
+		res = append(res, info)
+	}
+	return res, nil
+}
+
+func (s *PosixFS) multiStat(names ...string) ([]fs.FileInfo, error) {
 	if err := s.initStat(); err != nil {
 		return nil, err
 	}
-	var idx int
 	res := make([]fs.FileInfo, 0, len(names))
-	var batch strings.Builder
-	batch.Grow(1024)
-	for idx < len(names) {
-		batch.Reset()
-		// build max 1kb batches of names to stat
-		for batch.Len() < 1024 && idx < len(names) {
-			if names[idx] != "" {
-				batch.WriteString(shellescape.Quote(names[idx]))
-				if idx < len(names)-1 {
-					batch.WriteRune(' ')
-				}
-			}
-			idx++
+	for idx := 0; idx < len(names); {
+		var batch string
+		batch, idx = statBatch(names, idx)
+		if batch == "" {
+			// Every name in this batch was empty. Running stat with no operands
+			// would only fail, and Stat turns the missing result into ErrNotExist
+			// on its own.
+			continue
 		}
 
-		scanner := s.ExecScanner(fmt.Sprintf(*s.statCmd, batch.String()))
-		for scanner.Scan() {
-			line := scanner.Text()
-			if line == "" {
-				continue
-			}
-			info, err := s.parseStat(line)
-			if err != nil {
-				return res, err
-			}
-			res = append(res, info)
+		scanner := s.ExecScanner(fmt.Sprintf(*s.statCmd, batch))
+		// Assigned, not declared: a := here would shadow res and quietly drop
+		// every batch's results.
+		var err error
+		res, err = s.appendStatLines(scanner, res)
+		if err != nil {
+			return res, err
 		}
 		if err := scanner.Err(); err != nil {
 			if len(names) == 1 {
-				if commandRanAndFailed(err) {
-					return nil, PathError(OpStat, names[0], fs.ErrNotExist)
-				}
-				return nil, PathErrorf(OpStat, names[0], "stat: %w", err)
+				// A lone name is answered as a path error, so a partial result is
+				// not worth carrying back.
+				return nil, statScanError(err, names)
 			}
-			return res, fmt.Errorf("stat %s: %w", names, err)
+			return res, statScanError(err, names)
 		}
 	}
 	return res, nil

--- a/remotefs/posixfs_test.go
+++ b/remotefs/posixfs_test.go
@@ -1034,6 +1034,46 @@ func TestPosixStatLocalhost(t *testing.T) {
 	require.ErrorIs(t, err, fs.ErrNotExist)
 }
 
+func TestPosixMultiStatBatching(t *testing.T) {
+	// multiStat splits the names over several stat invocations to stay inside a
+	// conservative ARG_MAX, and only a directory with more than a kilobyte of
+	// names reaches the second batch. Nothing else covers that loop, and getting
+	// it wrong loses whole batches of results rather than failing.
+	const (
+		entries = 200
+		dir     = "/etc/many"
+	)
+
+	names := make([]string, 0, entries)
+	for i := range entries {
+		names = append(names, fmt.Sprintf("%s/entry-with-a-long-enough-name-%03d.conf", dir, i))
+	}
+
+	mr := rigtest.NewMockRunner()
+	mr.AddCommandSuccess(rigtest.Equal("stat -c %n /"))
+	mr.AddCommandOutput(rigtest.Contains("find"), strings.Join(append([]string{dir}, names...), "\x00"))
+
+	var statCalls int
+	mr.AddCommand(rigtest.HasPrefix("env -i"), func(a *rigtest.A) error {
+		statCalls++
+		// Answer for exactly the names this invocation asked about, so a batch
+		// that never reaches stat cannot be mistaken for one that did.
+		for _, name := range names {
+			if strings.Contains(a.Command, name) {
+				if _, err := fmt.Fprintf(a.Stdout, "0x81a4 10 2024-09-30 11:42:01.000000000 +0000 //%s//\n", name); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+
+	res, err := remotefs.NewPosixFS(mr).ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, res, entries, "every batch's results must be kept, not just the last one's")
+	require.Greater(t, statCalls, 1, "these names must not fit in a single batch, or the test proves nothing")
+}
+
 func TestPosixReadDirConnectionLost(t *testing.T) {
 	// A find that died mid-command reports a wrapped io.EOF. That is a lost
 	// connection, not an empty or missing directory, and must not collapse into


### PR DESCRIPTION
Fixes #454

multiStat carried //nolint:cyclop // TODO refactor: one function held the batching loop, the scan loop and the error classification, and the three were only related by sharing a result slice.

Two of them move out. statBatch quotes names into one command line and returns where to continue, which is also the natural place to say why empty names are skipped -- stat reads a missing operand as a failure of the whole batch. statScanError explains the single-name versus batch split: a lone name is answered like the os package would, where a command that ran and exited non-zero means the path is gone, while a batch cannot pin the failure on one of its names. appendStatLines takes the scan.

No behavior change intended, and the suppression is gone rather than moved.

The batching loop turned out to be untested, which a refactor of it should not be able to say: only a directory with more than a kilobyte of names reaches a second batch. TestPosixMultiStatBatching covers it with 200 entries, asserts more than one stat invocation so the test cannot pass vacuously, and answers only for the names each invocation actually asked about. It catches the class of mistake this refactor can make -- dropping whole batches rather than failing -- which is what a shadowed result slice did on the first attempt here.

