### PR TITLE
Fix/posix block size

### DIFF
--- a/remotefs/posixfile.go
+++ b/remotefs/posixfile.go
@@ -195,9 +195,16 @@ func (f *PosixFile) CopyFrom(src io.Reader) (int64, error) {
 	}
 	counter := &iostream.ByteCounter{}
 
+	// dd counts seek in output blocks rather than in bytes, so the block size has
+	// to divide the offset being resumed from.
+	bs := int64(streamBlockSize)
+	for f.pos%bs != 0 {
+		bs /= 2
+	}
+
 	err := f.fs.Exec(
 		// "if=" is omitted so dd reads stdin, see the note in Write above.
-		sh.Command("dd", "of="+f.path, fmt.Sprintf("bs=%d", f.fsBlockSize()), fmt.Sprintf("seek=%d", f.pos), "conv=notrunc"),
+		sh.Command("dd", "of="+f.path, fmt.Sprintf("bs=%d", bs), fmt.Sprintf("seek=%d", f.pos/bs), "conv=notrunc"),
 		cmd.Stdin(io.TeeReader(src, counter)),
 	)
 	if err != nil {

--- a/remotefs/posixfile.go
+++ b/remotefs/posixfile.go
@@ -40,11 +40,21 @@ func (f *PosixFile) fsBlockSize() int {
 		return f.blockSize
 	}
 
-	out, err := f.fs.ExecOutput(fmt.Sprintf(`stat -c "%%s" %[1]s 2> /dev/null || stat -f "%%k" %[1]s`, shellescape.Quote(path.Dir(f.path))))
+	f.blockSize = defaultBlockSize
+
+	// %o is the optimal I/O block size, the GNU spelling of BSD's %k. Not %s,
+	// which is the size of the directory's own data: that equals the block size
+	// on ext4, but XFS keeps small directories inline in the inode, where it is
+	// a few dozen bytes.
+	out, err := f.fs.ExecOutput(fmt.Sprintf(`stat -c "%%o" %[1]s 2> /dev/null || stat -f "%%k" %[1]s`, shellescape.Quote(path.Dir(f.path))))
 	if err != nil {
-		// fall back to default
-		f.blockSize = defaultBlockSize
-	} else if bs, err := strconv.Atoi(strings.TrimSpace(out)); err == nil {
+		return f.blockSize
+	}
+
+	// Anything outside this range is stat reporting something that is not a
+	// block size, and the default is safer than passing it on to dd.
+	if bs, err := strconv.Atoi(strings.TrimSpace(out)); err == nil &&
+		bs >= minBlockSize && bs <= maxBlockSize && bs&(bs-1) == 0 {
 		f.blockSize = bs
 	}
 

--- a/remotefs/posixfile_test.go
+++ b/remotefs/posixfile_test.go
@@ -11,22 +11,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// openPosixFileForWriting mocks the stat probes PosixFS.OpenFile performs and
-// returns a PosixFile for an existing, empty, writable /tmp/file.
-func openPosixFileForWriting(t *testing.T, mr *rigtest.MockRunner) remotefs.File {
+// openPosixFile mocks the stat probes PosixFS.OpenFile performs and returns a
+// PosixFile for an existing /tmp/file of the given size, whose parent directory
+// reports blockSize as its optimal I/O block size.
+func openPosixFile(t *testing.T, mr *rigtest.MockRunner, flags int, blockSize, size string) remotefs.File {
 	t.Helper()
 	// initStat: selects the GNU stat syntax.
 	mr.AddCommandSuccess(rigtest.Equal("stat -c %n /"))
 	// fsBlockSize probes the parent directory. Registered before the generic
 	// stat handler below so it is not swallowed by it.
-	mr.AddCommandOutput(rigtest.Contains(`stat -c "%s"`), "4096")
+	mr.AddCommandOutput(rigtest.Contains(`stat -c "%o"`), blockSize)
 	// Stat of the file itself: 0x81a4 = 0o100644 (regular file, rw-r--r--).
-	mr.AddCommandOutput(rigtest.Contains("-- /tmp/file"), "0x81a4 0 1234567890.000000000 ///tmp/file//")
+	mr.AddCommandOutput(rigtest.Contains("-- /tmp/file"), "0x81a4 "+size+" 1234567890.000000000 ///tmp/file//")
 
-	f, err := remotefs.NewPosixFS(mr).OpenFile("/tmp/file", os.O_WRONLY, 0o644)
+	f, err := remotefs.NewPosixFS(mr).OpenFile("/tmp/file", flags, 0o644)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, f.Close()) })
 	return f
+}
+
+// openPosixFileForWriting returns an empty, writable /tmp/file on a file system
+// reporting the usual 4096 byte block size.
+func openPosixFileForWriting(t *testing.T, mr *rigtest.MockRunner) remotefs.File {
+	t.Helper()
+	return openPosixFile(t, mr, os.O_WRONLY, "4096", "0")
 }
 
 // TestPosixFileWrite verifies that writes are piped into dd through stdin. dd
@@ -69,4 +77,40 @@ func TestPosixFileCopyFrom(t *testing.T) {
 	require.Equal(t, "hello", string(got))
 	require.Equal(t, "dd of=/tmp/file bs=4096 seek=0 conv=notrunc", mr.LastCommand())
 	require.NoError(t, mr.NotReceived(rigtest.Contains("/dev/stdin")))
+}
+
+// TestPosixFileBlockSize pins down what fsBlockSize asks stat for and what it
+// accepts back. It used to ask for %s, the size of the parent directory's own
+// data, which equals the block size on ext4 and so looked right there. XFS keeps
+// a small directory inline in the inode: a directory holding one file reported
+// 29 bytes, and dd was then handed bs=29.
+func TestPosixFileBlockSize(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		blockSize string
+	}{
+		{"reported", "8192"},
+		{"implausible", "29"}, // an XFS directory holding a single short-named file
+		{"unparseable", "?"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := rigtest.NewMockRunner()
+			mr.AddCommandSuccess(rigtest.HasPrefix("dd "))
+			// 16384 bytes is a whole number of blocks at any of the sizes under
+			// test, so a rejected one shows up as ddParams falling back to bs=1.
+			f := openPosixFile(t, mr, os.O_RDONLY, tc.blockSize, "16384")
+
+			_, err := f.CopyTo(io.Discard)
+			require.NoError(t, err)
+			require.NoError(t, mr.Received(rigtest.Contains(`stat -c "%o"`)),
+				"the optimal I/O block size is %o; %s is the directory's own size")
+
+			want := "dd if=/tmp/file bs=8192 skip=0 count=2"
+			if tc.blockSize != "8192" {
+				// Anything implausible or unreadable falls back to the default.
+				want = "dd if=/tmp/file bs=4096 skip=0 count=4"
+			}
+			require.Equal(t, want, mr.LastCommand())
+		})
+	}
 }

--- a/remotefs/posixfile_test.go
+++ b/remotefs/posixfile_test.go
@@ -75,7 +75,7 @@ func TestPosixFileCopyFrom(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(5), n)
 	require.Equal(t, "hello", string(got))
-	require.Equal(t, "dd of=/tmp/file bs=4096 seek=0 conv=notrunc", mr.LastCommand())
+	require.Equal(t, "dd of=/tmp/file bs=1048576 seek=0 conv=notrunc", mr.LastCommand())
 	require.NoError(t, mr.NotReceived(rigtest.Contains("/dev/stdin")))
 }
 

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -50,7 +50,11 @@ const (
 	minBlockSize = 512
 	maxBlockSize = 1 << 20
 
-	supportedFlags = os.O_RDONLY | os.O_WRONLY | os.O_RDWR | os.O_CREATE | os.O_EXCL | os.O_TRUNC | os.O_APPEND | os.O_SYNC
+	// The size of dd's read and write chunks when streaming a whole file. It is
+	// unrelated to the remote file system and only wants to be large enough that
+	// transferring a multi-gigabyte file is not syscall bound.
+	streamBlockSize = 1 << 20
+	supportedFlags  = os.O_RDONLY | os.O_WRONLY | os.O_RDWR | os.O_CREATE | os.O_EXCL | os.O_TRUNC | os.O_APPEND | os.O_SYNC
 
 	// statTimeLayout is the timestamp format of stat -c %y under LC_ALL=C: a date, a
 	// time with a fraction of a second and a UTC offset.

--- a/remotefs/posixfs.go
+++ b/remotefs/posixfs.go
@@ -44,7 +44,13 @@ var (
 
 const (
 	defaultBlockSize = 4096
-	supportedFlags   = os.O_RDONLY | os.O_WRONLY | os.O_RDWR | os.O_CREATE | os.O_EXCL | os.O_TRUNC | os.O_APPEND | os.O_SYNC
+
+	// The range of block sizes accepted from stat. Outside of it, stat reported
+	// something that is not a block size.
+	minBlockSize = 512
+	maxBlockSize = 1 << 20
+
+	supportedFlags = os.O_RDONLY | os.O_WRONLY | os.O_RDWR | os.O_CREATE | os.O_EXCL | os.O_TRUNC | os.O_APPEND | os.O_SYNC
 
 	// statTimeLayout is the timestamp format of stat -c %y under LC_ALL=C: a date, a
 	// time with a fraction of a second and a UTC offset.


### PR DESCRIPTION
Fixes #466

`PosixFile.fsBlockSize` asked stat for `%s` where `%o` was meant. `%s` is the
size of the probed directory's own data; `%o` is the optimal I/O block size,
which is what the BSD `%k` in the same fallback already asks for.

On ext4 a directory occupies whole blocks, so `%s` answers 4096 and happens to
agree with `%o` — the reason this survived. XFS keeps a small directory inline
in the inode, so `/var/lib/k0s/images` holding one 15-character filename
answers 29, and a k0sctl airgap bundle upload ran as `dd ... bs=29`. That is
~18 million syscall pairs for a 500 MB bundle, and turns a seconds-long upload
into an hours-long one. The issue has the byte-by-byte breakdown of the 29.

Three commits' worth of behaviour in two:

**Block size probe.** Ask for `%o`, and reject an answer that is not a
plausible power-of-two block size so a future misprobe degrades to the default
instead of to something unusable. That also removes a crash: when stat exited 0
but printed something unparseable, `blockSize` stayed 0 and `ddParams` panicked
on `numBytes % 0`.

**CopyFrom.** dd's `bs` there is only the size of the chunks it streams stdin
into the file with, unrelated to the remote filesystem, so it now uses a fixed
1 MiB rather than the probed value — 4096 was costing 128k syscall pairs per
gigabyte even in the good case. The same line passed `f.pos` to `seek=`, which
dd counts in output blocks and not bytes, so a resumed copy wrote at
`f.pos * bs`; the offset is 0 for an ordinary upload, which is why it went
unnoticed. The block size now shrinks when it does not divide the offset, which
is a real if unlikely regression in throughput for an unaligned resume — an
appending write would avoid it, but `oflag=append` is not portable to the BSD
and macOS dd this library targets, so I left it.

`WinFS` has no block-size probe, so there is nothing to mirror there. No
exported API changes.

Verified: both commits build, vet and test green independently; the two new
test cases fail against the unfixed code (one by assertion, one by the panic
above). I could not run `make lint` — the golangci-lint I have is built against
Go 1.25 and refuses this repo's 1.27 target — so the lint job is unverified.

---

Written by an AI coding agent working for @ftarasenko, who hit this on their
own XFS hosts, confirmed the `stat -c "%s %o"` output above and reviewed the
change before it was opened.

That agent's session has no API access to this repository, so it will not see
review comments or CI results here. Follow-up is @ftarasenko's — they will
relay review feedback and push changes.

---
_Generated by [Claude Code](https://claude.ai/code)_
