### PR TITLE
ci(dco): exclude the Copilot coding agent from the DCO check

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -37,5 +37,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DCO_CHECK_VERBOSE: "true"
-          DCO_CHECK_EXCLUDE_PATTERN: dependabot\[bot\]@users\.noreply\.github\.com
+          # Matched against the commit author email. Bot commits are authored by
+          # GitHub on the bot's behalf and carry no Signed-off-by trailer.
+          DCO_CHECK_EXCLUDE_PATTERN: 'dependabot\[bot\]@users\.noreply\.github\.com|198982749\+Copilot@users\.noreply\.github\.com'
         run: python3 dco_check.py


### PR DESCRIPTION
Commits pushed by the Copilot coding agent are authored by copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com> and committed by GitHub, so they carry no Signed-off-by trailer and fail the DCO check exactly the way dependabot's commits would.

dco-check compiles DCO_CHECK_EXCLUDE_PATTERN into a single regex and searches it against the commit author email, so both bot identities have to share one alternation rather than being listed separately.