### PR TITLE
test(kv): cover the invalid int error path in strict mode

### DIFF
--- a/kv/decoder_test.go
+++ b/kv/decoder_test.go
@@ -76,6 +76,16 @@ func TestDecoderWithStruct(t *testing.T) {
 			assert.True(t, target.Key3)
 			assert.Equal(t, 42, target.Key4)
 		})
+		t.Run("Invalid int", func(t *testing.T) {
+			type testStruct struct {
+				Key4 int `kv:"key4"`
+			}
+			target := testStruct{}
+			data := "key4=notanumber"
+			decoder := kv.NewDecoder(strings.NewReader(data))
+			decoder.Strict()
+			require.ErrorContains(t, decoder.Decode(&target), "parse int")
+		})
 		t.Run("Slices and pointers", func(t *testing.T) {
 			type testStruct struct {
 				Key1 *string  `kv:"key1"`


### PR DESCRIPTION
`kv.Decoder`'s `assignField` has a parse int error branch that no test exercised. Adding a case for it also surfaced that `Decode` in non-strict mode (the default) silently discards assign errors, including this one, so the only way to actually observe the error is through `Strict` mode. This test uses `Strict` to reach it.

Test only, no production code changed.

Tested with `go test ./kv/...`, `gofmt -l`, and `go vet ./kv/...`, all clean.
