### PR TITLE
chore(docs): Add agent instructions 

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,10 +7,11 @@ restating it here.
 
 ## Context to review with
 
-- The module targets **Go 1.27**. Language features from recent releases are
-  available and correct: ranging over an integer (`for i := range 10`), the
+- The module targets the latest Go version. Language features from recent releases
+  are available and correct: ranging over an integer (`for i := range 10`), the
   `min`/`max` builtins, generic type parameters, and `for` loops with
-  per-iteration variable scope. Do not report these as compile errors.
+  per-iteration variable scope. Do not report these as compile errors. In fact,
+  suggest using them where they make the code clearer.
 - **Test files are not linted** (`run.tests: false` in `.golangci.yml`), so
   review of `_test.go` code is genuinely useful here. Real bugs in tests will
   not be caught by anything else.
@@ -52,18 +53,15 @@ In rough order of how much these matter in this repository:
 
 ## Not worth flagging
 
-- Anything `.golangci.yml` deliberately disables: line length, magic numbers,
-  returning interfaces, exhaustive struct literals, named returns, whitespace
-  style, and `TODO` comments.
+- Anything `.golangci.yml` already catches or what is disabled intentionally.
 - Import order and formatting. `gci`, `gofmt`, `gofumpt` and `goimports` own
-  those.
+  those and will be caught in lint.
 - Grammar and wording preferences in comments, documentation or commit
   messages, unless the meaning is actually wrong.
-- Restating what the diff does, or summarising the change back to the author.
 
 ## Comments in the code
 
-Inline comments have to earn their place here. Two reasons qualify: a decision
+Inline comments have to earn their place. Two reasons qualify: a decision
 tree whose branching or ordering is genuinely hard to follow, and a
 strange-looking line that exists because of an external quirk — BSD `chmod`
 wanting `--` before the mode, a uutils flag that behaves unlike GNU's.
@@ -91,4 +89,4 @@ Keep each comment to one finding, and name the concrete failure — the input,
 state or platform where the code does the wrong thing. A reviewer acts on "with
 `UserKnownHostsFile none` this falls through to the read-only path and accepts
 an unknown key"; there is nothing to act on in "consider reviewing the error
-handling here". Skip praise and skip the summary wall.
+handling here". Skip praise and skip the summary wall-of-text.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,94 @@
+# Copilot instructions
+
+`github.com/k0sproject/rig/v2` is a Go library for managing remote hosts over
+SSH, OpenSSH, WinRM and localhost. `AGENTS.md` in the repository root is
+authoritative for layout, conventions and code style — follow it rather than
+restating it here.
+
+## Context to review with
+
+- The module targets **Go 1.27**. Language features from recent releases are
+  available and correct: ranging over an integer (`for i := range 10`), the
+  `min`/`max` builtins, generic type parameters, and `for` loops with
+  per-iteration variable scope. Do not report these as compile errors.
+- **Test files are not linted** (`run.tests: false` in `.golangci.yml`), so
+  review of `_test.go` code is genuinely useful here. Real bugs in tests will
+  not be caught by anything else.
+- `schemas/` is **generated** by `make schemas`. Review the config structs that
+  drive it, not the output.
+- This library runs commands on hosts it does not control: BusyBox and uutils
+  coreutils rather than GNU, BSD and macOS userlands, and Windows with a
+  PowerShell 5.1 baseline. Commands are wrapped in a POSIX shell, and the
+  operator's login shell may be fish. Findings about missing utilities,
+  non-GNU flag behaviour and shell quoting are in scope and welcome.
+- `remotefs.PosixFS` and `remotefs.WinFS` mirror each other. A behavioural
+  change to one usually needs the same change, or a deliberate difference, in
+  the other.
+- `rigtest.MockRunner` needs a stub for every command a code path executes. An
+  unstubbed command is a common cause of a test that passes for the wrong
+  reason.
+
+## Worth flagging
+
+In rough order of how much these matter in this repository:
+
+- **A doc comment or document that contradicts the implementation.** Comments
+  are read as specifications: a comment promising "removed only on failure"
+  above an unconditional cleanup, a doc claiming an error is "always nil" when
+  it is not, or a table in `docs/` that no longer matches the code. This is the
+  most valuable review you do here.
+- **Format-verb misuse**, especially `%s` applied to an `error` or a `[]string`,
+  which renders as `%!s(...)` and makes real failures unreadable.
+- **List and multi-file handling that only honours the first element** while the
+  documented contract covers all of them.
+- **Tests that assert success without asserting the new behaviour** the change
+  introduces, and new code paths (a fallback, a retry, an alternate utility)
+  left uncovered.
+- **Unexported sentinel errors** that callers outside the package cannot match
+  with `errors.Is`.
+- Aliasing of a caller's slice or map that is retained after construction.
+- A shell argument built from a variable without `sh.Command` or
+  `shellescape.Quote`.
+
+## Not worth flagging
+
+- Anything `.golangci.yml` deliberately disables: line length, magic numbers,
+  returning interfaces, exhaustive struct literals, named returns, whitespace
+  style, and `TODO` comments.
+- Import order and formatting. `gci`, `gofmt`, `gofumpt` and `goimports` own
+  those.
+- Grammar and wording preferences in comments, documentation or commit
+  messages, unless the meaning is actually wrong.
+- Restating what the diff does, or summarising the change back to the author.
+
+## Comments in the code
+
+Inline comments have to earn their place here. Two reasons qualify: a decision
+tree whose branching or ordering is genuinely hard to follow, and a
+strange-looking line that exists because of an external quirk — BSD `chmod`
+wanting `--` before the mode, a uutils flag that behaves unlike GNU's.
+
+Reviewing with that in mind:
+
+- Flag narration a change adds — a comment that restates the line below it or
+  the variable being assigned. `// find separator` above the line that finds
+  the separator, and `// if there is no separator, the line is invalid` above
+  `if idx == -1`, are noise. Whereas `// some versions of ssh output a broken
+  line for canonicaldomains that doesn't include a value` is exactly what a
+  comment is for.
+- Flag a comment that asserts what *another* function does. It rots silently
+  when that function changes; the rationale belongs in the callee's doc comment.
+- Do not ask for a comment on code that reads fine on its own. Absent narration
+  is not a finding.
+- A comment that contradicts the code is a different matter — that is a bug,
+  and reporting it is the most useful thing you do here.
+
+Doc comments on exported symbols are separate, and are required.
+
+## Review comments
+
+Keep each comment to one finding, and name the concrete failure — the input,
+state or platform where the code does the wrong thing. A reviewer acts on "with
+`UserKnownHostsFile none` this falls through to the read-only path and accepts
+an unknown key"; there is nothing to act on in "consider reviewing the error
+handling here". Skip praise and skip the summary wall.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,7 @@ implementations live under `protocol/` and satisfy `protocol.Connection`.
 
 Prefer additive changes, but a breaking change to an exported symbol is
 acceptable when it is the right fix — it ships in a v2.x release rather than
-needing a new module path. Call it out in the pull request so it can be
-documented. The two branches have diverged: a fix on one must be evaluated for
-the other.
+needing a new module path. The two branches have diverged significantly.
 
 ## Finding your way around
 
@@ -126,7 +124,10 @@ Beyond the linters:
 - Give every exported symbol a doc comment that starts with its name.
 - Mirror test files to sources: `foo.go` is tested by `foo_test.go`. Cover new
   exported behaviour including its error paths.
-- Comment the non-obvious — a quirk being worked around, or a decision that
+- Prefer reusing variable names that are used for the same concept elsewhere in
+  the codebase, rather than inventing a new name. The .golangci.yml contains
+  common names in `varnamelen`'s `ignore-patterns` for this reason.
+- Comment only the non-obvious — a quirk being worked around, or a decision that
   isn't clear from the code. Don't narrate what the next line plainly does.
 
 ## Gotchas
@@ -157,11 +158,11 @@ another model. Write it for that reader.
   costs a reviewer more than it tells them.
 - In a comment thread, answer the point and then stop.
 
-If you are an agent, three more:
+If you are an autonomous AI agent:
 
-- Say so. You are not expected to pass as human, and an unmarked
-  machine-written pull request costs the reviewer trust once they work it out.
-  One line naming what you are and who asked for the change is enough.
+- You are not expected to pass as human, and an unmarked machine-written pull
+  request costs the reviewer trust once they work it out. One line naming what
+  you are and who asked for the change is enough.
 - Don't fire and forget. A pull request is the start of a conversation: review
   comments, a red CI job and follow-up questions are all expected, and seeing
   them through is part of making the change.
@@ -172,10 +173,13 @@ If you are an agent, three more:
 ## Pull requests
 
 - Every commit needs a `Signed-off-by` trailer (`git commit -s`); a DCO check
-  enforces it. Do not add `Co-authored-by` trailers.
+  enforces it. Do not add `Co-authored-by` trailers that make some AI model
+  or coding assistant appear as a contributor.
 - Use conventional commit subjects with a scope, such as
   `fix(remotefs): ...`, `feat(ssh): ...` or `ci(dco): ...`.
-- Copilot reviews every pull request. Save a round trip by handling nil checks,
-  every error return, quoting and edge cases up front.
+- Copilot reviews pull requests. Save a round trip by handling nil checks,
+  every error return, quoting and edge cases up front. In fact, it is
+  probably a good idea to read the `.github/copilot-instructions.md` file 
+  before starting a change, so you know what to expect from the review.
 - Work on a branch and open a pull request; never push straight to `main` or
   `release-0.x`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,181 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in this repository. It is short on
+purpose: it covers what is *not* discoverable from the code, and points at the
+tooling for everything else.
+
+## Project
+
+`github.com/k0sproject/rig/v2` is a Go library for managing remote hosts over
+SSH, OpenSSH, WinRM and localhost. It handles connections, command execution,
+a remote filesystem, OS and distro detection, privilege escalation, service
+management and package management. The primary consumer is
+[k0sctl](https://github.com/k0sproject/k0sctl).
+
+A `rig.Client` pairs a `cmd.Runner` with lazily initialised providers for
+sudo, filesystem, init system, package manager and OS release. Protocol
+implementations live under `protocol/` and satisfy `protocol.Connection`.
+`rig.ClientWithConfig` wraps a `CompositeConfig` for YAML-friendly embedding.
+
+## API stability
+
+| Branch | Status |
+|---|---|
+| `main` | v2, released and in active downstream use. |
+| `release-0.x` | v0.x, maintenance only. |
+
+Prefer additive changes, but a breaking change to an exported symbol is
+acceptable when it is the right fix — it ships in a v2.x release rather than
+needing a new module path. Call it out in the pull request so it can be
+documented. The two branches have diverged: a fix on one must be evaluated for
+the other.
+
+## Finding your way around
+
+Read the API from the source of truth rather than from prose:
+
+```
+go list ./...          # every package
+go doc ./remotefs      # package summary
+go doc ./cmd Runner    # a single symbol
+```
+
+Do not inline an API reference into this file. One used to live here, and every
+hand-copied signature in it eventually contradicted the code.
+
+Longer-form documentation lives in `docs/`:
+
+| File | Covers |
+|---|---|
+| `EXTENDING.md` | adding protocols, init systems, package managers |
+| `TESTING.md` | unit, integration and fuzz testing |
+| `MIGRATING-from-v0.x.md` | v0.x to v2 API mapping |
+| `capability-discovery.md` | how provider and registry detection works |
+| `ssh-config-precedence.md` | `ssh_config` resolution order |
+| `pty-tty-semantics.md` | interactive session behaviour |
+
+## Package layout
+
+| Path | Contents |
+|---|---|
+| root | `Client`, `ClientWithConfig`, `CompositeConfig`, `Service`, options |
+| `protocol/` | the `Connection` interface plus `ssh`, `openssh`, `winrm`, `localhost` |
+| `cmd/` | runner interfaces, `Executor`, `Proc`, exec options, command gating |
+| `remotefs/` | the `FS` and `OS` interfaces, `PosixFS`, `WinFS`, upload and download |
+| `initsystem/` | service managers, one file per init system, auto-detected |
+| `packagemanager/` | package managers, one file per tool, auto-detected |
+| `os/` | `Release`: OS and distro detection, architecture |
+| `sudo/` | privilege escalation detection and command decoration |
+| `sshconfig/` | `ssh_config` parsing |
+| `sh/`, `powershell/` | shell and PowerShell command construction |
+| `retry/`, `redact/`, `log/` | retries, secret redaction, logging |
+| `kv/`, `byteslice/`, `stattime/`, `homedir/`, `iostream/` | small utilities |
+| `plumbing/` | lazy provider and registry infrastructure |
+| `rigtest/` | mocks and assertions for tests |
+| `internal/jsonschema/` | generator for the committed `schemas/` |
+| `test/` | integration suite; a separate Go module |
+
+## Commands
+
+```
+make test      # go test -v ./...
+make lint      # golangci-lint run    (FIX=true applies autofixes)
+make schemas   # regenerate schemas/ from the config structs
+make fuzz      # briefly run every fuzz target
+make inttest   # integration tests; needs Docker and bootloose
+```
+
+Tests and lint must both pass before a change is finished. CI additionally
+runs `go vet`, govulncheck, CodeQL and the integration matrix.
+
+## Code style
+
+`.golangci.yml` is authoritative and strict: it enables *all* golangci-lint
+checkers and then disables a short list. Read it for the current limits rather
+than trusting numbers quoted elsewhere. What it means in practice:
+
+- **Complexity**: `cyclop` and `funlen` are on. Split a long or branchy
+  function instead of suppressing the warning.
+- **Error wrapping**: `wrapcheck` and `err113` are on. Wrap errors crossing a
+  package boundary with `%w` and compare with `errors.Is`/`errors.As`. Declare
+  sentinel errors as package-level vars rather than returning a freshly built
+  dynamic error.
+- **Naming**: `varnamelen` permits a terse name only close to its declaration.
+  Name anything longer-lived in full.
+- **Formatting**: `gci`, `gofmt`, `gofumpt`, `goimports`. Run
+  `golangci-lint fmt`; `golangci-lint run` does *not* apply formatters. Also
+  `run.tests: false`, so test files are not linted at all — format and review
+  those by hand.
+- No line-length limit (`lll` is off), and returning interfaces is allowed
+  (`ireturn` is off).
+
+Beyond the linters:
+
+- Quote every shell argument built from a variable, with `sh.Command(...)` or
+  `shellescape.Quote(...)`. Never interpolate a value into a command string
+  with `fmt.Sprintf`.
+- Accept the narrowest runner interface that does the job:
+  `cmd.SimpleRunner` < `cmd.ContextRunner` < `cmd.Runner`.
+- Given a `*Client`, prefer `client.FS()`, `client.Service(name)` and
+  `client.Sudo()` over building `remotefs` or `initsystem` values by hand.
+- Signal a hopeless operation with `protocol.ErrNonRetryable`, re-exported as
+  `rig.ErrNonRetryable`; `retry` has its own `retry.ErrNonRetryable`. There is
+  no `ErrAbort` in this codebase.
+- Put OS-specific behaviour in a registry entry with a per-OS file, not in an
+  `if IsWindows()` branch inside shared code.
+- Give every exported symbol a doc comment that starts with its name.
+- Mirror test files to sources: `foo.go` is tested by `foo_test.go`. Cover new
+  exported behaviour including its error paths.
+- Comment the non-obvious — a quirk being worked around, or a decision that
+  isn't clear from the code. Don't narrate what the next line plainly does.
+
+## Gotchas
+
+- Commands are wrapped in a POSIX shell rather than trusting the login shell,
+  which may be fish or something else non-POSIX.
+- WinRM filesystem and transfer operations go through the `rigrcp` PowerShell
+  daemon rather than plain shell commands.
+- Changing a protocol config struct means regenerating `schemas/` with
+  `make schemas`. CI fails if the result is not committed.
+- `test/` is its own Go module and needs Docker plus bootloose images, with
+  `LINUX_IMAGE` selecting the distro. Failures there are usually genuine
+  coreutils differences — BusyBox and uutils are not GNU — so fix the
+  assumption rather than the test.
+
+## Writing for humans
+
+A pull request body, an issue or a review reply is read by a person, not by
+another model. Write it for that reader.
+
+- Explain the **why**: the motivation, the failure scenario, the reasoning
+  behind a non-obvious decision.
+- Don't re-narrate the diff. A reviewer can already see that a helper was
+  extracted, an import changed or a function was renamed.
+- Skip the implementation walkthrough and the validation transcript. Say in one
+  line what you verified; nobody needs a log of every command you ran.
+- Don't pad to appear thorough. Length is not credibility, and a wall of text
+  costs a reviewer more than it tells them.
+- In a comment thread, answer the point and then stop.
+
+If you are an agent, three more:
+
+- Say so. You are not expected to pass as human, and an unmarked
+  machine-written pull request costs the reviewer trust once they work it out.
+  One line naming what you are and who asked for the change is enough.
+- Don't fire and forget. A pull request is the start of a conversation: review
+  comments, a red CI job and follow-up questions are all expected, and seeing
+  them through is part of making the change.
+- If you cannot come back — no session to resume, no way to be re-invoked — say
+  so in the pull request and tell your operator that the follow-up falls to
+  them, so a person is accountable for the change.
+
+## Pull requests
+
+- Every commit needs a `Signed-off-by` trailer (`git commit -s`); a DCO check
+  enforces it. Do not add `Co-authored-by` trailers.
+- Use conventional commit subjects with a scope, such as
+  `fix(remotefs): ...`, `feat(ssh): ...` or `ci(dco): ...`.
+- Copilot reviews every pull request. Save a round trip by handling nil checks,
+  every error return, quoting and edge cases up front.
+- Work on a branch and open a pull request; never push straight to `main` or
+  `release-0.x`.


### PR DESCRIPTION
Adds AGENTS.md and copilot-instructions.md.
