### PR TITLE
test(openssh): widen the Connect budget to reduce flakiness under load

### DIFF
--- a/protocol/openssh/connection_test.go
+++ b/protocol/openssh/connection_test.go
@@ -179,7 +179,7 @@ func Test_classifyConnectError(t *testing.T) {
 // seconds.
 const (
 	controlMasterLifetime = 30 * time.Second
-	connectBudget         = 10 * time.Second
+	connectBudget         = 20 * time.Second
 )
 
 // fakeSSHScript stands in for the openssh client and reproduces what


### PR DESCRIPTION
## Why

TestConnectDoesNotWaitForControlMaster asserts Connect returns well under the fake control master's 30 second lifetime, using a 10 second budget. That budget is tight enough to fail under real CPU contention: it passed consistently in isolation (under 1.1s across repeated runs) but failed at 10.7s when run alongside other concurrent Go builds/tests on this machine. The test's own comment already acknowledges "go test ./..." runs packages in parallel and fork latency on a saturated machine stretches Connect to a few seconds, so the budget just wasn't loose enough.

## What changed

Widened connectBudget from 10s to 20s, still comfortably clear of the 30s control master lifetime the test guards against.

## Testing

go test ./protocol/openssh/... -run TestConnectDoesNotWaitForControlMaster passes repeatedly, both in isolation and while other test suites were running concurrently in this environment.
