### PR TITLE
ci: report exported API changes on pull requests

### DIFF
--- a/.github/workflows/api-diff.yml
+++ b/.github/workflows/api-diff.yml
@@ -1,0 +1,168 @@
+name: API diff
+
+# Reports what a pull request changes in the exported API and labels it.
+# Informational only: a break is allowed in a v2.x release.
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write # labels live behind the issues API
+
+# An older run's verdict is wrong once a newer commit exists.
+concurrency:
+  group: api-diff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  apidiff:
+    name: API diff
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # the merge base has to be reachable
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Compare exported API against the merge base
+        id: compare
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Written up front so a later failure still has something truthful to
+          # post, rather than leaving the previous commit's verdict standing.
+          mkdir -p "$RUNNER_TEMP/out"
+          : > "$RUNNER_TEMP/out/label"
+          printf '<!-- api-diff -->\n### Exported API\n\nThe comparison could not run for %s, so there is no verdict for this commit. See [the run](%s).\n' \
+            "$GITHUB_SHA" "$RUN_URL" > "$RUNNER_TEMP/out/body.md"
+
+          # Comparing against a release tag instead would blame every API
+          # change merged since that release on this pull request.
+          if ! base="$(git merge-base "$BASE_SHA" HEAD)"; then
+            echo "::error::cannot find the merge base of $BASE_SHA and HEAD"
+            exit 1
+          fi
+
+          git worktree add --detach --quiet "$RUNNER_TEMP/base" "$base"
+          go build -C internal/apidiff -o "$RUNNER_TEMP/apidiff" .
+
+          status=0
+          "$RUNNER_TEMP/apidiff" -base "$RUNNER_TEMP/base" -head "$GITHUB_WORKSPACE" \
+            > "$RUNNER_TEMP/report.md" || status=$?
+
+          # Any other status is a crash, not a verdict.
+          case "$status" in
+            0|3|4) ;;
+            *)
+              echo "::error::could not compare the exported API against $base (exit $status)"
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "## Exported API comparison"
+            echo
+            echo "Compared against \`$(git rev-parse --short "$base")\`."
+            echo
+            cat "$RUNNER_TEMP/report.md"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          cat "$RUNNER_TEMP/report.md"
+
+          case "$status" in
+            4) label="breaking-change"; note="This removes or changes exported API." ;;
+            3) label="additive-change"; note="This only adds exported API." ;;
+            *) label="";                note="" ;;
+          esac
+          printf '%s' "$label" > "$RUNNER_TEMP/out/label"
+
+          # head reads the file rather than ending the pipeline, where closing
+          # the pipe would kill tr with SIGPIPE under pipefail. The fence keeps
+          # symbol names in monospace; the backtick swap stops one escaping it.
+          report="$(head -c 40000 "$RUNNER_TEMP/report.md" | tr '`' "'")"
+          {
+            printf '<!-- api-diff -->\n### Exported API changed by this pull request\n\nCompared against `%s`.\n\n' \
+              "$(git rev-parse --short "$base")"
+            if [ -n "$note" ]; then printf '%s\n\n' "$note"; fi
+            printf '```text\n%s\n```\n' "$report"
+          } > "$RUNNER_TEMP/out/body.md"
+
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      # A fork's token is read-only, so those pull requests get the job summary
+      # and nothing else. always(), so a failed comparison clears its verdict.
+      - name: Label and comment
+        if: |
+          always() &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          LABEL_FILE: ${{ runner.temp }}/out/label
+          BODY_FILE: ${{ runner.temp }}/out/body.md
+          STATUS: ${{ steps.compare.outputs.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          label="$(cat "$LABEL_FILE" 2>/dev/null || true)"
+
+          # An earlier step can fail before writing a body.
+          if [ ! -f "$BODY_FILE" ]; then
+            mkdir -p "$(dirname "$BODY_FILE")"
+            printf '<!-- api-diff -->\n### Exported API\n\nThe comparison did not run for %s, so there is no verdict for this commit. See [the run](%s).\n' \
+              "$GITHUB_SHA" "$RUN_URL" > "$BODY_FILE"
+          fi
+
+          # Both labels are owned by this workflow, so the one that no longer
+          # applies has to come off; otherwise a fixed break keeps its label.
+          held="$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name')"
+          for managed in breaking-change additive-change; do
+            if [ "$managed" != "$label" ] && printf '%s\n' "$held" | grep -qxF "$managed"; then
+              gh pr edit "$PR" --repo "$REPO" --remove-label "$managed"
+              echo "removed stale label $managed"
+            fi
+          done
+
+          if [ -n "$label" ]; then
+            case "$label" in
+              breaking-change) colour="d73a4a" ;;
+              additive-change) colour="0e8a16" ;;
+            esac
+            gh label create "$label" --repo "$REPO" --color "$colour" \
+              --description "Applied by the API diff workflow" >/dev/null 2>&1 || true
+            gh pr edit "$PR" --repo "$REPO" --add-label "$label"
+          fi
+
+          existing="$(gh api "repos/$REPO/issues/$PR/comments" --paginate --jq \
+            '[.[] | select(.user.login == "github-actions[bot]")
+                  | select(.body | startswith("<!-- api-diff -->")) | .id] | first // empty')"
+
+          # jq builds the payload so the body is a correctly escaped string
+          # whatever the report contains; gh -F would convert some values.
+          jq -n --rawfile body "$BODY_FILE" '{body: $body}' > "$RUNNER_TEMP/payload.json"
+
+          # One comment per pull request, rewritten on every push, and removed
+          # once there is nothing left to report.
+          if [ "${STATUS:-}" = "0" ]; then
+            if [ -n "$existing" ]; then
+              gh api -X DELETE "repos/$REPO/issues/comments/$existing" >/dev/null
+              echo "removed comment $existing, this pull request no longer changes the API"
+            else
+              echo "no exported API changes, nothing to report"
+            fi
+          elif [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" --input "$RUNNER_TEMP/payload.json" >/dev/null
+            echo "updated comment $existing"
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" --input "$RUNNER_TEMP/payload.json" >/dev/null
+            echo "posted comment"
+          fi

--- a/.github/workflows/apidiff-tool.yml
+++ b/.github/workflows/apidiff-tool.yml
@@ -1,0 +1,26 @@
+name: API diff tool
+
+# Its own module, so the root "go test ./..." does not reach it.
+on:
+  pull_request:
+    paths:
+      - internal/apidiff/**
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Set up Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version-file: go.mod
+
+    - name: Test
+      run: go test -v ./...
+      working-directory: internal/apidiff

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ test/bootloose.yaml
 test/Library
 test/.ssh
 test/*.iid
+
+/internal/apidiff/apidiff

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,27 @@ lint:
 schemas:
 	$(MAKE) -C internal/jsonschema
 
+# Highest release tag for this module's major version that HEAD descends from.
+# Override to compare against something else: make apidiff API_BASE=v2.0.0
+API_BASE ?= $(shell git tag --merged HEAD --sort=-v:refname | grep -E '^v2\.[0-9]+\.[0-9]+$$' | head -n1)
+
+.PHONY: apidiff
+apidiff:
+	@set -e; \
+	base="$(API_BASE)"; \
+	test -n "$$base" || { echo "apidiff: no v2 tag reachable from HEAD; pass API_BASE=<ref>" >&2; exit 1; }; \
+	worktree=$$(mktemp -d); \
+	bindir=$$(mktemp -d); \
+	binary="$$bindir/apidiff"; \
+	trap 'git worktree remove --force "$$worktree" >/dev/null 2>&1 || rm -rf "$$worktree"; rm -rf "$$bindir"' EXIT; \
+	git worktree add --detach --quiet "$$worktree" "$$base"; \
+	go build -C internal/apidiff -o "$$binary" .; \
+	echo "# API diff: $$base -> working tree"; \
+	echo; \
+	status=0; \
+	"$$binary" -base "$$worktree" -head "$(CURDIR)" || status=$$?; \
+	case $$status in 0|3) ;; *) exit $$status ;; esac
+
 FUZZ_TIME := 10s
 .PHONY: fuzz
 fuzz:

--- a/internal/apidiff/go.mod
+++ b/internal/apidiff/go.mod
@@ -1,0 +1,13 @@
+module github.com/k0sproject/rig/internal/apidiff
+
+go 1.27.0
+
+require (
+	golang.org/x/exp v0.0.0-20260824195058-e88cd73687aa
+	golang.org/x/tools v0.49.0
+)
+
+require (
+	golang.org/x/mod v0.39.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
+)

--- a/internal/apidiff/go.sum
+++ b/internal/apidiff/go.sum
@@ -1,0 +1,14 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/exp v0.0.0-20260824195058-e88cd73687aa h1:QSyA8ishJCyT21kER9KwNt0b7BM3iRK4x9QXhjN5Fdk=
+golang.org/x/exp v0.0.0-20260824195058-e88cd73687aa/go.mod h1:zeBbvyFKDaLwa7CH/zI8KXt7gTl14SF7sO08Pl5jBCM=
+golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=
+golang.org/x/mod v0.39.0/go.mod h1:bvIbwjQ0HUFFf5AKukeeYQG4ZBUG9yxQbR9aEweIwYY=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.49.0 h1:3NI7VXzL9+1WZD52Dx2ttoPwD5DWrFGpl9mFZDlmisI=
+golang.org/x/tools v0.49.0/go.mod h1:SJNXV9DBKT0UbdttsQjbfJlAE/q+y36++zo3uL3N0Oo=
+golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
+golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
+golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
+golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=

--- a/internal/apidiff/main.go
+++ b/internal/apidiff/main.go
@@ -1,0 +1,265 @@
+// Command apidiff reports exported API differences between two checkouts of
+// the rig module and writes them as Markdown.
+//
+// It compares once per GOOS given, which covers the platform constraints this
+// module uses. API behind a GOARCH constraint, or behind a GOOS that is not in
+// the list, is not seen.
+//
+// Exit status reports what was found, so a caller can act on it without
+// parsing the output:
+//
+//	0  the exported API is unchanged
+//	1  one of the checkouts could not be inspected
+//	3  the API changed, but every change is backwards compatible
+//	4  an incompatible change is present
+//
+// Status 2 is deliberately never returned. The flag package exits with 2 when
+// it rejects an argument, and a panicking Go program exits with 2 as well, so
+// a caller that treated 2 as a result would report a crash as an API change.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"golang.org/x/exp/apidiff"
+	"golang.org/x/tools/go/packages"
+)
+
+const (
+	exitUnchanged    = 0
+	exitError        = 1
+	exitCompatible   = 3
+	exitIncompatible = 4
+)
+
+var (
+	errLoad = errors.New("failed to inspect packages")
+	errGOOS = errors.New("invalid GOOS list")
+
+	goosPattern = regexp.MustCompile(`^[a-z0-9]{2,12}$`)
+)
+
+func main() {
+	baseDir := flag.String("base", "", "directory holding the checkout to compare against (required)")
+	headDir := flag.String("head", ".", "directory holding the checkout to compare")
+	goosList := flag.String("goos", "linux,windows,darwin",
+		"comma separated GOOS values to compare")
+	flag.Parse()
+
+	if *baseDir == "" {
+		fmt.Fprintln(os.Stderr, "apidiff: -base is required")
+		flag.Usage()
+		os.Exit(exitError)
+	}
+
+	platforms, err := parseGOOS(*goosList)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apidiff: %v\n", err)
+		os.Exit(exitError)
+	}
+
+	status, err := run(os.Stdout, *baseDir, *headDir, platforms)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apidiff: %v\n", err)
+		os.Exit(exitError)
+	}
+	os.Exit(status)
+}
+
+func parseGOOS(list string) ([]string, error) {
+	var platforms []string
+	for goos := range strings.SplitSeq(list, ",") {
+		goos = strings.TrimSpace(goos)
+		if goos == "" {
+			continue
+		}
+		if !goosPattern.MatchString(goos) {
+			return nil, fmt.Errorf("%w: %q", errGOOS, goos)
+		}
+		platforms = append(platforms, goos)
+	}
+	if len(platforms) == 0 {
+		return nil, fmt.Errorf("%w: no values", errGOOS)
+	}
+
+	return platforms, nil
+}
+
+func run(out io.Writer, baseDir, headDir string, platforms []string) (int, error) {
+	var changes []apidiff.Change
+	for _, goos := range platforms {
+		base, err := load(baseDir, goos)
+		if err != nil {
+			return exitError, fmt.Errorf("base checkout %s (GOOS=%s): %w", baseDir, goos, err)
+		}
+		head, err := load(headDir, goos)
+		if err != nil {
+			return exitError, fmt.Errorf("head checkout %s (GOOS=%s): %w", headDir, goos, err)
+		}
+
+		// A symbol diff across module paths would list the whole API twice,
+		// once removed and once added.
+		if base.Path != head.Path {
+			writeReport(out, []string{fmt.Sprintf(
+				"module path changed from %s to %s: every import path moves, so nothing built against %s keeps compiling",
+				base.Path, head.Path, base.Path)}, nil, platforms)
+
+			return exitIncompatible, nil
+		}
+
+		changes = append(changes, apidiff.ModuleChanges(base, head).Changes...)
+	}
+
+	broken, added := partition(changes)
+
+	writeReport(out, broken, added, platforms)
+
+	switch {
+	case len(broken) > 0:
+		return exitIncompatible, nil
+	case len(added) > 0:
+		return exitCompatible, nil
+	default:
+		return exitUnchanged, nil
+	}
+}
+
+// partition splits changes into incompatible and compatible messages, sorted
+// and deduplicated: a change outside a build constraint is reported once per
+// GOOS, and apidiff reports a generic type's method once per type parameter.
+func partition(changes []apidiff.Change) (broken, added []string) {
+	seen := make(map[string]struct{}, len(changes))
+	for _, change := range changes {
+		if _, dup := seen[change.Message]; dup {
+			continue
+		}
+		seen[change.Message] = struct{}{}
+		if change.Compatible {
+			added = append(added, change.Message)
+
+			continue
+		}
+		broken = append(broken, change.Message)
+	}
+	sort.Strings(broken)
+	sort.Strings(added)
+
+	return broken, added
+}
+
+func writeReport(out io.Writer, broken, added, platforms []string) {
+	if len(broken) == 0 && len(added) == 0 {
+		fmt.Fprintf(out, "No exported API changes (%s).\n", strings.Join(platforms, ", "))
+
+		return
+	}
+
+	fmt.Fprintf(out, "Compared for %s. Entries read ./package.Symbol; the module root package is unprefixed.\n\n",
+		strings.Join(platforms, ", "))
+
+	if len(broken) > 0 {
+		fmt.Fprintf(out, "Incompatible changes (%d) - these break code that compiles against the base version:\n\n", len(broken))
+		writeList(out, broken)
+	}
+
+	if len(added) > 0 {
+		fmt.Fprintf(out, "Compatible changes (%d):\n\n", len(added))
+		writeList(out, added)
+	}
+}
+
+func writeList(out io.Writer, messages []string) {
+	for _, message := range messages {
+		// apidiff emits multi-line messages for type changes; indent the
+		// continuation lines to keep one entry per item.
+		fmt.Fprintf(out, "- %s\n", strings.ReplaceAll(strings.TrimSpace(message), "\n", "\n  "))
+	}
+	fmt.Fprintln(out)
+}
+
+func load(dir, goos string) (*apidiff.Module, error) {
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedTypes | packages.NeedSyntax |
+			packages.NeedTypesInfo | packages.NeedImports | packages.NeedDeps |
+			packages.NeedModule | packages.NeedFiles,
+		Dir: dir,
+		// A cross-GOOS load cannot use cgo. This drops files importing "C"
+		// along with whatever they export, which is checked for below.
+		Env: append(os.Environ(), "GOOS="+goos, "CGO_ENABLED=0"),
+	}
+
+	loaded, err := packages.Load(cfg, "./...")
+	if err != nil {
+		return nil, fmt.Errorf("load: %w", err)
+	}
+
+	var (
+		path     string
+		exported []*types.Package
+		failed   []string
+	)
+	for _, pkg := range loaded {
+		for _, pkgErr := range pkg.Errors {
+			failed = append(failed, fmt.Sprintf("%s: %v", pkg.PkgPath, pkgErr))
+		}
+		// IgnoredFiles legitimately includes the other platforms' files. A
+		// file importing "C" is excluded on every platform though, so nothing
+		// it exports would ever be compared.
+		for _, ignored := range pkg.IgnoredFiles {
+			if importsC(ignored) {
+				failed = append(failed,
+					fmt.Sprintf("%s: %s uses cgo, which this comparison cannot inspect", pkg.PkgPath, ignored))
+			}
+		}
+		if pkg.Module != nil && path == "" {
+			path = pkg.Module.Path
+		}
+		if pkg.Types == nil || isInternal(pkg.PkgPath) {
+			continue
+		}
+		exported = append(exported, pkg.Types)
+	}
+
+	// A package that fails to load is indistinguishable from a deleted one,
+	// which would be reported as a fabricated incompatible change.
+	if len(failed) > 0 {
+		return nil, fmt.Errorf("%w:\n%s", errLoad, strings.Join(failed, "\n"))
+	}
+	if len(exported) == 0 {
+		return nil, fmt.Errorf("%w: no packages found", errLoad)
+	}
+
+	return &apidiff.Module{Path: path, Packages: exported}, nil
+}
+
+// importsC reports whether the file at path imports "C". An unparseable file
+// is not cgo: it is either not Go, or broken in a way the type checker reports.
+func importsC(path string) bool {
+	parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+	if err != nil {
+		return false
+	}
+	for _, imported := range parsed.Imports {
+		if imported.Path != nil && imported.Path.Value == `"C"` {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isInternal(pkgPath string) bool {
+	return pkgPath == "internal" ||
+		strings.HasSuffix(pkgPath, "/internal") ||
+		strings.Contains(pkgPath, "/internal/")
+}

--- a/internal/apidiff/main_test.go
+++ b/internal/apidiff/main_test.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/exp/apidiff"
+)
+
+var allPlatforms = []string{"linux", "windows", "darwin"}
+
+// writeModule creates a throwaway module whose exported API is whatever the
+// caller puts in files, keyed by name within a single package directory.
+func writeModule(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.test/apitest\n\ngo 1.27\n"), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+
+	pkgDir := filepath.Join(dir, "thing")
+	if err := os.MkdirAll(pkgDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(pkgDir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	return dir
+}
+
+const keptAPI = `package thing
+
+// Kept is present in every version used by the tests.
+func Kept() {}
+`
+
+func module(body string) map[string]string {
+	return map[string]string{"thing.go": body}
+}
+
+func TestRunStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		base     map[string]string
+		head     map[string]string
+		want     int
+		contains string
+	}{
+		{
+			name:     "unchanged",
+			base:     module(keptAPI),
+			head:     module(keptAPI),
+			want:     exitUnchanged,
+			contains: "No exported API changes",
+		},
+		{
+			name:     "compatible addition",
+			base:     module(keptAPI),
+			head:     module(keptAPI + "\n// Added is new.\nfunc Added() {}\n"),
+			want:     exitCompatible,
+			contains: "Added: added",
+		},
+		{
+			name:     "incompatible removal",
+			base:     module(keptAPI + "\n// Doomed goes away.\nfunc Doomed() {}\n"),
+			head:     module(keptAPI),
+			want:     exitIncompatible,
+			contains: "Doomed: removed",
+		},
+		{
+			name:     "incompatible signature change",
+			base:     module(keptAPI),
+			head:     module(strings.Replace(keptAPI, "func Kept() {}", "func Kept(n int) {}", 1)),
+			want:     exitIncompatible,
+			contains: "Kept: changed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var out strings.Builder
+			status, err := run(&out, writeModule(t, test.base), writeModule(t, test.head), allPlatforms)
+			if err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			if status != test.want {
+				t.Errorf("status = %d, want %d\n%s", status, test.want, out.String())
+			}
+			if !strings.Contains(out.String(), test.contains) {
+				t.Errorf("report does not mention %q:\n%s", test.contains, out.String())
+			}
+		})
+	}
+}
+
+// Part of the exported API sits behind build constraints, so a comparison that
+// only type-checks the host platform silently misses changes to it.
+func TestRunSeesConstrainedAPI(t *testing.T) {
+	t.Parallel()
+
+	const windowsOnly = `//go:build windows
+
+package thing
+
+// OnlyOnWindows is exported on Windows alone.
+func OnlyOnWindows() {}
+`
+
+	base := writeModule(t, map[string]string{"thing.go": keptAPI, "thing_windows.go": windowsOnly})
+	head := writeModule(t, module(keptAPI))
+
+	t.Run("windows included", func(t *testing.T) {
+		t.Parallel()
+
+		var out strings.Builder
+		status, err := run(&out, base, head, allPlatforms)
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if status != exitIncompatible {
+			t.Errorf("status = %d, want %d\n%s", status, exitIncompatible, out.String())
+		}
+		if !strings.Contains(out.String(), "OnlyOnWindows: removed") {
+			t.Errorf("removal behind a build constraint was missed:\n%s", out.String())
+		}
+	})
+
+	t.Run("linux alone cannot see it", func(t *testing.T) {
+		t.Parallel()
+
+		var out strings.Builder
+		status, err := run(&out, base, head, []string{"linux"})
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if status != exitUnchanged {
+			t.Errorf("status = %d, want %d: this documents why every GOOS is compared\n%s",
+				status, exitUnchanged, out.String())
+		}
+	})
+}
+
+// Bumping the module path is the one change that moves every import path, and
+// it must not be reported as an unrelated pile of removals and additions.
+func TestRunModulePathChange(t *testing.T) {
+	t.Parallel()
+
+	base := writeModule(t, module(keptAPI))
+	head := writeModule(t, module(keptAPI))
+	if err := os.WriteFile(filepath.Join(head, "go.mod"),
+		[]byte("module example.test/apitest/v3\n\ngo 1.27\n"), 0o600); err != nil {
+		t.Fatalf("rewrite go.mod: %v", err)
+	}
+
+	var out strings.Builder
+	status, err := run(&out, base, head, allPlatforms)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if status != exitIncompatible {
+		t.Errorf("status = %d, want %d\n%s", status, exitIncompatible, out.String())
+	}
+	if !strings.Contains(out.String(), "module path changed from example.test/apitest to example.test/apitest/v3") {
+		t.Errorf("report does not name the module path change:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "Kept") {
+		t.Errorf("report lists individual symbols instead of the path change:\n%s", out.String())
+	}
+}
+
+// A package that does not compile is indistinguishable from a deleted one, so
+// a partial load has to be refused rather than reported as removals.
+func TestRunRefusesPartialLoad(t *testing.T) {
+	t.Parallel()
+
+	broken := module("package thing\n\nfunc Kept() { this is not go }\n")
+
+	for _, test := range []struct {
+		name string
+		base map[string]string
+		head map[string]string
+	}{
+		{name: "base does not compile", base: broken, head: module(keptAPI)},
+		{name: "head does not compile", base: module(keptAPI), head: broken},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var out strings.Builder
+			status, err := run(&out, writeModule(t, test.base), writeModule(t, test.head), allPlatforms)
+			if !errors.Is(err, errLoad) {
+				t.Fatalf("err = %v, want errLoad", err)
+			}
+			if status != exitError {
+				t.Errorf("status = %d, want %d", status, exitError)
+			}
+			if out.Len() != 0 {
+				t.Errorf("wrote a report despite failing to load:\n%s", out.String())
+			}
+		})
+	}
+}
+
+// The comparison runs with cgo off, which drops any file importing "C" along
+// with whatever it exports. That must be refused rather than reported as an
+// unchanged API.
+func TestRunRefusesCgo(t *testing.T) {
+	t.Parallel()
+
+	const cgoFile = `package thing
+
+import "C"
+
+// ExportedFromCgo would never be compared.
+func ExportedFromCgo() {}
+`
+
+	var out strings.Builder
+	status, err := run(&out,
+		writeModule(t, map[string]string{"thing.go": keptAPI, "thing_cgo.go": cgoFile}),
+		writeModule(t, module(keptAPI)),
+		allPlatforms)
+
+	if !errors.Is(err, errLoad) {
+		t.Fatalf("err = %v, want errLoad", err)
+	}
+	if !strings.Contains(err.Error(), "uses cgo") {
+		t.Errorf("error does not explain the cause: %v", err)
+	}
+	if status != exitError {
+		t.Errorf("status = %d, want %d", status, exitError)
+	}
+}
+
+func TestImportsC(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	for name, body := range map[string]string{
+		"cgo.go":      "package thing\n\nimport \"C\"\n",
+		"grouped.go":  "package thing\n\nimport (\n\t\"fmt\"\n\t\"C\"\n)\n",
+		"plain.go":    "package thing\n\nimport \"fmt\"\n",
+		"notc.go":     "package thing\n\nimport \"github.com/example/C\"\n",
+		"unparseable": "this is not go at all",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	for name, want := range map[string]bool{
+		"cgo.go":      true,
+		"grouped.go":  true,
+		"plain.go":    false,
+		"notc.go":     false,
+		"unparseable": false,
+		"absent.go":   false,
+	} {
+		if got := importsC(filepath.Join(dir, name)); got != want {
+			t.Errorf("importsC(%s) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestRunMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	var out strings.Builder
+	status, err := run(&out, filepath.Join(t.TempDir(), "absent"), writeModule(t, module(keptAPI)), allPlatforms)
+	if err == nil {
+		t.Fatal("expected an error for a directory that does not exist")
+	}
+	if status != exitError {
+		t.Errorf("status = %d, want %d", status, exitError)
+	}
+}
+
+func TestParseGOOS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("accepted", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := parseGOOS(" linux , windows ,,darwin")
+		if err != nil {
+			t.Fatalf("parseGOOS: %v", err)
+		}
+		if !equal(got, allPlatforms) {
+			t.Errorf("got %q, want %q", got, allPlatforms)
+		}
+	})
+
+	for _, list := range []string{"", " ", ",", "linux;windows", "GOOS", "a", "../etc", "linux$(id)"} {
+		t.Run("rejected "+list, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := parseGOOS(list); !errors.Is(err, errGOOS) {
+				t.Errorf("parseGOOS(%q) err = %v, want errGOOS", list, err)
+			}
+		})
+	}
+}
+
+func TestPartition(t *testing.T) {
+	t.Parallel()
+
+	broken, added := partition([]apidiff.Change{
+		{Message: "Zeta: removed", Compatible: false},
+		{Message: "Beta: added", Compatible: true},
+		// Unconstrained changes repeat once per GOOS, and apidiff repeats a
+		// generic type's method once per type parameter.
+		{Message: "Beta: added", Compatible: true},
+		{Message: "Generic[T].Method: added", Compatible: true},
+		{Message: "Generic[T].Method: added", Compatible: true},
+		{Message: "Alpha: removed", Compatible: false},
+		{Message: "Alpha: removed", Compatible: false},
+	})
+
+	wantBroken := []string{"Alpha: removed", "Zeta: removed"}
+	wantAdded := []string{"Beta: added", "Generic[T].Method: added"}
+
+	if !equal(broken, wantBroken) {
+		t.Errorf("broken = %q, want %q", broken, wantBroken)
+	}
+	if !equal(added, wantAdded) {
+		t.Errorf("added = %q, want %q", added, wantAdded)
+	}
+}
+
+func TestWriteReport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no changes names the platforms", func(t *testing.T) {
+		t.Parallel()
+
+		var out strings.Builder
+		writeReport(&out, nil, nil, allPlatforms)
+
+		if got := out.String(); got != "No exported API changes (linux, windows, darwin).\n" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("both sections", func(t *testing.T) {
+		t.Parallel()
+
+		var out strings.Builder
+		writeReport(&out, []string{"Gone: removed"}, []string{"New: added"}, allPlatforms)
+
+		for _, want := range []string{
+			"Compared for linux, windows, darwin.",
+			"Incompatible changes (1)",
+			"- Gone: removed",
+			"Compatible changes (1)",
+			"- New: added",
+		} {
+			if !strings.Contains(out.String(), want) {
+				t.Errorf("missing %q in:\n%s", want, out.String())
+			}
+		}
+	})
+
+	t.Run("multi-line message stays one item", func(t *testing.T) {
+		t.Parallel()
+
+		var out strings.Builder
+		writeReport(&out, []string{"Thing: changed\nfrom func()\nto func(int)"}, nil, allPlatforms)
+
+		if !strings.Contains(out.String(), "- Thing: changed\n  from func()\n  to func(int)\n") {
+			t.Errorf("continuation lines are not indented:\n%s", out.String())
+		}
+	})
+}
+
+func TestIsInternal(t *testing.T) {
+	t.Parallel()
+
+	for path, want := range map[string]bool{
+		"example.test/apitest/thing":              false,
+		"example.test/apitest/internal":           true,
+		"example.test/apitest/internal/thing":     true,
+		"internal":                                true,
+		"example.test/apitest/internalish":        false,
+		"example.test/apitest/thing/internal/sub": true,
+	} {
+		if got := isInternal(path); got != want {
+			t.Errorf("isInternal(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func equal(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
This was supposed to be a test drive of the github agentic workflows but turns out it can just as well be completely deterministic.

Adds a workflow that checks if a PR changes the consumer facing API. PRs containing breaking changes or additive changes are labeled as such. 